### PR TITLE
fix: election voting instruction and catch-state select accessible label

### DIFF
--- a/templates/Album/_album_macros.html.twig
+++ b/templates/Album/_album_macros.html.twig
@@ -3,18 +3,24 @@
 
   {% set locale = app.request.locale %}
   {% set currentCatchState = item.catchStateSlug ?? 'no' %}
+  {% set pokemonName = locale is same as('fr') ? item.pokemonSimplifiedFrenchName : item.pokemonSimplifiedName %}
 
   <div class="album-case col catch-state-{{ currentCatchState }}" id="{{ item.pokemonSlug }}">
     {% set dexNumber = dex.regionName is not empty ? item.pokemonRegionalDexNumber : item.pokemonNationalDexNumber %}
     <div class="text-center text-truncate">
-      <label class="album-case-title" for="catch-state-{{ item.pokemonSlug }}" data-bs-toggle="modal" data-bs-target="#modal-{{ item.pokemonSlug }}">
+      {# This title opens the info modal - it is not a form label for the
+         catch-state select below, even though both share the same
+         Pokémon. Giving it a `for` here used to make the select's
+         accessible name "#150 Mewtwo" instead of describing the control,
+         so the select gets its own hidden label instead (see below). #}
+      <span class="album-case-title" data-bs-toggle="modal" data-bs-target="#modal-{{ item.pokemonSlug }}">
         <span class="album-case-dex-number">
           #{{ dexNumber }}
         </span>
         <span class="album-case-name">
-          {{ locale is same as('fr') ? item.pokemonSimplifiedFrenchName : item.pokemonSimplifiedName }}
+          {{ pokemonName }}
         </span>
-      </label>
+      </span>
     </div>
     <div class="album-case-image text-center" title="#{{ dexNumber }} {{ locale is same as('fr') ? item.pokemonFrenchName : item.pokemonName }}">
       <span data-bs-toggle="modal" data-bs-target="#modal-{{ item.pokemonSlug }}">
@@ -37,6 +43,9 @@
     <div class="album-case-catch-state-container">
       {% if canEdit %}
         <div class="album-case-action text-center" hidden>
+          <label class="visually-hidden" for="catch-state-{{ item.pokemonSlug }}">
+            {{ 'album.catch_state.select.label'|trans({'pokemonName': pokemonName}) }}
+          </label>
           <select class="catch-state-{{ currentCatchState }}" id="catch-state-{{ item.pokemonSlug }}" name="catch-state[{{ item.pokemonSlug }}]">
             {% for catchState in catchStates %}
               {% set isSelected = (catchState.slug is same as(currentCatchState)) %}

--- a/templates/Election/_candidates.html.twig
+++ b/templates/Election/_candidates.html.twig
@@ -1,6 +1,11 @@
 {% import "common/Pokemon/_image_macros.html.twig" as imageMacros %}
 
 <form action="" method="POST" id="election">
+  {% if not isTheLastOne %}
+    <p class="text-center text-body-secondary mb-2">
+      {{ 'election.candidates.instruction'|trans }}
+    </p>
+  {% endif %}
   <div class="row mt-xl-3 mt-1 ms-xl-5 me-xl-5 ms-md-3 me-md-3 ms-sm-1 me-sm-1">
     {% for item in pokemons %}
       <div class="col-xl-2 col-md-4 col-sm-6 col-6 mb-xl-3 mb-1 p-xl-3 p-lg-2 p-1 {{ isTheLastOne ? 'offset-xl-5 offset-md-4 offset-sm-3 offset-3' : '' }}">

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -86,6 +86,9 @@ album:
     alt:
       regular: "Image if"
       shiny: "Shiny image of"
+  catch_state:
+    select:
+      label: "Catch status of {pokemonName}"
   update:
     title: "Update"
     success:
@@ -457,6 +460,8 @@ admin:
         cta: "Invalidate!"
 
 election:
+  candidates:
+    instruction: "Pick every Pokémon you like here — you can check more than one."
   choose:
     action: "I choose this one"
   the_end: "Well done, you're done!"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -92,6 +92,9 @@ album:
     alt:
       regular: "Image de"
       shiny: "Image chromatique de"
+  catch_state:
+    select:
+      label: "Statut de capture de {pokemonName}"
   update:
     title: "Maj"
     success:
@@ -463,6 +466,8 @@ admin:
         cta: "Invalider"
 
 election:
+  candidates:
+    instruction: "Choisis tous les Pokémon que tu préfères ici, tu peux en cocher plusieurs."
   choose:
     action: "Je choisi celui-là"
   the_end: "Bravo, tu as fini"


### PR DESCRIPTION
## Summary
Stacked on #360. The last 2 minor items from the UI/UX audit that were never in an action plan (the 3rd, a box/list view toggle, stays out of scope as a product decision rather than a bug):

- **No instruction above the election candidate grid**: a first-time voter only learns they can pick multiple favorites from the reactive counter badge after clicking something. Added a short instruction line above the grid (hidden on the single-finalist "isTheLastOne" screen, where there's nothing to pick).
- **Ambiguous catch-state select label**: the `<select>` picked up its accessible name from a `for`-associated `<label>` that's actually the case's title *and* modal-trigger (dex number + Pokémon name) — a screen reader announced "#150 Mewtwo" instead of a description of the control. Dropped the `for` from the title (turned into a `<span>`, since its only real behavior was already `data-bs-toggle="modal"`) and gave the select its own hidden, descriptive label.

## Test plan
- [x] `lint:twig` — 60/60 files valid
- [x] Rendered `/fr/album/demo` live — confirmed the hidden label renders and the title is no longer a `<label>`
- [x] Integration: Album + Election — 130 tests, 2175 assertions, green
- [x] Browser (Chrome + Firefox): Album + Election — 20/20 each, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)