### PR TITLE
fix: replace dex grid resting opacity with border/shadow hover affordance

### DIFF
--- a/public/css/dex-list.css
+++ b/public/css/dex-list.css
@@ -1,11 +1,12 @@
 .dex-item .card {
-    opacity: 50%;
     transition:
         border-color 0.4s ease,
-        opacity 0.9s ease
+        box-shadow 0.25s ease,
+        transform 0.25s ease
     ;
 }
 .dex-item .card:hover {
     border-color: var(--bs-secondary);
-    opacity: 100%;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, .16);
+    transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- The `.dex-item .card` resting state was 50% opacity, which reads as a disabled/locked state once several cards are shown together in the grid.
- Hover affordance now comes from `border-color`, `box-shadow` and a small `translateY` lift instead of an opacity change; cards are fully opaque at rest.

## Test plan
- [x] Load the dex list page and confirm cards render fully visible (not dimmed) at rest.
- [x] Hover a card and confirm border/shadow/lift transition still feels intentional.
- [x] Check both light/dark rendering if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)