### PR TITLE
fix: catch-state save-failure revert, responsive box grid, CSS tokens, DOM render perf

### DIFF
--- a/public/css/album.css
+++ b/public/css/album.css
@@ -18,6 +18,27 @@
     font-size: .6rem;
     padding-bottom: .125rem;
 }
+
+/* Below md, .album-box shows fewer columns (row-cols-3/row-cols-sm-4), so
+   cells are wider than at the 6-column desktop density: scale text up
+   accordingly instead of keeping the desktop-tuned sizes illegibly small. */
+@media (max-width: 767.98px) {
+    .album-case-dex-number {
+        font-size: .65rem;
+    }
+    .album-case-name {
+        font-size: .75rem;
+    }
+    .album-case-catch-state {
+        font-size: .8rem;
+    }
+    .album-case-forms {
+        font-size: .7rem;
+    }
+    .album-case-action {
+        font-size: .7rem;
+    }
+}
 .album-case-action select {
     width: 100%;
 }

--- a/public/css/album.css
+++ b/public/css/album.css
@@ -42,12 +42,6 @@
 .album-case-action select {
     width: 100%;
 }
-.pokemon-icon {
-    max-width: 68px;
-    max-height: 56px;
-    font-size: .3rem;
-    color: rgba(0 0 0 / 0%);
-}
 a.album-case-catch-state-edit-action {
     color: inherit;
 }
@@ -59,14 +53,6 @@ a.album-case-catch-state-edit-action:hover {
     max-width: 768px;
 }
 
-.album-modal-types {
-    color: white;
-}
-
-.list-group-item .icon-link {
-    align-items: inherit;
-}
-
 .modal-body .list-group {
     font-size: 0.85rem;
 }
@@ -75,20 +61,20 @@ a.album-case-catch-state-edit-action:hover {
 }
 .modal-body a.pokemon-icon {
     text-decoration: none;
-    color: #aab7b8;
+    color: var(--icon-link-color);
 }
 .modal-body a.pokemon-icon:hover {
-    color: #408b91;
+    color: var(--icon-link-hover-color);
 }
 .modal-body a.pokemon-icon:hover .img-thumbnail {
-    border-color: #408b91;
+    border-color: var(--icon-link-hover-color);
 }
 .modal-body a.pokemon-icon.active {
     text-decoration: underline;
-    color: #212529;
+    color: var(--bs-body-color);
 }
 .modal-body .active .img-thumbnail {
-    border-color: #212529;
+    border-color: var(--bs-body-color);
 }
 
 #report a {

--- a/public/css/album.css
+++ b/public/css/album.css
@@ -93,6 +93,19 @@ a.album-case-catch-state-edit-action:hover {
     width: 100%;
 }
 
+/* A full living dex renders hundreds of cases: defer layout/paint for the
+   ones off-screen instead of paying for all of them up front. Scoped to
+   .album-case itself (not its .album-line/.box ancestor, and not the
+   sibling .modal) because content-visibility implies CSS containment, which
+   would otherwise clip each Pokémon's position:fixed detail modal to its
+   ancestor's box instead of letting it overlay the full viewport.
+   contain-intrinsic-size is only a placeholder used before the first real
+   render, so a rough estimate is enough. */
+.album-case {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 140px;
+}
+
 .d-flex[hidden] {
     display: none !important;
 }

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -1,3 +1,8 @@
+:root {
+    --icon-link-color: #aab7b8;
+    --icon-link-hover-color: #408b91;
+}
+
 html {
     scroll-behavior: auto !important;
     scroll-padding-bottom: 80px;
@@ -5,4 +10,21 @@ html {
 
 .container {
     padding-bottom: 4rem;
+}
+
+/* Shared by Album and Election, which both render Pokémon icon links and
+   type badges - kept here once instead of duplicated per feature file. */
+.pokemon-icon {
+    max-width: 68px;
+    max-height: 56px;
+    font-size: .3rem;
+    color: rgba(0 0 0 / 0%);
+}
+
+.album-modal-types {
+    color: white;
+}
+
+.list-group-item .icon-link {
+    align-items: inherit;
 }

--- a/public/css/election.css
+++ b/public/css/election.css
@@ -3,27 +3,12 @@
     cursor: pointer;
 }
 
-.pokemon-icon {
-    max-width: 68px;
-    max-height: 56px;
-    font-size: .3rem;
-    color: rgba(0 0 0 / 0%);
-}
-
 a.election-card-catch-state-edit-action {
     color: inherit;
 }
 
 a.election-card-catch-state-edit-action:hover {
     color: black;
-}
-
-.album-modal-types {
-    color: white;
-}
-
-.list-group-item .icon-link {
-    align-items: inherit;
 }
 
 .election-top-item .card-img.img-fluid {

--- a/public/js/album-edit.js
+++ b/public/js/album-edit.js
@@ -1,5 +1,6 @@
 function watchCatchStates() {
   document.querySelectorAll(".album-container select").forEach(function (element) {
+    element.dataset.committedValue = element.value;
     element.addEventListener("change", onChangeCatchState);
   });
 }
@@ -30,9 +31,11 @@ function watchToggleEditMode() {
 
 function onChangeCatchState(event) {
   const target = event.target;
+  const previousValue = target.dataset.committedValue ?? target.value;
 
-  saveChange(target);
-  changeClass(target);
+  target.disabled = true;
+
+  saveChange(target, previousValue);
 }
 
 function onActivateEditMode(event) {
@@ -87,7 +90,7 @@ function onActivateAllReadMode(event) {
   readMode.setAttribute("hidden", true);
 }
 
-function saveChange(target) {
+function saveChange(target, previousValue) {
   const pokemon = target.closest(".album-case").getAttribute("id");
   const catchState = target.value;
 
@@ -102,12 +105,20 @@ function saveChange(target) {
         throw new Error("Something went wrong on api server!");
       }
 
+      target.dataset.committedValue = catchState;
+      changeClass(target);
+      target.disabled = false;
+
       new bootstrap.Toast(
         document.getElementById("successToast-" + pokemon)
       ).show();
     })
     .catch((error) => {
       console.error(error);
+
+      target.value = previousValue;
+      changeClass(target);
+      target.disabled = false;
 
       new bootstrap.Toast(
         document.getElementById("errorToast-" + pokemon)

--- a/public/js/trainer_dex.js
+++ b/public/js/trainer_dex.js
@@ -8,11 +8,14 @@ function watchAttributes()
 function onChangeAttributes(event)
 {
   const target = event.target;
+  const previousChecked = !target.checked;
 
-  saveChange(target);
+  target.disabled = true;
+
+  saveChange(target, previousChecked);
 }
 
-function saveChange(target)
+function saveChange(target, previousChecked)
 {
   const form = target.closest('form');
   const dexSlug = form.getAttribute('data-dex');
@@ -38,12 +41,17 @@ function saveChange(target)
         throw new Error('Something went wrong on api server!');
       }
 
+      target.disabled = false;
+
       new bootstrap.Toast(
         document.getElementById('successToast-'+dexSlug)
       ).show();
     })
     .catch(error => {
       console.error(error);
+
+      target.checked = previousChecked;
+      target.disabled = false;
 
       new bootstrap.Toast(
         document.getElementById('errorToast-'+dexSlug)

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -11,26 +11,24 @@
     <link rel="stylesheet" href="{{ asset('css/album.css') }}">
 
     <style>
+    {% include 'common/_catch_state_color_tokens.html.twig' %}
     {% for catchState in catchStates %}
     .album-case.catch-state-{{ catchState.slug }} .album-case-catch-state {
-        background-color: {{ catchState.color }};
+        background-color: var(--catch-state-{{ catchState.slug }});
     }
     .album-case.catch-state-{{ catchState.slug }} .album-case-action {
-        background-color: {{ catchState.color }};
+        background-color: var(--catch-state-{{ catchState.slug }});
     }
     tr.catch-state-{{ catchState.slug }} td,
     tr.catch-state-{{ catchState.slug }} th {
-        background-color: {{ catchState.color }};
+        background-color: var(--catch-state-{{ catchState.slug }});
     }
     {% endfor %}
 
     {% include 'common/_catch_state_progress_bar_styles.html.twig' %}
 
-    {% for type in types %}
-    .pokemon-type-{{ type.slug }} {
-        background-color: {{ type.color }};
-    }
-    {% endfor %}
+    {% include 'common/_pokemon_type_color_tokens.html.twig' %}
+    {% include 'common/_pokemon_type_color_classes.html.twig' %}
     </style>
 {% endblock stylesheets %}
 

--- a/templates/Album/view/_box.html.twig
+++ b/templates/Album/view/_box.html.twig
@@ -5,7 +5,7 @@
 <div class="album-container album-box">
 {% if filters is not empty %}
     <h2 class="sticky-top">{{ 'title.empty'|trans }}</h2>
-    <div class="row row-cols-6 album-line">
+    <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
         {% for item in list %}
             {{ macro.albumCase(item, dex, allowedToEdit, catchStates, sharedTrainerId, list, loop) }}
         {% endfor %}
@@ -13,7 +13,7 @@
 {% else %}
     <div id="box-1" class="box row">
         {{ macro.boxTitle(1) }}
-        <div class="row row-cols-6 album-line">
+        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
             {% for item in list %}
             {% set boxNumber = (loop.index0 / (6*5)) + 1 %}
 
@@ -23,7 +23,7 @@
     <hr>
     <div id="box-{{ boxNumber }}" class="box row">
         {{ macro.boxTitle(boxNumber) }}
-        <div class="row row-cols-6 album-line">
+        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
             {% endif %}
 
             {{ macro.albumCase(item, dex, allowedToEdit, catchStates, sharedTrainerId, list, loop) }}

--- a/templates/AlbumDexList/index.html.twig
+++ b/templates/AlbumDexList/index.html.twig
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="{{ asset('css/dex-list.css') }}">
 
   <style>
+  {% include 'common/_catch_state_color_tokens.html.twig' %}
   {% include 'common/_catch_state_progress_bar_styles.html.twig' %}
   </style>
 {% endblock stylesheets %}

--- a/templates/Election/index.html.twig
+++ b/templates/Election/index.html.twig
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="{{ asset('css/election.css') }}">
 
   <style>
+    {% include 'common/_pokemon_type_color_tokens.html.twig' %}
+    {% include 'common/_pokemon_type_color_classes.html.twig' %}
+
     {% for type in types %}
       {% set iconUrl = pokemonTypeIconUrl|format(type.slug) %}
-      .pokemon-type-{{type.slug}}{
-        background-color: {{type.color}}FF;
-      }
       .filters-types.pokemon-type-{{type.slug}}{
         background-image: url('{{ iconUrl }}');
       }

--- a/templates/Home/index.html.twig
+++ b/templates/Home/index.html.twig
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="{{ asset('css/dex-list.css') }}">
 
   <style>
+  {% include 'common/_catch_state_color_tokens.html.twig' %}
   {% include 'common/_catch_state_progress_bar_styles.html.twig' %}
   </style>
 {% endblock stylesheets %}

--- a/templates/Trainer/index.html.twig
+++ b/templates/Trainer/index.html.twig
@@ -9,6 +9,7 @@
   {{ parent() }}
 
   <style>
+  {% include 'common/_catch_state_color_tokens.html.twig' %}
   {% include 'common/_catch_state_progress_bar_styles.html.twig' %}
   </style>
 {% endblock stylesheets %}

--- a/templates/common/_catch_state_color_tokens.html.twig
+++ b/templates/common/_catch_state_color_tokens.html.twig
@@ -1,0 +1,8 @@
+{# Defines one CSS custom property per catch-state color so every page that
+   themes catch-states (progress bars, album cases, tables, ...) reads from a
+   single source instead of re-emitting the color literal in every rule. #}
+:root {
+    {% for catchState in catchStates %}
+    --catch-state-{{ catchState.slug }}: {{ catchState.color }};
+    {% endfor %}
+}

--- a/templates/common/_catch_state_progress_bar_styles.html.twig
+++ b/templates/common/_catch_state_progress_bar_styles.html.twig
@@ -1,8 +1,8 @@
 {% for catchState in catchStates %}
 .progress-bar.catch-state-{{ catchState.slug }} {
-    background-color: {{ catchState.color }};
+    background-color: var(--catch-state-{{ catchState.slug }});
 }
 .tooltip-{{ catchState.slug }} {
-    --bs-tooltip-bg: {{ catchState.color }};
+    --bs-tooltip-bg: var(--catch-state-{{ catchState.slug }});
 }
 {% endfor %}

--- a/templates/common/_pokemon_type_color_classes.html.twig
+++ b/templates/common/_pokemon_type_color_classes.html.twig
@@ -1,0 +1,10 @@
+{# Shared ".pokemon-type-X { background-color }" badge rules, reused by both
+   Album (type badges) and Election (filter buttons) instead of each page
+   re-emitting its own copy of the same rule. Requires
+   common/_pokemon_type_color_tokens.html.twig to be included on the same
+   page for the --pokemon-type-X custom properties to resolve. #}
+{% for type in types %}
+.pokemon-type-{{ type.slug }} {
+    background-color: var(--pokemon-type-{{ type.slug }});
+}
+{% endfor %}

--- a/templates/common/_pokemon_type_color_tokens.html.twig
+++ b/templates/common/_pokemon_type_color_tokens.html.twig
@@ -1,0 +1,8 @@
+{# Defines one CSS custom property per Pokémon type color, consumed by
+   common/_pokemon_type_color_classes.html.twig and by page-specific rules
+   (e.g. the Election filter buttons) that need the raw color value. #}
+:root {
+    {% for type in types %}
+    --pokemon-type-{{ type.slug }}: {{ type.color }};
+    {% endfor %}
+}

--- a/tests/src/Browser/Album/SelectAndLabelTest.php
+++ b/tests/src/Browser/Album/SelectAndLabelTest.php
@@ -353,7 +353,9 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#errorToast-squirtle');
         $this->assertSelectorWillNotBeVisible('#successToast-squirtle');
 
-        $this->assertSelectorAttributeNotContains('#squirtle', 'class', 'catch-state-no');
-        $this->assertSelectorAttributeContains('#squirtle', 'class', 'catch-state-tobreed');
+        // On a failed save, the case must revert to its last confirmed catch-state
+        // instead of silently keeping the unsaved value the user picked.
+        $this->assertSelectorAttributeContains('#squirtle', 'class', 'catch-state-no');
+        $this->assertSelectorAttributeNotContains('#squirtle', 'class', 'catch-state-tobreed');
     }
 }


### PR DESCRIPTION
## Summary
Stacked on #359 (UI/UX audit quick wins). Three further items from the same audit, kept on their own branch/PR since they're more invasive than the quick wins:

- **Catch-state save-failure revert**: `album-edit.js`/`trainer_dex.js` applied the visual state change optimistically and never rolled it back on a failed PATCH/PUT — a user could believe an unsaved change had stuck. Now the visual state only updates after the request confirms; on failure it reverts to the last confirmed value, and the control is disabled while in flight to avoid racing overlapping changes.
- **Responsive box grid**: `Album/view/_box.html.twig` was fixed at `row-cols-6` on every viewport, giving ~55-60px cells with near-illegible text on a phone. Now `row-cols-3`/`row-cols-sm-4`/`row-cols-md-6`, with case text sized up below 768px.
- **CSS custom-property tokens**: catch-state/Pokémon-type colors come from backend data so they must stay in per-page inline `<style>` blocks, but the color literal was being re-emitted into 2-5 separate rules per page. New shared partials (`common/_catch_state_color_tokens.html.twig`, `common/_pokemon_type_color_tokens.html.twig`, `common/_pokemon_type_color_classes.html.twig`) declare each color once as a `:root` custom property, consumed via `var()` everywhere else. Also deduped `.pokemon-icon`/`.album-modal-types`/`.list-group-item .icon-link`, which were byte-identical between `album.css` and `election.css`, into `base.css`.
- **DOM render perf**: `content-visibility: auto` on `.album-case` so the browser defers layout/paint for off-screen cases on a large dex. Scoped to `.album-case` itself rather than its `.album-line`/`.box` ancestor — content-visibility implies CSS containment, and each Pokémon's detail modal is a *sibling* of its case, not a descendant; containing higher up clipped the modal's `position: fixed` to the ancestor's box. First attempt broke `ModalTest::testModalImageSwitch` on Chrome; rescoping fixed it. Note this only reduces rendering cost, not DOM node count/memory — real pagination would need a backend change and is out of scope here.

## Test plan
- [x] `lint:twig` — 60/60 files valid
- [x] Full integration + unit suite — 604 tests, 5282 assertions, green
- [x] Full browser suite against **both** Chrome and Firefox — 42/42 each, green (this is what caught the content-visibility/modal regression before it shipped)
- [x] `SelectAndLabelTest::testActionCatchStateChangeError` updated to assert the corrected (reverted) behavior instead of the bug it used to lock in

🤖 Generated with [Claude Code](https://claude.com/claude-code)