### PR TITLE
Copy share link to clipboard with toast feedback on click (#284)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-share-link-copy-toast.md
+++ b/docs/superpowers/plans/2026-07-06-share-link-copy-toast.md
@@ -1,0 +1,349 @@
+# Share link auto-copy + toast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clicking the album "share" link copies the share URL to the clipboard and shows a confirmation/error toast, instead of navigating.
+
+**Architecture:** Server-rendered toast markup (two new Bootstrap toasts, merged into the existing `_toasts.html.twig` container) plus a JS click handler on `.share` that prevents navigation, reads the link's browser-resolved absolute `href`, calls `navigator.clipboard.writeText()`, and shows the matching toast.
+
+**Tech Stack:** Symfony 8 / Twig, vanilla JS (no bundler — plain files under `public/js/`), Bootstrap 5 (Toast component, already used elsewhere), PHPUnit + Panther (browser tests via Selenium).
+
+## Global Constraints
+
+- Docker-only toolchain: run all commands via `docker compose exec php ...` — no PHP/Composer/PHPUnit on the host.
+- No modal, no visible link/input, no manual copy button (simplified from the issue's literal wording per explicit user decision — see spec).
+- Do not change the `.share` anchor's `href`, class, or visibility condition (`{% if not dex.isPrivate %}`) — only add a click listener to it.
+- `final` classes for test classes; every test class is `@internal`, uses `#[CoversClass]` or `#[CoversNothing]`, and extends `WebTestCase` (integration) or `AbstractBrowserTestCase` (browser).
+- Spec: `docs/superpowers/specs/2026-07-06-share-link-copy-toast-design.md`.
+
+---
+
+### Task 1: Share toasts markup (translations + macro + container gate)
+
+**Files:**
+- Modify: `translations/messages+intl-icu.en.yaml`
+- Modify: `translations/messages+intl-icu.fr.yaml`
+- Modify: `templates/Album/_album_macros.html.twig:241` (after the existing `toasts` macro)
+- Modify: `templates/Album/_toasts.html.twig` (full rewrite, currently 10 lines)
+- Test: `tests/src/Integration/Controller/Album/Display/IntroTest.php`
+
+**Interfaces:**
+- Produces: Twig macro `macro.shareToasts()` (no params) rendering `<div id="shareToastSuccess">` / `<div id="shareToastError">`, used by `_toasts.html.twig`.
+- Produces: translation keys `album.share.toast.success`, `album.share.toast.error`.
+- Consumes: nothing new (uses existing `dex.isPrivate` and `allowedToEdit` variables already in scope in `_toasts.html.twig`, per `templates/Album/index.html.twig:66` which includes it).
+
+- [ ] **Step 1: Write the failing test assertions**
+
+In `tests/src/Integration/Controller/Album/Display/IntroTest.php`, every existing test method already asserts either:
+```php
+$this->assertCountFilter($crawler, 0, '#intro .share');
+```
+or
+```php
+$this->assertCountFilter($crawler, 1, '#intro .share');
+```
+Add matching toast-count assertions right after each. Since the exact line `$this->assertCountFilter($crawler, 0, '#intro .share');` is repeated identically in 5 methods (`testIntroHome`, `testIntroDemoList3`, `testIntroGoldSilverCrystal`, `testIntroBlackWhiteFrench`, `testIntroBlackWhiteEnglish`), and `$this->assertCountFilter($crawler, 1, '#intro .share');` is repeated identically in 2 methods (`testIntroDemoLiteShiny`, `testIntroDemoAnotherTrainer`), do this as two find-and-replace-all edits:
+
+Replace every occurrence of:
+```php
+        $this->assertCountFilter($crawler, 0, '#intro .share');
+```
+with:
+```php
+        $this->assertCountFilter($crawler, 0, '#intro .share');
+
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+```
+
+Replace every occurrence of:
+```php
+        $this->assertCountFilter($crawler, 1, '#intro .share');
+```
+with:
+```php
+        $this->assertCountFilter($crawler, 1, '#intro .share');
+
+        $this->assertCountFilter($crawler, 1, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 1, '#shareToastError');
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Display/IntroTest.php
+```
+Expected: 7 failures, each "Failed asserting that actual size 0 matches expected size ..." (or similar) for `#shareToastSuccess`/`#shareToastError`, since those elements don't exist yet.
+
+- [ ] **Step 3: Add translation keys**
+
+In `translations/messages+intl-icu.en.yaml`, insert after line 142 (`open_distinguish_types: More`, the last line of the `offcanvas:` block, before the blank line and `update:` top-level section):
+```yaml
+  share:
+    toast:
+      success: "Link copied to the clipboard!"
+      error: "Could not copy the link automatically, please copy it manually."
+```
+(indented at the same level as `offcanvas:`, i.e. 2 spaces, as a new child of `album:`)
+
+In `translations/messages+intl-icu.fr.yaml`, insert after line 147 (`open_distinguish_types: Avancées`, the last line of the `offcanvas:` block, before the blank line and `update:` top-level section):
+```yaml
+  share:
+    toast:
+      success: "Lien copié dans le presse-papier !"
+      error: "Impossible de copier le lien automatiquement, merci de le copier manuellement."
+```
+
+- [ ] **Step 4: Add the `shareToasts()` macro**
+
+In `templates/Album/_album_macros.html.twig`, insert after line 241 (`{% endmacro %}`, closing the existing `toasts` macro) and before line 243 (`{% macro boxTitle(boxNumber) %}`):
+```twig
+
+{% macro shareToasts() %}
+  <div id="shareToastSuccess" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.success'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+
+  <div id="shareToastError" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.error'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+{% endmacro %}
+```
+
+- [ ] **Step 5: Widen the toast container gate**
+
+Replace the full content of `templates/Album/_toasts.html.twig` (currently):
+```twig
+{% import "Album/_album_macros.html.twig" as macro %}
+
+{% if allowedToEdit %}
+    <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
+        {% for item in list %}
+            {{ macro.toasts(item) }}
+        {% endfor %}
+    </div>
+{% endif %}
+```
+with:
+```twig
+{% import "Album/_album_macros.html.twig" as macro %}
+
+{% if allowedToEdit or not dex.isPrivate %}
+    <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
+        {% if allowedToEdit %}
+            {% for item in list %}
+                {{ macro.toasts(item) }}
+            {% endfor %}
+        {% endif %}
+
+        {% if not dex.isPrivate %}
+            {{ macro.shareToasts() }}
+        {% endif %}
+    </div>
+{% endif %}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Display/IntroTest.php
+```
+Expected: all tests green (`OK (7 tests, ...)`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add translations/messages+intl-icu.en.yaml translations/messages+intl-icu.fr.yaml templates/Album/_album_macros.html.twig templates/Album/_toasts.html.twig tests/src/Integration/Controller/Album/Display/IntroTest.php
+git commit -m "feat(album): add share success/error toast markup"
+```
+
+---
+
+### Task 2: Click handler — copy to clipboard, show toast, no navigation
+
+**Files:**
+- Modify: `public/js/album.js` (currently 155 lines, append new functions)
+- Modify: `templates/Album/index.html.twig:81`
+- Test: `tests/src/Browser/Album/ShareLinkTest.php` (new)
+
+**Interfaces:**
+- Consumes: `#shareToastSuccess` / `#shareToastError` elements produced by Task 1 (must land first).
+- Produces: `watchShareLink()` (called once at page load from `templates/Album/index.html.twig`), `onShareLinkClick(event)` (internal, registered as the `click` listener on every `.share` element).
+
+- [ ] **Step 1: Write the failing browser test**
+
+Create `tests/src/Browser/Album/ShareLinkTest.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Album;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+#[Group('api-mocked-testing')]
+final class ShareLinkTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testClickingShareLinkWithWorkingClipboardShowsSuccessToastAndDoesNotNavigate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/demoliteshiny');
+
+        $client->executeScript(
+            "Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: () => Promise.resolve() } });"
+        );
+
+        $this->assertSelectorIsNotVisible('#shareToastSuccess');
+        $this->assertSelectorIsNotVisible('#shareToastError');
+
+        $urlBeforeClick = $client->getCurrentURL();
+
+        $client->click($crawler->filter('#intro .share')->link());
+
+        $this->assertSame($urlBeforeClick, $client->getCurrentURL());
+
+        $this->assertSelectorWillBeVisible('#shareToastSuccess');
+        $this->assertSelectorWillNotBeVisible('#shareToastSuccess');
+        $this->assertSelectorWillNotBeVisible('#shareToastError');
+    }
+
+    public function testClickingShareLinkWithFailingClipboardShowsErrorToastAndDoesNotNavigate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/demoliteshiny');
+
+        $client->executeScript(
+            "Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: () => Promise.reject() } });"
+        );
+
+        $this->assertSelectorIsNotVisible('#shareToastSuccess');
+        $this->assertSelectorIsNotVisible('#shareToastError');
+
+        $urlBeforeClick = $client->getCurrentURL();
+
+        $client->click($crawler->filter('#intro .share')->link());
+
+        $this->assertSame($urlBeforeClick, $client->getCurrentURL());
+
+        $this->assertSelectorWillBeVisible('#shareToastError');
+        $this->assertSelectorWillNotBeVisible('#shareToastError');
+        $this->assertSelectorWillNotBeVisible('#shareToastSuccess');
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Album/ShareLinkTest.php
+```
+Expected: both tests time out / fail on `assertSelectorWillBeVisible('#shareToastSuccess')` (or `#shareToastError`), since nothing shows the toast yet — clicking `.share` still navigates (no listener attached), so the `assertSame($urlBeforeClick, ...)` assertion should fail first.
+
+- [ ] **Step 3: Implement the click handler**
+
+Append to `public/js/album.js` (after the final `activateReadMode` function, currently ending at line 155):
+```js
+
+function watchShareLink() {
+  document.querySelectorAll(".share").forEach(function (element) {
+    element.addEventListener("click", onShareLinkClick);
+  });
+}
+
+function onShareLinkClick(event) {
+  event.preventDefault();
+
+  const shareUrl = event.currentTarget.href;
+
+  if (!navigator.clipboard) {
+    new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    return;
+  }
+
+  navigator.clipboard.writeText(shareUrl)
+    .then(function () {
+      new bootstrap.Toast(document.getElementById("shareToastSuccess")).show();
+    })
+    .catch(function () {
+      new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    });
+}
+```
+
+- [ ] **Step 4: Wire it up**
+
+In `templates/Album/index.html.twig`, change:
+```twig
+    <script>
+    (function() {
+        watchScreenshotMode();
+    })();
+    </script>
+```
+to:
+```twig
+    <script>
+    (function() {
+        watchScreenshotMode();
+        watchShareLink();
+    })();
+    </script>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Album/ShareLinkTest.php
+```
+Expected: `OK (2 tests, ...)`.
+
+- [ ] **Step 6: Run the full existing test suite to check for regressions**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Album
+```
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add public/js/album.js templates/Album/index.html.twig tests/src/Browser/Album/ShareLinkTest.php
+git commit -m "feat(album): copy share link to clipboard on click with toast feedback"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** click interception (Task 2 Step 3-4) ✓, absolute URL via `event.currentTarget.href` (Task 2 Step 3) ✓, success/error toasts (Task 1) ✓, no-navigator.clipboard fallback (Task 2 Step 3) ✓, merged toast container (Task 1 Step 5) ✓, translations (Task 1 Step 3) ✓, existing `.share` anchor/`IntroTest` untouched apart from additive assertions ✓.
+- **Deviation from spec's testing section:** the spec proposed asserting "one of the two toasts becomes visible" without controlling which, since Clipboard API availability is environment-dependent. This plan instead stubs `navigator.clipboard` via `executeScript` before clicking, making both the success and the error path deterministic and independently assertable — a stricter test than the spec called for, still fully consistent with its intent (verify the click doesn't navigate and produces the expected toast).
+- **Placeholder scan:** none — every step has complete, runnable code.
+- **Type/id consistency:** `#shareToastSuccess` / `#shareToastError` used identically across the macro (Task 1), the JS (Task 2), and both test files.

--- a/docs/superpowers/specs/2026-07-06-share-link-copy-toast-design.md
+++ b/docs/superpowers/specs/2026-07-06-share-link-copy-toast-design.md
@@ -1,0 +1,148 @@
+# Design — Share link auto-copy + toast
+
+**Date:** 2026-07-06
+**Branch:** feature/modal_copypaste
+**Issue:** https://github.com/douzeEnsemble/pokenini-web/issues/284
+
+## Context
+
+The album intro (`templates/Album/_intro.html.twig`) shows a "share" icon (`.share`, visible only `{% if not dex.isPrivate %}`) whose `href` is the current album view URL with `?t=<trainerId>` appended. Today clicking it just navigates to that same URL (which happens to render the shared/read-only view). There is no copy-to-clipboard affordance.
+
+Issue #284 asks that clicking the share link copy it to the clipboard and confirm with a toast, instead of navigating.
+
+## Chosen approach
+
+Intercept the click in JS, copy the link via the Clipboard API, and confirm with a toast. No modal, no visible link/input, no copy button — the simplest option that satisfies the issue's core ask (auto-copy + toast confirmation).
+
+Two other approaches were considered and rejected for now: (a) a modal showing the link in a readonly input with a manual copy button, closer to the issue's literal wording but more UI than requested after discussion; (b) leaving navigation as a fallback when the Clipboard API is unavailable — rejected because it would silently change page state instead of just informing the user, and the plain `<a href>` is still there for manual copy (right-click → copy link) regardless.
+
+## Behavior
+
+On click on `.share`:
+1. `preventDefault()` — no navigation.
+2. Read `event.currentTarget.href`. The DOM `.href` property is always browser-resolved to an absolute URL, even though the Twig-rendered attribute is a relative path — no template change needed to obtain the absolute URL.
+3. If `navigator.clipboard` exists, call `writeText(shareUrl)`:
+  - resolved → show `#shareToastSuccess`.
+  - rejected (e.g. permission denied) → show `#shareToastError`.
+4. If `navigator.clipboard` doesn't exist (non-secure context) → show `#shareToastError` directly, no exception thrown.
+
+## Changes
+
+### 1. `public/js/album.js`
+
+Add, following the existing `watchScreenshotMode` / `onEnableScreenshotMode` style:
+
+```js
+function watchShareLink() {
+  document.querySelectorAll(".share").forEach(function (element) {
+    element.addEventListener("click", onShareLinkClick);
+  });
+}
+
+function onShareLinkClick(event) {
+  event.preventDefault();
+
+  const shareUrl = event.currentTarget.href;
+
+  if (!navigator.clipboard) {
+    new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    return;
+  }
+
+  navigator.clipboard.writeText(shareUrl)
+    .then(function () {
+      new bootstrap.Toast(document.getElementById("shareToastSuccess")).show();
+    })
+    .catch(function () {
+      new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    });
+}
+```
+
+### 2. `templates/Album/index.html.twig`
+
+Call `watchShareLink();` in the existing unconditional IIFE, next to `watchScreenshotMode();` (this script block already runs regardless of `allowedToEdit`, matching the share link's own visibility condition which only depends on `dex.isPrivate`).
+
+### 3. `templates/Album/_album_macros.html.twig`
+
+Add a `shareToasts()` macro (no params, unlike `toasts(item)` which is per-Pokémon) producing the two toast elements, mirroring the existing `toasts(item)` macro structure:
+
+```twig
+{% macro shareToasts() %}
+  <div id="shareToastSuccess" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.success'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+
+  <div id="shareToastError" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.error'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+{% endmacro %}
+```
+
+### 4. `templates/Album/_toasts.html.twig`
+
+Currently the whole container is gated by `allowedToEdit`. Widen the gate so the container renders whenever either condition applies, and render each toast group independently inside:
+
+```twig
+{% import "Album/_album_macros.html.twig" as macro %}
+
+{% if allowedToEdit or not dex.isPrivate %}
+    <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
+        {% if allowedToEdit %}
+            {% for item in list %}
+                {{ macro.toasts(item) }}
+            {% endfor %}
+        {% endif %}
+
+        {% if not dex.isPrivate %}
+            {{ macro.shareToasts() }}
+        {% endif %}
+    </div>
+{% endif %}
+```
+
+This avoids two overlapping fixed-position toast containers when both conditions are true.
+
+### 5. Translations (`translations/messages+intl-icu.{en,fr}.yaml`)
+
+Add under `album:`:
+
+```yaml
+  share:
+    toast:
+      success: "Link copied to the clipboard!"
+      error: "Could not copy the link automatically, please copy it manually."
+```
+
+(French wording to be adapted equivalently, e.g. `"Lien copié dans le presse-papier !"` / `"Impossible de copier le lien automatiquement, merci de le copier manuellement."`)
+
+## Testing
+
+- `tests/src/Integration/Controller/Album/Display/IntroTest.php`: unaffected — the `.share` anchor's markup, class, and `href` are unchanged. No new assertions needed there (the toasts are a separate container not currently asserted on).
+- New browser test (`tests/src/Browser/Album/...`, following the `ModalTest.php` pattern with `AbstractBrowserTestCase` + Panther): load an album page with a visible share link, click `.share`, then assert:
+  - the browser did not navigate away (URL unchanged) — confirms `preventDefault()` ran;
+  - one of `#shareToastSuccess` / `#shareToastError` becomes visible — not asserting which one, since Clipboard API availability depends on the test environment (the app is served over plain `http://web` in CI, a non-secure context, so the error path is the realistic CI outcome; asserting "a toast appeared" rather than which one keeps the test meaningful without being tied to that environment detail).
+
+## Files to create/modify
+
+| File | Action |
+|---|---|
+| `public/js/album.js` | Add `watchShareLink()` / `onShareLinkClick()` |
+| `templates/Album/index.html.twig` | Call `watchShareLink();` |
+| `templates/Album/_album_macros.html.twig` | Add `shareToasts()` macro |
+| `templates/Album/_toasts.html.twig` | Widen gate, render both toast groups |
+| `translations/messages+intl-icu.en.yaml` | Add `album.share.toast.*` |
+| `translations/messages+intl-icu.fr.yaml` | Add `album.share.toast.*` |
+| `tests/src/Browser/Album/ShareLinkTest.php` (new) | Click → no navigation + toast visible |
+
+## Out of scope
+
+- No modal, no visible link/input, no manual copy button (simplified per user decision).
+- No change to the `.share` anchor's `href`/attributes/visibility condition.
+- No change to `IntroTest.php` (existing assertions already cover `.share` presence/href correctly).

--- a/public/js/album.js
+++ b/public/js/album.js
@@ -133,3 +133,28 @@ function swapNode(firstNode, secondNode) {
   firstNode.replaceWith(secondNode);
   parent.insertBefore(firstNode, afterSecondNode);
 }
+
+function watchShareLink() {
+  document.querySelectorAll(".share").forEach(function (element) {
+    element.addEventListener("click", onShareLinkClick);
+  });
+}
+
+function onShareLinkClick(event) {
+  event.preventDefault();
+
+  const shareUrl = event.currentTarget.href;
+
+  if (!navigator.clipboard) {
+    new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    return;
+  }
+
+  navigator.clipboard.writeText(shareUrl)
+    .then(function () {
+      new bootstrap.Toast(document.getElementById("shareToastSuccess")).show();
+    })
+    .catch(function () {
+      new bootstrap.Toast(document.getElementById("shareToastError")).show();
+    });
+}

--- a/templates/Album/_album_macros.html.twig
+++ b/templates/Album/_album_macros.html.twig
@@ -240,6 +240,22 @@
   </div>
 {% endmacro %}
 
+{% macro shareToasts() %}
+  <div id="shareToastSuccess" class="toast text-bg-light text-dark" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.success'|trans }}</div>
+      <button type="button" class="btn-close btn-close-dark me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+
+  <div id="shareToastError" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.share.toast.error'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+{% endmacro %}
+
 {% macro boxTitle(boxNumber) %}
   <div class="box-title sticky-top">
     {% set title = ('title.box'|trans)~' '~boxNumber %}

--- a/templates/Album/_toasts.html.twig
+++ b/templates/Album/_toasts.html.twig
@@ -1,9 +1,15 @@
 {% import "Album/_album_macros.html.twig" as macro %}
 
-{% if allowedToEdit %}
+{% if allowedToEdit or not dex.isPrivate %}
     <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
-        {% for item in list %}
-            {{ macro.toasts(item) }}
-        {% endfor %}
+        {% if allowedToEdit %}
+            {% for item in list %}
+                {{ macro.toasts(item) }}
+            {% endfor %}
+        {% endif %}
+
+        {% if not dex.isPrivate %}
+            {{ macro.shareToasts() }}
+        {% endif %}
     </div>
 {% endif %}

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -79,6 +79,7 @@
     <script>
     (function() {
         watchScreenshotMode();
+        watchShareLink();
     })();
     </script>
 

--- a/tests/src/Browser/Album/ShareLinkTest.php
+++ b/tests/src/Browser/Album/ShareLinkTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Album;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+#[Group('api-mocked-testing')]
+final class ShareLinkTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testClickingShareLinkWithWorkingClipboardShowsSuccessToastAndDoesNotNavigate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/demoliteshiny');
+
+        $client->executeScript(
+            "Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: () => Promise.resolve() } });"
+        );
+
+        $this->assertSelectorIsNotVisible('#shareToastSuccess');
+        $this->assertSelectorIsNotVisible('#shareToastError');
+
+        $urlBeforeClick = $client->getCurrentURL();
+
+        $client->click($crawler->filter('#intro .share')->link());
+
+        $this->assertSame($urlBeforeClick, $client->getCurrentURL());
+
+        $this->assertSelectorWillBeVisible('#shareToastSuccess');
+        $this->assertSelectorWillNotBeVisible('#shareToastSuccess');
+        $this->assertSelectorWillNotBeVisible('#shareToastError');
+    }
+
+    public function testClickingShareLinkWithFailingClipboardShowsErrorToastAndDoesNotNavigate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/demoliteshiny');
+
+        $client->executeScript(
+            "Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: () => Promise.reject() } });"
+        );
+
+        $this->assertSelectorIsNotVisible('#shareToastSuccess');
+        $this->assertSelectorIsNotVisible('#shareToastError');
+
+        $urlBeforeClick = $client->getCurrentURL();
+
+        $client->click($crawler->filter('#intro .share')->link());
+
+        $this->assertSame($urlBeforeClick, $client->getCurrentURL());
+
+        $this->assertSelectorWillBeVisible('#shareToastError');
+        $this->assertSelectorWillNotBeVisible('#shareToastError');
+        $this->assertSelectorWillNotBeVisible('#shareToastSuccess');
+    }
+}

--- a/tests/src/Integration/Controller/Album/Display/CommonTest.php
+++ b/tests/src/Integration/Controller/Album/Display/CommonTest.php
@@ -130,7 +130,7 @@ final class CommonTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.album-case .album-case-catch-state a.album-case-catch-state-label');
         $this->assertCountFilter($crawler, 41, '.album-case .album-case-catch-state span.album-case-catch-state-label');
 
-        $this->assertCountFilter($crawler, 0, '.toast');
+        $this->assertCountFilter($crawler, 2, '.toast');
 
         $this->assertCountFilter($crawler, 1, 'script[src="/js/album.js"]');
         $this->assertCountFilter($crawler, 0, 'script[src="/js/album-edit.js"]');
@@ -151,9 +151,10 @@ final class CommonTest extends WebTestCase
         $this->assertCountFilter($crawler, 41, '.album-case .album-case-catch-state a.album-case-catch-state-label');
         $this->assertCountFilter($crawler, 0, '.album-case .album-case-catch-state span.album-case-catch-state-label');
 
-        $this->assertCountFilter($crawler, 82, '.toast');
+        $this->assertCountFilter($crawler, 84, '.toast');
         $this->assertCountFilter($crawler, 41, '.toast.text-bg-success');
-        $this->assertCountFilter($crawler, 41, '.toast.text-bg-danger');
+        $this->assertCountFilter($crawler, 1, '.toast.text-bg-light');
+        $this->assertCountFilter($crawler, 42, '.toast.text-bg-danger');
 
         $this->assertCountFilter($crawler, 1, 'script[src="/js/album.js"]');
 

--- a/tests/src/Integration/Controller/Album/Display/IntroTest.php
+++ b/tests/src/Integration/Controller/Album/Display/IntroTest.php
@@ -66,6 +66,9 @@ final class IntroTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 0, '#intro .share');
 
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+
         $this->assertCountFilter($crawler, 0, '#intro .album-private');
         $this->assertCountFilter($crawler, 0, '#intro .album-another-trainer');
         $this->assertCountFilter($crawler, 0, '#intro .dex-type');
@@ -116,6 +119,9 @@ final class IntroTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 0, '#intro .share');
 
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+
         $this->assertCountFilter($crawler, 0, '#intro .album-private');
         $this->assertCountFilter($crawler, 0, '#intro .album-another-trainer');
         $this->assertCountFilter($crawler, 0, '#intro .dex-type');
@@ -163,6 +169,9 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .goto.goto-topofthelist');
 
         $this->assertCountFilter($crawler, 1, '#intro .share');
+
+        $this->assertCountFilter($crawler, 1, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 1, '#shareToastError');
         $this->assertEquals(
             '/fr/album/demoliteshiny?t=7b52009b64fd0a2a49e6d8a939753077792b0554',
             $crawler->filter('#intro .share')->attr('href')
@@ -222,6 +231,9 @@ final class IntroTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 0, '#intro .share');
 
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+
         $this->assertCountFilter($crawler, 0, '#intro .album-private');
         $this->assertCountFilter($crawler, 0, '#intro .album-another-trainer');
         $this->assertCountFilter($crawler, 0, '#intro .dex-type');
@@ -276,6 +288,9 @@ final class IntroTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 0, '#intro .share');
 
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+
         $this->assertCountFilter($crawler, 0, '#intro .album-private');
         $this->assertCountFilter($crawler, 0, '#intro .album-another-trainer');
         $this->assertCountFilter($crawler, 0, '#intro .dex-type');
@@ -325,6 +340,9 @@ final class IntroTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 0, '#intro .share');
 
+        $this->assertCountFilter($crawler, 0, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 0, '#shareToastError');
+
         $this->assertCountFilter($crawler, 0, '#intro .album-private');
         $this->assertCountFilter($crawler, 0, '#intro .album-another-trainer');
         $this->assertCountFilter($crawler, 0, '#intro .dex-type');
@@ -368,6 +386,9 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .goto.goto-topofthelist');
 
         $this->assertCountFilter($crawler, 1, '#intro .share');
+
+        $this->assertCountFilter($crawler, 1, '#shareToastSuccess');
+        $this->assertCountFilter($crawler, 1, '#shareToastError');
         $this->assertEquals(
             '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554',
             $crawler->filter('#intro .share')->attr('href')

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -140,6 +140,10 @@ album:
     filters:
       title: Filters
       open_distinguish_types: More
+  share:
+    toast:
+      success: "Link copied to the clipboard!"
+      error: "Could not copy the link automatically, please copy it manually."
 
 update:
   labels:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -145,6 +145,10 @@ album:
       title: Informations
     title: Filtres
     open_distinguish_types: Avancées
+  share:
+    toast:
+      success: "Lien copié dans le presse-papier !"
+      error: "Impossible de copier le lien automatiquement, merci de le copier manuellement."
 
 update:
   labels:


### PR DESCRIPTION
Clicking the album share icon now copies the link and shows a success/error toast instead of navigating away.