### PR TITLE
fix: sync mock home-tile links and progress data with real pokedex fixtures

### DIFF
--- a/docs/superpowers/plans/2026-07-13-mock-coherence-implementation.md
+++ b/docs/superpowers/plans/2026-07-13-mock-coherence-implementation.md
@@ -1,0 +1,892 @@
+# Mock Data Coherence (home ↔ pokedex) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every dex tile shown on the home page (`/album/dex`) must link to a pokedex page that actually exists (no 404s), and the progress numbers shown on the home tile must match the real data behind the pokedex page it links to.
+
+**Architecture:** Moco fixtures under `tests/resources/moco/Back/responses/` model the backend. Four dex slugs are flagged "on home" in one or more `dex/*.json` files but have no `/album/{slug}` moco route at all (404 on click). Two more (`swordshield`, `home` in `dex/trainer.json`) do have a route, but the home tile's hand-typed `report` numbers don't match the real `pokemons[]` list behind that route. This plan (a) adds the four missing routes/fixtures, sized to reproduce the `report` numbers already promised by the existing dex-list fixtures (so those numbers become true instead of needing to change), and (b) recomputes the two genuinely-wrong `report` blocks (and their `admin.json` counterparts, which share the same underlying album fixtures) from the real data.
+
+**Tech Stack:** PHPUnit (Symfony WebTestCase) integration tests, Moco JSON fixtures, a throwaway Python script (host-side, no Docker needed — pure JSON file generation).
+
+## Global Constraints
+
+- Fixture edits are plain JSON file edits — no PHP/Docker needed to write them. Only running the PHPUnit tests requires the container: `docker compose exec php php vendor/bin/phpunit <path>`.
+- After **any** change to `tests/resources/moco/Back/moco.json`, run `make restart-mocks` before running tests — Moco loads its config at container start and does not hot-reload.
+- The report-recompute formula (from the approved design doc `docs/superpowers/specs/2026-07-13-mock-coherence-design.md`): given a `pokemons[]` list, `total_caught` = count where `catch_state.slug == "yes"`; `total_uncaught` = count where `catch_state` is `null` or `slug == "no"`; `detail[]` lists only the catch states with a non-zero count, always including a `"no"` bucket when `total_uncaught > 0` and a `"yes"` bucket when `total_caught > 0` (this is what lets the twig progress bar render the uncaught mass — see `templates/common/_progress_bar_macros.html.twig:11` which substitutes `report.totalUncaught` for the literal `"no"` count); `total` = sum of all bucket counts.
+- Catch-state label metadata (`name`/`french_name`/`color`) in any `detail[]` entry must match the canonical values in `tests/resources/moco/Back/responses/labels.json` (`yes`/`Oui`/`#66bb6a`, `totrade`/`À échanger`/`#ff9100`, `totransfer`/`à transférer`/`#ffd54f`, `tobreed`/`af. reproduire`/`#4fc3f7`, `toevolve`/`af. évoluer`/`#9575cd`, `no`/`Non`/`#e57373`).
+- The scratchpad directory for throwaway scripts is `/tmp/claude-1000/-home-renaud-projects-pokenini-web/14bf70fc-ff13-44a4-b590-09a064608f41/scratchpad`. Nothing there is committed.
+
+---
+
+### Task 1: Write regression tests that prove the dead links
+
+**Files:**
+- Modify: `tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+**Interfaces:**
+- Consumes: `App\Tests\Utils\GetUserToken::getFakeUserToken(string $identifier = '789465465489', string $providerName = 'TestProvider')`, `TestNavTrait::assertCountFilter`.
+- Produces: nothing new consumed by later tasks — this is the regression proof that Task 2 and Task 3 make pass.
+
+- [ ] **Step 1: Add a new test method that follows every home-tile link for the default trainer**
+
+Add this method to `AlbumDexListTest`, right after `testAlbumDexList()` (after line 79):
+
+```php
+    public function testAlbumDexListTilesAreAllClickable(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/dex');
+
+        $this->assertResponseIsSuccessful();
+
+        $hrefs = array_unique($crawler->filter('.dex-item a')->extract(['href']));
+
+        self::assertNotEmpty($hrefs);
+
+        foreach ($hrefs as $href) {
+            $client->request('GET', $href);
+            self::assertTrue(
+                $client->getResponse()->isSuccessful(),
+                sprintf('Expected %s to be reachable, got status %d', $href, $client->getResponse()->getStatusCode())
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Add a clickability assertion to the custom-slug test**
+
+In `testAlbumDexListCustomDexLinksToUniqueSettingsSlug()` (currently ending at line 290), add two lines right before the closing `}`:
+
+```php
+        $this->assertEquals('/fr/album/home-shiny-custom', $album->filter('a')->attr('href'));
+        $this->assertEquals('https://icon.pokenini.fr/banner/homeshiny.png', $album->filter('img')->attr('src'));
+
+        $client->request('GET', '/fr/album/home-shiny-custom');
+        self::assertTrue($client->getResponse()->isSuccessful());
+    }
+```
+
+(This replaces the existing two `assertEquals` lines + closing brace with the same two lines plus the new clickability check.)
+
+- [ ] **Step 3: Run the new tests and confirm they fail**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter 'testAlbumDexListTilesAreAllClickable|testAlbumDexListCustomDexLinksToUniqueSettingsSlug' tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+Expected: FAIL — `testAlbumDexListTilesAreAllClickable` fails on the first broken slug (`/fr/album/homeshiny`, "got status 404"); `testAlbumDexListCustomDexLinksToUniqueSettingsSlug` fails on the new clickability assertion for `/fr/album/home-shiny-custom` ("got status 404").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
+git commit -m "test: prove home-tile links can 404 (homeshiny/homepogo/alpha/home-shiny-custom)"
+```
+
+---
+
+### Task 2: Add the four missing album fixtures and moco routes
+
+**Files:**
+- Create: `tests/resources/moco/Back/responses/album/default/homeshiny.json`
+- Create: `tests/resources/moco/Back/responses/album/default/homepogo.json`
+- Create: `tests/resources/moco/Back/responses/album/default/alpha.json`
+- Create: `tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json`
+- Modify: `tests/resources/moco/Back/moco.json`
+- Modify: `tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json`
+
+**Interfaces:**
+- Consumes: `tests/resources/moco/Back/responses/album/default/home.json`'s real `pokedex.pokemons[]` list (1477 entries) as a source of valid `Pokemon` objects to clone.
+- Produces: three catch-all `/album/{slug}` moco routes (`homeshiny`, `homepogo`, `alpha`) and one bearer-scoped one (`home-shiny-custom`, only for trainer `77de68daecd823babbb58edb1c8e14d7106e83bb`), each resolving to a fixture whose `pokedex.report` exactly reproduces the numbers already promised in `dex/trainer.json` (and, for `home-shiny-custom`, in `dex/77de68…json`) — so Task 1's test passes and no other existing assertion needs to change.
+
+- [ ] **Step 1: Write the fixture-generation script**
+
+Create `/tmp/claude-1000/-home-renaud-projects-pokenini-web/14bf70fc-ff13-44a4-b590-09a064608f41/scratchpad/build_mock_fixtures.py`:
+
+```python
+import copy
+import json
+
+REPO = "/home/renaud/projects/pokenini-web"
+
+CATCH_STATES = {
+    "yes": {"name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a"},
+    "totrade": {"name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100"},
+    "totransfer": {"name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f"},
+    "tobreed": {"name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7"},
+    "toevolve": {"name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd"},
+    "no": {"name": "No", "french_name": "Non", "slug": "no", "color": "#e57373"},
+}
+ORDER = ["yes", "totrade", "totransfer", "tobreed", "toevolve", "no"]
+
+with open(f"{REPO}/tests/resources/moco/Back/responses/album/default/home.json", encoding="utf-8") as f:
+    pool = json.load(f)["pokedex"]["pokemons"]
+
+
+def take(n, offset):
+    chosen = copy.deepcopy(pool[offset:offset + n])
+    for p in chosen:
+        p["catch_state"] = None
+    return chosen
+
+
+def build_report(pokemons):
+    counts = {}
+    for p in pokemons:
+        cs = p["catch_state"]
+        slug = cs["slug"] if cs else "no"
+        counts[slug] = counts.get(slug, 0) + 1
+    detail = [{"catch_state": CATCH_STATES[s], "count": counts[s]} for s in ORDER if counts.get(s, 0) > 0]
+    return {
+        "total": sum(counts.values()),
+        "total_caught": counts.get("yes", 0),
+        "total_uncaught": counts.get("no", 0),
+        "detail": detail,
+    }
+
+
+def write_fixture(path, pokemons, dex_meta):
+    report = build_report(pokemons)
+    payload = {
+        "pokedex": {
+            "dex": dex_meta,
+            "pokemons": pokemons,
+            "report": report,
+            "filtered_report": report,
+        },
+        "filters": [],
+    }
+    with open(f"{REPO}/{path}", "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(path, "->", report)
+
+
+# homeshiny: 151 total, 1 yes, 150 uncaught (matches dex/trainer.json's existing homeshiny report)
+homeshiny_pk = take(151, 0)
+homeshiny_pk[0]["catch_state"] = CATCH_STATES["yes"]
+write_fixture(
+    "tests/resources/moco/Back/responses/album/default/homeshiny.json",
+    homeshiny_pk,
+    {
+        "slug": "homeshiny", "original_slug": "homeshiny", "name": "Home Shiny", "french_name": "Home Chromatique",
+        "flags": {"is_shiny": True, "is_private": False, "is_on_home": True, "is_display_form": True, "is_released": True, "is_premium": False, "is_custom": False},
+        "display_template": "box", "region": None,
+        "selection_rule": "p.isShiny",
+        "description": "Shiny variants of every Pokémon transferable to Pokémon Home.",
+        "french_description": "Variantes chromatiques de tous les Pokémon transférables sur Pokémon Home.",
+        "version": "20230421.090014",
+    },
+)
+
+# homepogo: 60 total, all caught (matches dex/trainer.json's existing homepogo report)
+homepogo_pk = take(60, 151)
+for p in homepogo_pk:
+    p["catch_state"] = CATCH_STATES["yes"]
+write_fixture(
+    "tests/resources/moco/Back/responses/album/default/homepogo.json",
+    homepogo_pk,
+    {
+        "slug": "homepogo", "original_slug": "homepogo", "name": "Home Pokemon Go", "french_name": "Home Pokemon Go",
+        "flags": {"is_shiny": False, "is_private": False, "is_on_home": True, "is_display_form": False, "is_released": True, "is_premium": False, "is_custom": True},
+        "display_template": "list-7", "region": None,
+        "selection_rule": "p.custom.homepogo",
+        "description": "Custom list of Pokémon transferred through Pokémon Go to Pokémon Home.",
+        "french_description": "Liste personnalisée des Pokémon transférés depuis Pokémon Go vers Pokémon Home.",
+        "version": "20230421.090014",
+    },
+)
+
+# alpha: 50 total, 25 yes, 15 toevolve, 10 uncaught (matches dex/trainer.json's existing alpha report)
+alpha_pk = take(50, 211)
+for i, p in enumerate(alpha_pk):
+    if i < 25:
+        p["catch_state"] = CATCH_STATES["yes"]
+    elif i < 40:
+        p["catch_state"] = CATCH_STATES["toevolve"]
+write_fixture(
+    "tests/resources/moco/Back/responses/album/default/alpha.json",
+    alpha_pk,
+    {
+        "slug": "alpha", "original_slug": "alpha", "name": "Alpha", "french_name": "Baron",
+        "flags": {"is_shiny": False, "is_private": False, "is_on_home": True, "is_display_form": True, "is_released": True, "is_premium": True, "is_custom": False},
+        "display_template": "list-3", "region": None,
+        "selection_rule": "p.isAlpha",
+        "description": "Alpha Pokémon forms.",
+        "french_description": "Formes Alpha des Pokémon.",
+        "version": "20230421.090014",
+    },
+)
+
+# home-shiny-custom (trainer "3"): 4 total, 1 yes, 3 uncaught (matches dex/77de68...json's existing report)
+custom_pk = take(4, 261)
+custom_pk[0]["catch_state"] = CATCH_STATES["yes"]
+write_fixture(
+    "tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json",
+    custom_pk,
+    {
+        "slug": "homeshiny", "original_slug": "homeshiny", "name": "Home Shiny Custom", "french_name": "Home Chromatique Perso",
+        "flags": {"is_shiny": True, "is_private": False, "is_on_home": True, "is_display_form": True, "is_released": True, "is_premium": False, "is_custom": True},
+        "display_template": "box", "region": None,
+        "selection_rule": "p.isShiny and p.custom.trainer3",
+        "description": "Trainer 3's custom shiny Home selection.",
+        "french_description": "Sélection chromatique personnalisée du dresseur 3 pour Home.",
+        "version": "20230421.090014",
+    },
+)
+```
+
+- [ ] **Step 2: Run the script**
+
+Run: `mkdir -p "/home/renaud/projects/pokenini-web/tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb" && python3 "/tmp/claude-1000/-home-renaud-projects-pokenini-web/14bf70fc-ff13-44a4-b590-09a064608f41/scratchpad/build_mock_fixtures.py"`
+
+Expected output (four lines, one per fixture):
+```
+tests/resources/moco/Back/responses/album/default/homeshiny.json -> {'total': 151, 'total_caught': 1, 'total_uncaught': 150, 'detail': [{'catch_state': {'name': 'Yes', 'french_name': 'Oui', 'slug': 'yes', 'color': '#66bb6a'}, 'count': 1}, {'catch_state': {'name': 'No', 'french_name': 'Non', 'slug': 'no', 'color': '#e57373'}, 'count': 150}]}
+tests/resources/moco/Back/responses/album/default/homepogo.json -> {'total': 60, 'total_caught': 60, 'total_uncaught': 0, 'detail': [{'catch_state': {'name': 'Yes', 'french_name': 'Oui', 'slug': 'yes', 'color': '#66bb6a'}, 'count': 60}]}
+tests/resources/moco/Back/responses/album/default/alpha.json -> {'total': 50, 'total_caught': 25, 'total_uncaught': 10, 'detail': [{'catch_state': {'name': 'Yes', 'french_name': 'Oui', 'slug': 'yes', 'color': '#66bb6a'}, 'count': 25}, {'catch_state': {'name': 'To evolve', 'french_name': 'af. évoluer', 'slug': 'toevolve', 'color': '#9575cd'}, 'count': 15}, {'catch_state': {'name': 'No', 'french_name': 'Non', 'slug': 'no', 'color': '#e57373'}, 'count': 10}]}
+tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json -> {'total': 4, 'total_caught': 1, 'total_uncaught': 3, 'detail': [{'catch_state': {'name': 'Yes', 'french_name': 'Oui', 'slug': 'yes', 'color': '#66bb6a'}, 'count': 1}, {'catch_state': {'name': 'No', 'french_name': 'Non', 'slug': 'no', 'color': '#e57373'}, 'count': 3}]}
+```
+
+Confirm each printed `report` matches the corresponding existing `dex/*.json` entry exactly (this is what guarantees no other test assertion needs to change).
+
+- [ ] **Step 3: Add the three catch-all moco routes**
+
+In `tests/resources/moco/Back/moco.json`, find this block (the `/album/mega` catch-all route):
+
+```json
+  {
+    "request": {
+      "uri": {
+        "match": "/album/mega"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/mega.json"
+    }
+  },
+```
+
+Replace it with the same block followed by three new ones:
+
+```json
+  {
+    "request": {
+      "uri": {
+        "match": "/album/mega"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/mega.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/homeshiny"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/homeshiny.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/homepogo"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/homepogo.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/alpha"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/alpha.json"
+    }
+  },
+```
+
+- [ ] **Step 4: Add the trainer-scoped moco route for home-shiny-custom**
+
+In the same file, find this block (trainer `"3"`'s `/album/dex` route):
+
+```json
+  {
+    "request": {
+      "uri": "/album/dex",
+      "headers": {
+        "accept": "application/json",
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer 77de68daecd823babbb58edb1c8e14d7106e83bb"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json"
+    }
+  },
+```
+
+Replace it with the same block followed by a new one:
+
+```json
+  {
+    "request": {
+      "uri": "/album/dex",
+      "headers": {
+        "accept": "application/json",
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer 77de68daecd823babbb58edb1c8e14d7106e83bb"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/home-shiny-custom"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer 77de68daecd823babbb58edb1c8e14d7106e83bb"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json"
+    }
+  },
+```
+
+- [ ] **Step 5: Fix the missing "no" bucket in trainer "3"'s existing report**
+
+In `tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json`, the `report.detail` array currently only has a `"yes"` entry even though `total_uncaught` is `3` — without a `"no"` bucket, the progress bar can't render that uncaught mass (see the Global Constraints note on `_progress_bar_macros.html.twig:11`). Replace:
+
+```json
+    "report": {
+      "total": 4,
+      "total_caught": 1,
+      "total_uncaught": 3,
+      "detail": [
+        {
+          "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" },
+          "count": 1
+        }
+      ]
+    }
+```
+
+with:
+
+```json
+    "report": {
+      "total": 4,
+      "total_caught": 1,
+      "total_uncaught": 3,
+      "detail": [
+        {
+          "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" },
+          "count": 1
+        },
+        {
+          "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" },
+          "count": 3
+        }
+      ]
+    }
+```
+
+- [ ] **Step 6: Validate moco wiring and restart mocks**
+
+Run: `tools/check-moco-refs/check_moco_refs.sh tests/resources/moco/Back/moco.json tests/resources/moco/Back`
+Expected: no errors (every route's `file` exists, no orphaned fixture files newly introduced).
+
+Run: `cd "/home/renaud/projects/pokenini-web" && docker compose restart moco.back`
+Expected: `moco.back` restarts successfully.
+
+- [ ] **Step 7: Rerun Task 1's tests and confirm they now pass**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter 'testAlbumDexListTilesAreAllClickable|testAlbumDexListCustomDexLinksToUniqueSettingsSlug' tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+Expected: PASS (2 tests, 0 failures).
+
+- [ ] **Step 8: Run the full AlbumDexListTest file to confirm no other assertion broke**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+Expected: PASS (all methods green — `testAlbumDexList`, `testAlbumDexListFrench`, `testAlbumDexListEnglish` and the others should be unaffected since the new fixtures were built to reproduce the exact `report` numbers those tests already assert).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/resources/moco/Back/moco.json \
+  tests/resources/moco/Back/responses/album/default/homeshiny.json \
+  tests/resources/moco/Back/responses/album/default/homepogo.json \
+  tests/resources/moco/Back/responses/album/default/alpha.json \
+  tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json \
+  tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json
+git commit -m "fix: add missing album fixtures/routes for homeshiny, homepogo, alpha, home-shiny-custom"
+```
+
+---
+
+### Task 3: Fix swordshield/home report numbers in dex/trainer.json (and the tests that hardcode them)
+
+**Files:**
+- Modify: `tests/resources/moco/Back/responses/dex/trainer.json`
+- Modify: `tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+**Interfaces:**
+- Consumes: real pokemon counts from `tests/resources/moco/Back/responses/album/default/swordshield.json` (935 entries, all `catch_state: null`) and `tests/resources/moco/Back/responses/album/default/home.json` (1477 entries, all `catch_state: null`) — already established as fact in the design doc's research.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Recompute the swordshield report block**
+
+In `tests/resources/moco/Back/responses/dex/trainer.json`, replace:
+
+```json
+    "report": {
+      "total": 400,
+      "total_caught": 50,
+      "total_uncaught": 140,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 50 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 30 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 50 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 60 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 70 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 140 }
+      ]
+    }
+```
+
+with:
+
+```json
+    "report": {
+      "total": 935,
+      "total_caught": 0,
+      "total_uncaught": 935,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 935 }
+      ]
+    }
+```
+
+- [ ] **Step 2: Recompute the home report block and fix its non-canonical catch-state labels**
+
+In the same file, replace:
+
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 88,
+      "total_uncaught": 63,
+      "detail": [
+        { "catch_state": { "name": "Caught", "french_name": "Attrapé", "slug": "yes", "color": "#198754" }, "count": 88 },
+        { "catch_state": { "name": "Not caught", "french_name": "Pas attrapé", "slug": "no", "color": "#dc3545" }, "count": 63 }
+      ]
+    }
+```
+
+with:
+
+```json
+    "report": {
+      "total": 1477,
+      "total_caught": 0,
+      "total_uncaught": 1477,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 1477 }
+      ]
+    }
+```
+
+- [ ] **Step 3: Update the dependent test assertions in AlbumDexListTest.php**
+
+In `testAlbumDexList()`:
+
+Replace:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Épée, Bouclier 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+        $this->assertEquals('https://icon.pokenini.fr/banner/swordshield.png', $firstAlbum->filter('img')->attr('src'));
+
+        $secondAlbum = $crawler->filter('.dex-item')->eq(2);
+        $this->assertEquals('Home Chromatique 0.66% 99.34%', $secondAlbum->text());
+        $this->assertEquals('/fr/album/homeshiny', $secondAlbum->filter('a')->attr('href'));
+        $this->assertEquals('https://icon.pokenini.fr/banner/homeshiny.png', $secondAlbum->filter('img')->attr('src'));
+
+        $this->assertCountFilter($crawler, 5, '.dex-item .progress');
+        $this->assertCountFilter($crawler, 14, '.dex-item .progress-bar');
+
+        $homeAlbum = $crawler->filter('.dex-item')->eq(1);
+        $this->assertEquals('41.72%', $homeAlbum->filter('.progress-bar.catch-state-no')->text());
+        $this->assertEquals('58.28%', $homeAlbum->filter('.progress-bar.catch-state-yes')->text());
+```
+
+with:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Épée, Bouclier 100%', $firstAlbum->text());
+        $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+        $this->assertEquals('https://icon.pokenini.fr/banner/swordshield.png', $firstAlbum->filter('img')->attr('src'));
+
+        $secondAlbum = $crawler->filter('.dex-item')->eq(2);
+        $this->assertEquals('Home Chromatique 0.66% 99.34%', $secondAlbum->text());
+        $this->assertEquals('/fr/album/homeshiny', $secondAlbum->filter('a')->attr('href'));
+        $this->assertEquals('https://icon.pokenini.fr/banner/homeshiny.png', $secondAlbum->filter('img')->attr('src'));
+
+        $this->assertCountFilter($crawler, 5, '.dex-item .progress');
+        $this->assertCountFilter($crawler, 8, '.dex-item .progress-bar');
+
+        $homeAlbum = $crawler->filter('.dex-item')->eq(1);
+        $this->assertEquals('100%', $homeAlbum->filter('.progress-bar.catch-state-no')->text());
+```
+
+In `testAlbumDexListFrench()`, replace:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Épée, Bouclier 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+```
+with:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Épée, Bouclier 100%', $firstAlbum->text());
+        $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+```
+
+In `testAlbumDexListEnglish()`, replace:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Sword, Shield 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('/en/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+```
+with:
+```php
+        $firstAlbum = $crawler->filter('.dex-item')->first();
+        $this->assertEquals('Sword, Shield 100%', $firstAlbum->text());
+        $this->assertEquals('/en/album/swordshield', $firstAlbum->filter('a')->attr('href'));
+```
+
+- [ ] **Step 4: Run the full test file**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php`
+
+Expected: PASS (all methods green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/resources/moco/Back/responses/dex/trainer.json \
+  tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
+git commit -m "fix: sync swordshield/home report numbers with their real album fixtures"
+```
+
+---
+
+### Task 4: Fix admin.json's report numbers to match the same shared album fixtures
+
+**Files:**
+- Modify: `tests/resources/moco/Back/responses/dex/admin.json`
+
+**Interfaces:**
+- Consumes: real pokemon counts from `album/default/redgreenblueyellow.json` (151, all null), `album/default/goldsilvercrystal.json` (278, all null), `album/default/home.json` (1477, all null), `album/default/mega.json` (50, all null), and the two new fixtures from Task 2 (`homeshiny.json` → 151/1/150, `alpha.json` → 50/25/15/10).
+- Produces: nothing consumed by later tasks. No existing test asserts admin.json's report numbers (verified: no integration or browser test references the `admin` fake-auth identity together with `.dex-item`/`.progress-bar` selectors), so this task carries no risk of breaking existing assertions.
+
+`admin.json` shares the exact same catch-all `/album/{slug}` moco routes as `trainer.json` for `redgreenblueyellow`, `goldsilvercrystal`, `home`, `homeshiny`, `alpha`, and `mega` — so whatever `report` numbers it shows on its home tiles for those slugs must match the one real album fixture behind that slug, otherwise clicking through for the admin trainer will show different data than the tile promised (the exact bug class this whole plan exists to fix).
+
+- [ ] **Step 1: Fix redgreenblueyellow (real total 151, all uncaught)**
+
+Replace:
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 90,
+      "total_uncaught": 20,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 90 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 8 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 8 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 10 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 15 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 20 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 0,
+      "total_uncaught": 151,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 151 }
+      ]
+    }
+```
+
+- [ ] **Step 2: Fix goldsilvercrystal (real total 278, all uncaught)**
+
+Replace:
+```json
+    "report": {
+      "total": 251,
+      "total_caught": 140,
+      "total_uncaught": 40,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 140 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 11 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 15 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 20 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 25 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 40 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 278,
+      "total_caught": 0,
+      "total_uncaught": 278,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 278 }
+      ]
+    }
+```
+
+- [ ] **Step 3: Fix home (real total 1477, all uncaught — same shared fixture as trainer.json's home)**
+
+Replace:
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 68,
+      "total_uncaught": 30,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 68 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 8 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 10 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 15 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 20 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 30 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 1477,
+      "total_caught": 0,
+      "total_uncaught": 1477,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 1477 }
+      ]
+    }
+```
+
+- [ ] **Step 4: Fix homeshiny (must match the new shared fixture from Task 2: 151/1/150)**
+
+Replace:
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 0,
+      "total_uncaught": 140,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 0 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 1 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 2 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 3 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 5 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 140 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 151,
+      "total_caught": 1,
+      "total_uncaught": 150,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 1 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 150 }
+      ]
+    }
+```
+
+- [ ] **Step 5: Fix alpha (must match the new shared fixture from Task 2: 50/25/15/10)**
+
+Replace:
+```json
+    "report": {
+      "total": 50,
+      "total_caught": 15,
+      "total_uncaught": 10,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 15 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 5 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 5 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 7 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 8 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 10 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 50,
+      "total_caught": 25,
+      "total_uncaught": 10,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 25 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 15 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 10 }
+      ]
+    }
+```
+
+- [ ] **Step 6: Fix mega (real total 50, all uncaught)**
+
+Replace:
+```json
+    "report": {
+      "total": 46,
+      "total_caught": 21,
+      "total_uncaught": 5,
+      "detail": [
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 21 },
+        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 5 },
+        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 5 },
+        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 5 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 5 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 5 }
+      ]
+    }
+```
+with:
+```json
+    "report": {
+      "total": 50,
+      "total_caught": 0,
+      "total_uncaught": 50,
+      "detail": [
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 50 }
+      ]
+    }
+```
+
+- [ ] **Step 7: Validate JSON and moco wiring**
+
+Run: `python3 -c "import json; json.load(open('tests/resources/moco/Back/responses/dex/admin.json'))" && echo OK`
+Expected: `OK` (confirms the file is still valid JSON after six manual edits).
+
+Run: `tools/check-moco-refs/check_moco_refs.sh tests/resources/moco/Back/moco.json tests/resources/moco/Back`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/resources/moco/Back/responses/dex/admin.json
+git commit -m "fix: sync admin.json report numbers with the shared album fixtures"
+```
+
+---
+
+### Task 5: Full verification pass
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the full Album controller test suite**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/`
+
+Expected: PASS, 0 failures, 0 errors.
+
+- [ ] **Step 2: Run jsonlint and the moco-refs check across the whole fixture tree**
+
+Run: `docker compose exec php php tools/jsonlint/vendor/bin/jsonlint tests/resources/moco/Back/moco.json tests/resources/moco/Back/responses/dex/trainer.json tests/resources/moco/Back/responses/dex/admin.json tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json tests/resources/moco/Back/responses/album/default/homeshiny.json tests/resources/moco/Back/responses/album/default/homepogo.json tests/resources/moco/Back/responses/album/default/alpha.json tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json`
+
+Expected: no syntax errors reported for any file.
+
+Run: `tools/check-moco-refs/check_moco_refs.sh tests/resources/moco/Back/moco.json tests/resources/moco/Back`
+
+Expected: no errors.
+
+- [ ] **Step 3: Run the full integration suite to catch any unrelated fixture consumer**
+
+Run: `docker compose exec php php vendor/bin/phpunit --group api-mocked-testing`
+
+Expected: PASS. If anything outside `Album/` fails, it means another test reads one of the six edited `dex/*.json`/`admin.json` entries or the `trainer.json` swordshield/home blocks in a way not yet accounted for — investigate before considering the plan done.
+
+- [ ] **Step 4: Manual sanity check in the browser (optional but recommended)**
+
+Run: `make start` (if not already running), then visit `http://localhost/fr/connect/f/c?t=admin` followed by `http://localhost/fr/album/dex` — confirm all six admin home tiles are clickable and none 404. Repeat for the default dev session (`http://localhost/fr/album/dex` without the fake-auth redirect, or via `?t=` override) to see the `homeshiny`/`homepogo`/`alpha` tiles working.

--- a/docs/superpowers/specs/2026-07-12-composer-updates-automation-design.md
+++ b/docs/superpowers/specs/2026-07-12-composer-updates-automation-design.md
@@ -32,22 +32,22 @@ New workflow file: `.github/workflows/composer_updates.yml`
 Single job `composer-updates` on `ubuntu-latest`.
 
 1. **Checkout** — plain `actions/checkout@v6` with the default `GITHUB_TOKEN` (no PAT).
-   Kept off this step so the PAT isn't exposed as a persisted git credential during the
-   8 `composer update` steps, each of which executes third-party package/plugin code.
+    Kept off this step so the PAT isn't exposed as a persisted git credential during the
+    8 `composer update` steps, each of which executes third-party package/plugin code.
 2. **PHP setup** — reuse `./.github/actions/local-php`. No Docker compose stack.
 3. **Composer updates** — one step per directory, same order as the `updates` Makefile
-   target, each `composer update --bump-after-update --with-all-dependencies
-   --optimize-autoloader`:
-   - main app (`--working-dir=./`)
-   - `tools/deptrac`, `tools/infection`, `tools/jsonlint`, `tools/php-cs-fixer`,
-     `tools/phpmd`, `tools/phpstan`, `tools/psalm`
+    target, each `composer update --bump-after-update --with-all-dependencies
+    --optimize-autoloader`:
+    - main app (`--working-dir=./`)
+    - `tools/deptrac`, `tools/infection`, `tools/jsonlint`, `tools/php-cs-fixer`,
+      `tools/phpmd`, `tools/phpstan`, `tools/psalm`
 4. **Open/update PR** — `peter-evans/create-pull-request@v7`:
-   - `token: ${{ secrets.PAT_TOKEN }}` (only step that needs it — authenticates the
-     push/PR, which is what makes the PR trigger the downstream `pull_request`-gated
-     workflows)
-   - `branch: chore/composer-updates`, `delete-branch: true`
-   - `commit-message` / `title`: `Composers updates`
-   - `labels: dependencies` (confirmed this label exists in `pokenini-web`)
+    - `token: ${{ secrets.PAT_TOKEN }}` (only step that needs it — authenticates the
+      push/PR, which is what makes the PR trigger the downstream `pull_request`-gated
+      workflows)
+    - `branch: chore/composer-updates`, `delete-branch: true`
+    - `commit-message` / `title`: `Composers updates`
+    - `labels: dependencies` (confirmed this label exists in `pokenini-web`)
 
 **Hardening:** top-level `permissions: contents: read` and a `concurrency` group
 (`composer-updates`, `cancel-in-progress: true`).

--- a/docs/superpowers/specs/2026-07-13-mock-coherence-design.md
+++ b/docs/superpowers/specs/2026-07-13-mock-coherence-design.md
@@ -1,0 +1,114 @@
+# Mock data coherence (home ↔ pokedex)
+
+## Problem
+
+The Moco fixtures under `tests/resources/moco/Back/responses/` model the flow from
+the home dex list (`GET /album/dex`, rendered as clickable tiles filtered on
+`flags.is_on_home`) to the individual pokedex page (`GET /album/{dexSlug}`). Two
+kinds of drift have accumulated between these fixtures, since they were authored
+by hand and independently over time:
+
+1. **Dead links**: a dex tile is flagged `is_on_home: true` in a `dex/*.json`
+    fixture, but no moco route (and no `album/**/*.json` fixture) exists for the
+    slug it links to. Clicking the tile 404s.
+2. **Numeric drift**: where a route *does* exist, the home tile's `report`
+    (caught/uncaught counts) is hand-typed independently from the album
+    fixture's real `pokemons[]` list, so the two pages show different numbers
+    for what's supposed to be the same trainer+dex progress.
+
+## Principle
+
+The album fixture's real `pokemons[]` list becomes the single source of truth.
+Each home-tile row's `report` block is *derived* from it, not hand-authored
+separately. This is enforced mechanically by a one-off script rather than by
+hand, because two of the album fixtures (`swordshield.json`, `home.json`) have
+935 and 1477 rows respectively — hand-computing sums at that scale is
+error-prone and won't scale to future fixture changes.
+
+### Report formula
+
+Reverse-engineered from the one fixture that was already internally
+consistent (`trainer.json`'s `swordshield` entry, whose `detail[]` buckets
+summed exactly to `total`). Given a pokedex's `pokemons[]` list and the six
+catch states from `labels.json` (`yes`, `totrade`, `totransfer`, `tobreed`,
+`toevolve`, `no`):
+
+- `total_caught` = count of entries where `catch_state.slug == "yes"`
+- `total_uncaught` = count of entries where `catch_state` is `null` or
+  `catch_state.slug == "no"`
+- `detail[]` = one entry per catch state label, with the count of pokemons
+  carrying that exact `catch_state.slug` (entries with `catch_state: null`
+  are not counted in any specific `detail[]` bucket, only in
+  `total_uncaught`)
+- `total` = `total_caught` + `total_uncaught` + sum of the four intermediate
+  bucket counts (`totrade` + `totransfer` + `tobreed` + `toevolve`)
+
+Rows where `report` is currently `null` (e.g. `da4b9237…json`'s
+`homepokemongo` row) stay `null` — the home template already treats a null
+report as "no progress bar shown", which is a valid, self-consistent state,
+not a bug.
+
+## Fixes
+
+### 1. Missing routes / fixtures (four broken links)
+
+| Slug | Referenced by (dex/*.json) | Fix |
+|---|---|---|
+| `homeshiny` | `trainer.json`, `admin.json`, `159bb9b6…json` | New `album/default/homeshiny.json`, catch-all `Bearer .*` moco route (same pattern as `mega.json`). Flags: `is_shiny: true`. |
+| `alpha` | `trainer.json`, `admin.json`, `159bb9b6…json` | New `album/default/alpha.json`, catch-all route. Flags: `is_premium: true`. |
+| `homepogo` | `trainer.json` | New `album/default/homepogo.json`, catch-all route. Flags: `is_custom: true`. Kept distinct from the existing `homepokemongo` dex per explicit decision — this is a different, custom dex. |
+| `home-shiny-custom` | `dex/77de68…json` (trainer `"3"`) | New trainer-scoped moco route (`Bearer 77de68daecd823babbb58edb1c8e14d7106e83bb`) + `album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json`. This is the slug the existing `AlbumDexListTest::testAlbumDexListCustomDexLinksToUniqueSettingsSlug` already asserts is linked to, but the test never follows the link. |
+
+Each new album fixture is cloned from the shape of an existing small fixture
+(`album/default/mega.json`, 50 rows) as a starting template, then trimmed/
+adjusted (dex slug, name, flags, a handful of representative Pokémon) rather
+than authored from scratch. All Pokémon entries start with `catch_state:
+null` (matches the current state of `swordshield.json`/`home.json` — no
+fixture currently has catch-state variety; that's Phase 2 scope).
+
+### 2. Report resync (numeric drift)
+
+For every row with `is_on_home: true` and a non-null `report` across
+`dex/trainer.json`, `dex/admin.json`, `dex/159bb9b6…json`, and
+`dex/77de68…json`, recompute `report` from the real pokemon count of the
+album fixture it links to, using the formula above. This replaces the
+existing hand-typed numbers (e.g. `swordshield` moves from the fictional
+`400/50/140` to the real `935/0/935`).
+
+Newly added fixtures (`homeshiny`, `alpha`, `homepogo`, `home-shiny-custom`)
+get their home-tile `report` computed the same way, from the moment they're
+created.
+
+### Out of scope for this pass
+
+- **`flags` mismatches** between a dex-list row (`dex/*.json`) and the album
+  fixture's own `pokedex.dex.flags` (e.g. `mega.json` has `is_on_home: false`
+  internally, contradicting the dex-list row). These aren't rendered
+  anywhere the user compares against the home tile, so fixing them is
+  cosmetic, not a coherence bug the user experiences.
+- **Phase 2 — diversity**: giving each trainer profile (admin, collector, the
+  numbered `"0"`–`"3"` trainers, etc.) a distinct, meaningful catch-state
+  distribution (early game / near-complete / shiny-focused / etc.) instead of
+  the current "everything is `null`" state. This is explicitly deferred to a
+  follow-up spec once coherence lands, per user instruction ("cohérence
+  d'abord, puis diversité").
+
+## Implementation approach
+
+A one-off Python script, kept in the session scratchpad only (not committed
+to the repo), reads each affected `dex/*.json` and its linked
+`album/**/*.json` fixture, and rewrites the `report` block in place using the
+formula above. New fixture files and new `moco.json` routes are added by
+hand (structural JSON, not mechanically derivable). The script is then
+re-run as a final consistency pass over the touched files.
+
+## Verification
+
+1. Run the integration tests that already cover these fixtures inside the
+    container: `AlbumDexListTest`, and the `Album/Display` test suite
+    (`docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/`).
+2. A small consistency check (can reuse the same script in a "check" mode, or
+    a short ad hoc script) confirming, for every `dex/*.json` file: every row
+    with `is_on_home: true` resolves to an actual moco route, and every row
+    with a non-null `report` has `report.total` equal to the pokemon count of
+    the album fixture it links to.

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -760,6 +760,24 @@
   },
   {
     "request": {
+      "uri": {
+        "match": "/album/home-shiny-custom"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer 77de68daecd823babbb58edb1c8e14d7106e83bb"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json"
+    }
+  },
+  {
+    "request": {
       "uri": "/album/dex",
       "headers": {
         "accept": "application/json",
@@ -1368,6 +1386,60 @@
     },
     "response": {
       "file": "/var/moco/responses/album/default/mega.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/homeshiny"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/homeshiny.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/homepogo"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/homepogo.json"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/alpha"
+      },
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "file": "/var/moco/responses/album/default/alpha.json"
     }
   },
   {

--- a/tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json
+++ b/tests/resources/moco/Back/responses/album/77de68daecd823babbb58edb1c8e14d7106e83bb/home-shiny-custom.json
@@ -1,0 +1,760 @@
+{
+  "pokedex": {
+    "dex": {
+      "slug": "homeshiny",
+      "original_slug": "homeshiny",
+      "name": "Home Shiny Custom",
+      "french_name": "Home Chromatique Perso",
+      "flags": {
+        "is_shiny": true,
+        "is_private": false,
+        "is_on_home": true,
+        "is_display_form": true,
+        "is_released": true,
+        "is_premium": false,
+        "is_custom": true
+      },
+      "display_template": "box",
+      "region": null,
+      "selection_rule": "p.isShiny and p.custom.trainer3",
+      "description": "Trainer 3's custom shiny Home selection.",
+      "french_description": "Sélection chromatique personnalisée du dresseur 3 pour Home.",
+      "version": "20230421.090014"
+    },
+    "pokemons": [
+      {
+        "pokemon": {
+          "slug": "sudowoodo-f",
+          "labels": {
+            "name": "Sudowoodo ♀",
+            "french_name": "Simularbre ♀",
+            "simplified_name": "Sudowoodo",
+            "simplified_french_name": "Simularbre",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 185,
+          "regional_dex_number": null,
+          "icon": "sudowoodo-f",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "sudowoodo"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0185-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "politoed",
+          "labels": {
+            "name": "Politoed ♂️",
+            "french_name": "Tarpaud ♂️",
+            "simplified_name": "Politoed",
+            "simplified_french_name": "Tarpaud",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 186,
+          "regional_dex_number": null,
+          "icon": "politoed",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "poliwag"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0186-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "politoed-f",
+          "labels": {
+            "name": "Politoed ♀",
+            "french_name": "Tarpaud ♀",
+            "simplified_name": "Politoed",
+            "simplified_french_name": "Tarpaud",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 186,
+          "regional_dex_number": null,
+          "icon": "politoed-f",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "poliwag"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0186-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hoppip",
+          "labels": {
+            "name": "Hoppip",
+            "french_name": "Granivol",
+            "simplified_name": "Hoppip",
+            "simplified_french_name": "Granivol",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 187,
+          "regional_dex_number": null,
+          "icon": "hoppip",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "hoppip"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0187-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      }
+    ],
+    "report": {
+      "total": 4,
+      "total_caught": 1,
+      "total_uncaught": 3,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 1
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 3
+        }
+      ]
+    },
+    "filtered_report": {
+      "total": 4,
+      "total_caught": 1,
+      "total_uncaught": 3,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 1
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 3
+        }
+      ]
+    }
+  },
+  "filters": []
+}

--- a/tests/resources/moco/Back/responses/album/default/alpha.json
+++ b/tests/resources/moco/Back/responses/album/default/alpha.json
@@ -1,0 +1,8808 @@
+{
+  "pokedex": {
+    "dex": {
+      "slug": "alpha",
+      "original_slug": "alpha",
+      "name": "Alpha",
+      "french_name": "Baron",
+      "flags": {
+        "is_shiny": false,
+        "is_private": false,
+        "is_on_home": true,
+        "is_display_form": true,
+        "is_released": true,
+        "is_premium": true,
+        "is_custom": false
+      },
+      "display_template": "list-3",
+      "region": null,
+      "selection_rule": "p.isAlpha",
+      "description": "Alpha Pokémon forms.",
+      "french_description": "Formes Alpha des Pokémon.",
+      "version": "20230421.090014"
+    },
+    "pokemons": [
+      {
+        "pokemon": {
+          "slug": "articuno",
+          "labels": {
+            "name": "Articuno",
+            "french_name": "Artikodin",
+            "simplified_name": "Articuno",
+            "simplified_french_name": "Artikodin",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 144,
+          "regional_dex_number": null,
+          "icon": "articuno",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "articuno"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0144-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "articuno-galar",
+          "labels": {
+            "name": "Articuno-Galar",
+            "french_name": "Artikodin de Galar",
+            "simplified_name": "Articuno",
+            "simplified_french_name": "Artikodin",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 144,
+          "regional_dex_number": null,
+          "icon": "articuno-galar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "articuno"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0144-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "zapdos",
+          "labels": {
+            "name": "Zapdos",
+            "french_name": "Électhor",
+            "simplified_name": "Zapdos",
+            "simplified_french_name": "Électhor",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 145,
+          "regional_dex_number": null,
+          "icon": "zapdos",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "zapdos"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0145-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "zapdos-galar",
+          "labels": {
+            "name": "Zapdos-Galar",
+            "french_name": "Électhor de Galar",
+            "simplified_name": "Zapdos",
+            "simplified_french_name": "Électhor",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 145,
+          "regional_dex_number": null,
+          "icon": "zapdos-galar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "zapdos"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0145-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "moltres",
+          "labels": {
+            "name": "Moltres",
+            "french_name": "Sulfura",
+            "simplified_name": "Moltres",
+            "simplified_french_name": "Sulfura",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 146,
+          "regional_dex_number": null,
+          "icon": "moltres",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "moltres"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0146-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "moltres-galar",
+          "labels": {
+            "name": "Moltres-Galar",
+            "french_name": "Sulfura de Galar",
+            "simplified_name": "Moltres",
+            "simplified_french_name": "Sulfura",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 146,
+          "regional_dex_number": null,
+          "icon": "moltres-galar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "moltres"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0146-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dratini",
+          "labels": {
+            "name": "Dratini",
+            "french_name": "Minidraco",
+            "simplified_name": "Dratini",
+            "simplified_french_name": "Minidraco",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 147,
+          "regional_dex_number": null,
+          "icon": "dratini",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "dratini"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0147-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dragon",
+            "name": "Dragon",
+            "french_name": "Dragon",
+            "color": "#0a6dc8"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dragonair",
+          "labels": {
+            "name": "Dragonair",
+            "french_name": "Draco",
+            "simplified_name": "Dragonair",
+            "simplified_french_name": "Draco",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 148,
+          "regional_dex_number": null,
+          "icon": "dragonair",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "dratini"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0148-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dragon",
+            "name": "Dragon",
+            "french_name": "Dragon",
+            "color": "#0a6dc8"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dragonite",
+          "labels": {
+            "name": "Dragonite",
+            "french_name": "Dracolosse",
+            "simplified_name": "Dragonite",
+            "simplified_french_name": "Dracolosse",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 149,
+          "regional_dex_number": null,
+          "icon": "dragonite",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "dratini"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0149-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dragon",
+            "name": "Dragon",
+            "french_name": "Dragon",
+            "color": "#0a6dc8"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mewtwo",
+          "labels": {
+            "name": "Mewtwo",
+            "french_name": "Mewtwo",
+            "simplified_name": "Mewtwo",
+            "simplified_french_name": "Mewtwo",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 150,
+          "regional_dex_number": null,
+          "icon": "mewtwo",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "mewtwo"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0150-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "legendary",
+            "name": "Legendary",
+            "french_name": "Légendaire"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mew",
+          "labels": {
+            "name": "Mew",
+            "french_name": "Mew",
+            "simplified_name": "Mew",
+            "simplified_french_name": "Mew",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 151,
+          "regional_dex_number": null,
+          "icon": "mew",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "mew"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0151-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "mythical",
+            "name": "Mythical",
+            "french_name": "Fabuleux"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "chikorita",
+          "labels": {
+            "name": "Chikorita",
+            "french_name": "Germignon",
+            "simplified_name": "Chikorita",
+            "simplified_french_name": "Germignon",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 152,
+          "regional_dex_number": null,
+          "icon": "chikorita",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "chikorita"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0152-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "bayleef",
+          "labels": {
+            "name": "Bayleef",
+            "french_name": "Macronium",
+            "simplified_name": "Bayleef",
+            "simplified_french_name": "Macronium",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 153,
+          "regional_dex_number": null,
+          "icon": "bayleef",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "chikorita"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0153-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meganium",
+          "labels": {
+            "name": "Meganium ♂️",
+            "french_name": "Méganium ♂️",
+            "simplified_name": "Meganium",
+            "simplified_french_name": "Méganium",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 154,
+          "regional_dex_number": null,
+          "icon": "meganium",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "chikorita"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0154-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meganium-f",
+          "labels": {
+            "name": "Meganium ♀",
+            "french_name": "Méganium ♀",
+            "simplified_name": "Meganium",
+            "simplified_french_name": "Méganium",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 154,
+          "regional_dex_number": null,
+          "icon": "meganium-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "chikorita"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0154-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "cyndaquil",
+          "labels": {
+            "name": "Cyndaquil",
+            "french_name": "Héricendre",
+            "simplified_name": "Cyndaquil",
+            "simplified_french_name": "Héricendre",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 155,
+          "regional_dex_number": null,
+          "icon": "cyndaquil",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "cyndaquil"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0155-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "quilava",
+          "labels": {
+            "name": "Quilava",
+            "french_name": "Feurisson",
+            "simplified_name": "Quilava",
+            "simplified_french_name": "Feurisson",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 156,
+          "regional_dex_number": null,
+          "icon": "quilava",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "cyndaquil"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0156-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "typhlosion",
+          "labels": {
+            "name": "Typhlosion",
+            "french_name": "Typhlosion",
+            "simplified_name": "Typhlosion",
+            "simplified_french_name": "Typhlosion",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 157,
+          "regional_dex_number": null,
+          "icon": "typhlosion",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "cyndaquil"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0157-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "typhlosion-hisui",
+          "labels": {
+            "name": "Typhlosion-Hisui",
+            "french_name": "Typhlosion de Hisui",
+            "simplified_name": "Typhlosion",
+            "simplified_french_name": "Typhlosion",
+            "forms_label": "Hisuian",
+            "forms_french_label": "de Hisui"
+          },
+          "national_dex_number": 157,
+          "regional_dex_number": null,
+          "icon": "typhlosion-hisui",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "cyndaquil"
+          },
+          "original_game_bundle": {
+            "slug": "pokemonlegendsarceus"
+          },
+          "order_number": "9999-0157-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "hisuian",
+            "name": "Hisuian",
+            "french_name": "de Hisui"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "totodile",
+          "labels": {
+            "name": "Totodile",
+            "french_name": "Kaiminus",
+            "simplified_name": "Totodile",
+            "simplified_french_name": "Kaiminus",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 158,
+          "regional_dex_number": null,
+          "icon": "totodile",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "totodile"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0158-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "croconaw",
+          "labels": {
+            "name": "Croconaw",
+            "french_name": "Crocrodil",
+            "simplified_name": "Croconaw",
+            "simplified_french_name": "Crocrodil",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 159,
+          "regional_dex_number": null,
+          "icon": "croconaw",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "totodile"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0159-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "feraligatr",
+          "labels": {
+            "name": "Feraligatr",
+            "french_name": "Aligatueur",
+            "simplified_name": "Feraligatr",
+            "simplified_french_name": "Aligatueur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 160,
+          "regional_dex_number": null,
+          "icon": "feraligatr",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "totodile"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0160-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sentret",
+          "labels": {
+            "name": "Sentret",
+            "french_name": "Fouinette",
+            "simplified_name": "Sentret",
+            "simplified_french_name": "Fouinette",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 161,
+          "regional_dex_number": null,
+          "icon": "sentret",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "sentret"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0161-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "furret",
+          "labels": {
+            "name": "Furret",
+            "french_name": "Fouinar",
+            "simplified_name": "Furret",
+            "simplified_french_name": "Fouinar",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 162,
+          "regional_dex_number": null,
+          "icon": "furret",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "sentret"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0162-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hoothoot",
+          "labels": {
+            "name": "Hoothoot",
+            "french_name": "Hoothoot",
+            "simplified_name": "Hoothoot",
+            "simplified_french_name": "Hoothoot",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 163,
+          "regional_dex_number": null,
+          "icon": "hoothoot",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "hoothoot"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0163-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "noctowl",
+          "labels": {
+            "name": "Noctowl",
+            "french_name": "Noarfang",
+            "simplified_name": "Noctowl",
+            "simplified_french_name": "Noarfang",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 164,
+          "regional_dex_number": null,
+          "icon": "noctowl",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "hoothoot"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0164-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ledyba",
+          "labels": {
+            "name": "Ledyba ♂️",
+            "french_name": "Coxy ♂️",
+            "simplified_name": "Ledyba",
+            "simplified_french_name": "Coxy",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 165,
+          "regional_dex_number": null,
+          "icon": "ledyba",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "ledyba"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0165-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ledyba-f",
+          "labels": {
+            "name": "Ledyba ♀",
+            "french_name": "Coxy ♀",
+            "simplified_name": "Ledyba",
+            "simplified_french_name": "Coxy",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 165,
+          "regional_dex_number": null,
+          "icon": "ledyba-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "ledyba"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0165-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ledian",
+          "labels": {
+            "name": "Ledian ♂️",
+            "french_name": "Coxyclaque ♂️",
+            "simplified_name": "Ledian",
+            "simplified_french_name": "Coxyclaque",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 166,
+          "regional_dex_number": null,
+          "icon": "ledian",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "ledyba"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0166-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ledian-f",
+          "labels": {
+            "name": "Ledian ♀",
+            "french_name": "Coxyclaque ♀",
+            "simplified_name": "Ledian",
+            "simplified_french_name": "Coxyclaque",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 166,
+          "regional_dex_number": null,
+          "icon": "ledian-f",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "ledyba"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0166-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "spinarak",
+          "labels": {
+            "name": "Spinarak",
+            "french_name": "Mimigal",
+            "simplified_name": "Spinarak",
+            "simplified_french_name": "Mimigal",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 167,
+          "regional_dex_number": null,
+          "icon": "spinarak",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "spinarak"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0167-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ariados",
+          "labels": {
+            "name": "Ariados",
+            "french_name": "Migalos",
+            "simplified_name": "Ariados",
+            "simplified_french_name": "Migalos",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 168,
+          "regional_dex_number": null,
+          "icon": "ariados",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "spinarak"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0168-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "crobat",
+          "labels": {
+            "name": "Crobat",
+            "french_name": "Nostenfer",
+            "simplified_name": "Crobat",
+            "simplified_french_name": "Nostenfer",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 169,
+          "regional_dex_number": null,
+          "icon": "crobat",
+          "family_order": 8,
+          "family_lead": {
+            "slug": "zubat"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0169-008",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "chinchou",
+          "labels": {
+            "name": "Chinchou",
+            "french_name": "Loupio",
+            "simplified_name": "Chinchou",
+            "simplified_french_name": "Loupio",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 170,
+          "regional_dex_number": null,
+          "icon": "chinchou",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "chinchou"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0170-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "lanturn",
+          "labels": {
+            "name": "Lanturn",
+            "french_name": "Lanturn",
+            "simplified_name": "Lanturn",
+            "simplified_french_name": "Lanturn",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 171,
+          "regional_dex_number": null,
+          "icon": "lanturn",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "chinchou"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0171-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pichu",
+          "labels": {
+            "name": "Pichu",
+            "french_name": "Pichu",
+            "simplified_name": "Pichu",
+            "simplified_french_name": "Pichu",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 172,
+          "regional_dex_number": null,
+          "icon": "pichu",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0172-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": {
+            "slug": "baby",
+            "name": "Baby",
+            "french_name": "Bébé"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "cleffa",
+          "labels": {
+            "name": "Cleffa",
+            "french_name": "Mélo",
+            "simplified_name": "Cleffa",
+            "simplified_french_name": "Mélo",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 173,
+          "regional_dex_number": null,
+          "icon": "cleffa",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "clefairy"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0173-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": {
+            "slug": "baby",
+            "name": "Baby",
+            "french_name": "Bébé"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "igglybuff",
+          "labels": {
+            "name": "Igglybuff",
+            "french_name": "Toudoudou",
+            "simplified_name": "Igglybuff",
+            "simplified_french_name": "Toudoudou",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 174,
+          "regional_dex_number": null,
+          "icon": "igglybuff",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "jigglypuff"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0174-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": {
+            "slug": "baby",
+            "name": "Baby",
+            "french_name": "Bébé"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "togepi",
+          "labels": {
+            "name": "Togepi",
+            "french_name": "Togepi",
+            "simplified_name": "Togepi",
+            "simplified_french_name": "Togepi",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 175,
+          "regional_dex_number": null,
+          "icon": "togepi",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "togepi"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0175-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": {
+            "slug": "baby",
+            "name": "Baby",
+            "french_name": "Bébé"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "togetic",
+          "labels": {
+            "name": "Togetic",
+            "french_name": "Togetic",
+            "simplified_name": "Togetic",
+            "simplified_french_name": "Togetic",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 176,
+          "regional_dex_number": null,
+          "icon": "togetic",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "togepi"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0176-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "To evolve",
+          "french_name": "af. évoluer",
+          "slug": "toevolve",
+          "color": "#9575cd"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "natu",
+          "labels": {
+            "name": "Natu",
+            "french_name": "Natu",
+            "simplified_name": "Natu",
+            "simplified_french_name": "Natu",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 177,
+          "regional_dex_number": null,
+          "icon": "natu",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "natu"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0177-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "xatu",
+          "labels": {
+            "name": "Xatu ♂️",
+            "french_name": "Xatu ♂️",
+            "simplified_name": "Xatu",
+            "simplified_french_name": "Xatu",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 178,
+          "regional_dex_number": null,
+          "icon": "xatu",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "natu"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0178-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "xatu-f",
+          "labels": {
+            "name": "Xatu ♀",
+            "french_name": "Xatu ♀",
+            "simplified_name": "Xatu",
+            "simplified_french_name": "Xatu",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 178,
+          "regional_dex_number": null,
+          "icon": "xatu-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "natu"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0178-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mareep",
+          "labels": {
+            "name": "Mareep",
+            "french_name": "Wattouat",
+            "simplified_name": "Mareep",
+            "simplified_french_name": "Wattouat",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 179,
+          "regional_dex_number": null,
+          "icon": "mareep",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "mareep"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0179-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "flaaffy",
+          "labels": {
+            "name": "Flaaffy",
+            "french_name": "Lainergie",
+            "simplified_name": "Flaaffy",
+            "simplified_french_name": "Lainergie",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 180,
+          "regional_dex_number": null,
+          "icon": "flaaffy",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "mareep"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0180-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ampharos",
+          "labels": {
+            "name": "Ampharos",
+            "french_name": "Pharamp",
+            "simplified_name": "Ampharos",
+            "simplified_french_name": "Pharamp",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 181,
+          "regional_dex_number": null,
+          "icon": "ampharos",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "mareep"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0181-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "bellossom",
+          "labels": {
+            "name": "Bellossom",
+            "french_name": "Joliflor",
+            "simplified_name": "Bellossom",
+            "simplified_french_name": "Joliflor",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 182,
+          "regional_dex_number": null,
+          "icon": "bellossom",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0182-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "marill",
+          "labels": {
+            "name": "Marill",
+            "french_name": "Marill",
+            "simplified_name": "Marill",
+            "simplified_french_name": "Marill",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 183,
+          "regional_dex_number": null,
+          "icon": "marill",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "marill"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0183-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "azumarill",
+          "labels": {
+            "name": "Azumarill",
+            "french_name": "Azumarill",
+            "simplified_name": "Azumarill",
+            "simplified_french_name": "Azumarill",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 184,
+          "regional_dex_number": null,
+          "icon": "azumarill",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "marill"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0184-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sudowoodo",
+          "labels": {
+            "name": "Sudowoodo ♂️",
+            "french_name": "Simularbre ♂️",
+            "simplified_name": "Sudowoodo",
+            "simplified_french_name": "Simularbre",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 185,
+          "regional_dex_number": null,
+          "icon": "sudowoodo",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "sudowoodo"
+          },
+          "original_game_bundle": {
+            "slug": "goldsilvercrystal"
+          },
+          "order_number": "9999-0185-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": null
+        }
+      }
+    ],
+    "report": {
+      "total": 50,
+      "total_caught": 25,
+      "total_uncaught": 10,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 25
+        },
+        {
+          "catch_state": {
+            "name": "To evolve",
+            "french_name": "af. évoluer",
+            "slug": "toevolve",
+            "color": "#9575cd"
+          },
+          "count": 15
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 10
+        }
+      ]
+    },
+    "filtered_report": {
+      "total": 50,
+      "total_caught": 25,
+      "total_uncaught": 10,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 25
+        },
+        {
+          "catch_state": {
+            "name": "To evolve",
+            "french_name": "af. évoluer",
+            "slug": "toevolve",
+            "color": "#9575cd"
+          },
+          "count": 15
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 10
+        }
+      ]
+    }
+  },
+  "filters": []
+}

--- a/tests/resources/moco/Back/responses/album/default/homepogo.json
+++ b/tests/resources/moco/Back/responses/album/default/homepogo.json
@@ -1,0 +1,10530 @@
+{
+  "pokedex": {
+    "dex": {
+      "slug": "homepogo",
+      "original_slug": "homepogo",
+      "name": "Home Pokemon Go",
+      "french_name": "Home Pokemon Go",
+      "flags": {
+        "is_shiny": false,
+        "is_private": false,
+        "is_on_home": true,
+        "is_display_form": false,
+        "is_released": true,
+        "is_premium": false,
+        "is_custom": true
+      },
+      "display_template": "list-7",
+      "region": null,
+      "selection_rule": "p.custom.homepogo",
+      "description": "Custom list of Pokémon transferred through Pokémon Go to Pokémon Home.",
+      "french_description": "Liste personnalisée des Pokémon transférés depuis Pokémon Go vers Pokémon Home.",
+      "version": "20230421.090014"
+    },
+    "pokemons": [
+      {
+        "pokemon": {
+          "slug": "exeggcute",
+          "labels": {
+            "name": "Exeggcute",
+            "french_name": "Noeunoeuf",
+            "simplified_name": "Exeggcute",
+            "simplified_french_name": "Noeunoeuf",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 102,
+          "regional_dex_number": null,
+          "icon": "exeggcute",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "exeggcute"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0102-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "exeggutor",
+          "labels": {
+            "name": "Exeggutor",
+            "french_name": "Noadkoko",
+            "simplified_name": "Exeggutor",
+            "simplified_french_name": "Noadkoko",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 103,
+          "regional_dex_number": null,
+          "icon": "exeggutor",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "exeggcute"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0103-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "exeggutor-alola",
+          "labels": {
+            "name": "Exeggutor-Alola",
+            "french_name": "Noadkoko d'Alola",
+            "simplified_name": "Exeggutor",
+            "simplified_french_name": "Noadkoko",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 103,
+          "regional_dex_number": null,
+          "icon": "exeggutor-alola",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "exeggcute"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0103-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "dragon",
+            "name": "Dragon",
+            "french_name": "Dragon",
+            "color": "#0a6dc8"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "cubone",
+          "labels": {
+            "name": "Cubone",
+            "french_name": "Osselait",
+            "simplified_name": "Cubone",
+            "simplified_french_name": "Osselait",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 104,
+          "regional_dex_number": null,
+          "icon": "cubone",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "cubone"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0104-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "marowak",
+          "labels": {
+            "name": "Marowak",
+            "french_name": "Ossatueur",
+            "simplified_name": "Marowak",
+            "simplified_french_name": "Ossatueur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 105,
+          "regional_dex_number": null,
+          "icon": "marowak",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "cubone"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0105-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "marowak-alola",
+          "labels": {
+            "name": "Marowak-Alola",
+            "french_name": "Ossatueur d'Alola",
+            "simplified_name": "Marowak",
+            "simplified_french_name": "Ossatueur",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 105,
+          "regional_dex_number": null,
+          "icon": "marowak-alola",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "cubone"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0105-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hitmonlee",
+          "labels": {
+            "name": "Hitmonlee",
+            "french_name": "Kicklee",
+            "simplified_name": "Hitmonlee",
+            "simplified_french_name": "Kicklee",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 106,
+          "regional_dex_number": null,
+          "icon": "hitmonlee",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "hitmonlee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0106-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hitmonchan",
+          "labels": {
+            "name": "Hitmonchan",
+            "french_name": "Tygnon",
+            "simplified_name": "Hitmonchan",
+            "simplified_french_name": "Tygnon",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 107,
+          "regional_dex_number": null,
+          "icon": "hitmonchan",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "hitmonlee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0107-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "lickitung",
+          "labels": {
+            "name": "Lickitung",
+            "french_name": "Excelangue",
+            "simplified_name": "Lickitung",
+            "simplified_french_name": "Excelangue",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 108,
+          "regional_dex_number": null,
+          "icon": "lickitung",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "lickitung"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0108-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "koffing",
+          "labels": {
+            "name": "Koffing",
+            "french_name": "Smogo",
+            "simplified_name": "Koffing",
+            "simplified_french_name": "Smogo",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 109,
+          "regional_dex_number": null,
+          "icon": "koffing",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "koffing"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0109-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "weezing",
+          "labels": {
+            "name": "Weezing",
+            "french_name": "Smogogo",
+            "simplified_name": "Weezing",
+            "simplified_french_name": "Smogogo",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 110,
+          "regional_dex_number": null,
+          "icon": "weezing",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "koffing"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0110-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "weezing-galar",
+          "labels": {
+            "name": "Weezing-Galar",
+            "french_name": "Smogogo de Galar",
+            "simplified_name": "Weezing",
+            "simplified_french_name": "Smogogo",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 110,
+          "regional_dex_number": null,
+          "icon": "weezing-galar",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "koffing"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0110-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rhyhorn",
+          "labels": {
+            "name": "Rhyhorn ♂️",
+            "french_name": "Rhinocorne ♂️",
+            "simplified_name": "Rhyhorn",
+            "simplified_french_name": "Rhinocorne",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 111,
+          "regional_dex_number": null,
+          "icon": "rhyhorn",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "rhyhorn"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0111-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rhyhorn-f",
+          "labels": {
+            "name": "Rhyhorn ♀",
+            "french_name": "Rhinocorne ♀",
+            "simplified_name": "Rhyhorn",
+            "simplified_french_name": "Rhinocorne",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 111,
+          "regional_dex_number": null,
+          "icon": "rhyhorn-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "rhyhorn"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0111-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rhydon",
+          "labels": {
+            "name": "Rhydon ♂️",
+            "french_name": "Rhinoféros ♂️",
+            "simplified_name": "Rhydon",
+            "simplified_french_name": "Rhinoféros",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 112,
+          "regional_dex_number": null,
+          "icon": "rhydon",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "rhyhorn"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0112-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rhydon-f",
+          "labels": {
+            "name": "Rhydon ♀",
+            "french_name": "Rhinoféros ♀",
+            "simplified_name": "Rhydon",
+            "simplified_french_name": "Rhinoféros",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 112,
+          "regional_dex_number": null,
+          "icon": "rhydon-f",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "rhyhorn"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0112-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "chansey",
+          "labels": {
+            "name": "Chansey",
+            "french_name": "Leveinard",
+            "simplified_name": "Chansey",
+            "simplified_french_name": "Leveinard",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 113,
+          "regional_dex_number": null,
+          "icon": "chansey",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "chansey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0113-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tangela",
+          "labels": {
+            "name": "Tangela",
+            "french_name": "Saquedeneu",
+            "simplified_name": "Tangela",
+            "simplified_french_name": "Saquedeneu",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 114,
+          "regional_dex_number": null,
+          "icon": "tangela",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "tangela"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0114-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kangaskhan",
+          "labels": {
+            "name": "Kangaskhan",
+            "french_name": "Kangourex",
+            "simplified_name": "Kangaskhan",
+            "simplified_french_name": "Kangourex",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 115,
+          "regional_dex_number": null,
+          "icon": "kangaskhan",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "kangaskhan"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0115-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "horsea",
+          "labels": {
+            "name": "Horsea",
+            "french_name": "Hypotrempe",
+            "simplified_name": "Horsea",
+            "simplified_french_name": "Hypotrempe",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 116,
+          "regional_dex_number": null,
+          "icon": "horsea",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "horsea"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0116-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "seadra",
+          "labels": {
+            "name": "Seadra",
+            "french_name": "Hypocéan",
+            "simplified_name": "Seadra",
+            "simplified_french_name": "Hypocéan",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 117,
+          "regional_dex_number": null,
+          "icon": "seadra",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "horsea"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0117-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "goldeen",
+          "labels": {
+            "name": "Goldeen ♂️",
+            "french_name": "Poissirène ♂️",
+            "simplified_name": "Goldeen",
+            "simplified_french_name": "Poissirène",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 118,
+          "regional_dex_number": null,
+          "icon": "goldeen",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "goldeen"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0118-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "goldeen-f",
+          "labels": {
+            "name": "Goldeen ♀",
+            "french_name": "Poissirène ♀",
+            "simplified_name": "Goldeen",
+            "simplified_french_name": "Poissirène",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 118,
+          "regional_dex_number": null,
+          "icon": "goldeen-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "goldeen"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0118-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "seaking",
+          "labels": {
+            "name": "Seaking ♂️",
+            "french_name": "Poissoroy ♂️",
+            "simplified_name": "Seaking",
+            "simplified_french_name": "Poissoroy",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 119,
+          "regional_dex_number": null,
+          "icon": "seaking",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "goldeen"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0119-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "seaking-f",
+          "labels": {
+            "name": "Seaking ♀",
+            "french_name": "Poissoroy ♀",
+            "simplified_name": "Seaking",
+            "simplified_french_name": "Poissoroy",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 119,
+          "regional_dex_number": null,
+          "icon": "seaking-f",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "goldeen"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0119-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "staryu",
+          "labels": {
+            "name": "Staryu",
+            "french_name": "Stari",
+            "simplified_name": "Staryu",
+            "simplified_french_name": "Stari",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 120,
+          "regional_dex_number": null,
+          "icon": "staryu",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "staryu"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0120-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "starmie",
+          "labels": {
+            "name": "Starmie",
+            "french_name": "Staross",
+            "simplified_name": "Starmie",
+            "simplified_french_name": "Staross",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 121,
+          "regional_dex_number": null,
+          "icon": "starmie",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "staryu"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0121-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mr-mime",
+          "labels": {
+            "name": "Mr. Mime",
+            "french_name": "M. Mime",
+            "simplified_name": "Mr. Mime",
+            "simplified_french_name": "M. Mime",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 122,
+          "regional_dex_number": null,
+          "icon": "mr-mime",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "mr-mime"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0122-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mr-mime-galar",
+          "labels": {
+            "name": "Mr. Mime-Galar",
+            "french_name": "M. Mime de Galar",
+            "simplified_name": "Mr. Mime",
+            "simplified_french_name": "M. Mime",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 122,
+          "regional_dex_number": null,
+          "icon": "mr-mime-galar",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "mr-mime"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0122-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "scyther",
+          "labels": {
+            "name": "Scyther ♂️",
+            "french_name": "Insécateur ♂️",
+            "simplified_name": "Scyther",
+            "simplified_french_name": "Insécateur",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 123,
+          "regional_dex_number": null,
+          "icon": "scyther",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "scyther"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0123-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "scyther-f",
+          "labels": {
+            "name": "Scyther ♀",
+            "french_name": "Insécateur ♀",
+            "simplified_name": "Scyther",
+            "simplified_french_name": "Insécateur",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 123,
+          "regional_dex_number": null,
+          "icon": "scyther-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "scyther"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0123-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "jynx",
+          "labels": {
+            "name": "Jynx",
+            "french_name": "Lippoutou",
+            "simplified_name": "Jynx",
+            "simplified_french_name": "Lippoutou",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 124,
+          "regional_dex_number": null,
+          "icon": "jynx",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "jynx"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0124-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "electabuzz",
+          "labels": {
+            "name": "Electabuzz",
+            "french_name": "Élektek",
+            "simplified_name": "Electabuzz",
+            "simplified_french_name": "Élektek",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 125,
+          "regional_dex_number": null,
+          "icon": "electabuzz",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "electabuzz"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0125-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "magmar",
+          "labels": {
+            "name": "Magmar",
+            "french_name": "Magmar",
+            "simplified_name": "Magmar",
+            "simplified_french_name": "Magmar",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 126,
+          "regional_dex_number": null,
+          "icon": "magmar",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "magmar"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0126-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pinsir",
+          "labels": {
+            "name": "Pinsir",
+            "french_name": "Scarabrute",
+            "simplified_name": "Pinsir",
+            "simplified_french_name": "Scarabrute",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 127,
+          "regional_dex_number": null,
+          "icon": "pinsir",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "pinsir"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0127-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tauros",
+          "labels": {
+            "name": "Tauros",
+            "french_name": "Tauros",
+            "simplified_name": "Tauros",
+            "simplified_french_name": "Tauros",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 128,
+          "regional_dex_number": null,
+          "icon": "tauros",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "tauros"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0128-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tauros-paldea",
+          "labels": {
+            "name": "Tauros-Paldea",
+            "french_name": "Tauros de Paldea",
+            "simplified_name": "Tauros",
+            "simplified_french_name": "Tauros",
+            "forms_label": "Paldean",
+            "forms_french_label": "de Paldea"
+          },
+          "national_dex_number": 128,
+          "regional_dex_number": null,
+          "icon": "tauros-paldea",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "tauros"
+          },
+          "original_game_bundle": {
+            "slug": "scarletviolet"
+          },
+          "order_number": "9999-0128-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "paldean",
+            "name": "Paldean",
+            "french_name": "de Paldea"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tauros-paldea-blaze",
+          "labels": {
+            "name": "Tauros-Paldea-Blaze",
+            "french_name": "Tauros Rage Flamboyante de Paldea",
+            "simplified_name": "Tauros",
+            "simplified_french_name": "Tauros",
+            "forms_label": "Blaze Paldean",
+            "forms_french_label": "Rage Flamboyante de Paldea"
+          },
+          "national_dex_number": 128,
+          "regional_dex_number": null,
+          "icon": "tauros-paldea-fire",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "tauros"
+          },
+          "original_game_bundle": {
+            "slug": "scarletviolet"
+          },
+          "order_number": "9999-0128-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "paldean",
+            "name": "Paldean",
+            "french_name": "de Paldea"
+          },
+          "special": null,
+          "variant": {
+            "slug": "alternate",
+            "name": "Alternate",
+            "french_name": "Alternatif"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tauros-paldea-aqua",
+          "labels": {
+            "name": "Tauros-Paldea-Aqua",
+            "french_name": "Tauros Rage Aquatique de Paldea",
+            "simplified_name": "Tauros",
+            "simplified_french_name": "Tauros",
+            "forms_label": "Aqua Paldean",
+            "forms_french_label": "Rage Aquatique de Paldea"
+          },
+          "national_dex_number": 128,
+          "regional_dex_number": null,
+          "icon": "tauros-paldea-water",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "tauros"
+          },
+          "original_game_bundle": {
+            "slug": "scarletviolet"
+          },
+          "order_number": "9999-0128-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "paldean",
+            "name": "Paldean",
+            "french_name": "de Paldea"
+          },
+          "special": null,
+          "variant": {
+            "slug": "alternate",
+            "name": "Alternate",
+            "french_name": "Alternatif"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "magikarp",
+          "labels": {
+            "name": "Magikarp ♂️",
+            "french_name": "Magicarpe ♂️",
+            "simplified_name": "Magikarp",
+            "simplified_french_name": "Magicarpe",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 129,
+          "regional_dex_number": null,
+          "icon": "magikarp",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "magikarp"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0129-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "magikarp-f",
+          "labels": {
+            "name": "Magikarp ♀",
+            "french_name": "Magicarpe ♀",
+            "simplified_name": "Magikarp",
+            "simplified_french_name": "Magicarpe",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 129,
+          "regional_dex_number": null,
+          "icon": "magikarp-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "magikarp"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0129-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gyarados",
+          "labels": {
+            "name": "Gyarados ♂️",
+            "french_name": "Léviator ♂️",
+            "simplified_name": "Gyarados",
+            "simplified_french_name": "Léviator",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 130,
+          "regional_dex_number": null,
+          "icon": "gyarados",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "magikarp"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0130-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gyarados-f",
+          "labels": {
+            "name": "Gyarados ♀",
+            "french_name": "Léviator ♀",
+            "simplified_name": "Gyarados",
+            "simplified_french_name": "Léviator",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 130,
+          "regional_dex_number": null,
+          "icon": "gyarados-f",
+          "family_order": 7,
+          "family_lead": {
+            "slug": "magikarp"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0130-007",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "lapras",
+          "labels": {
+            "name": "Lapras",
+            "french_name": "Lokhlass",
+            "simplified_name": "Lapras",
+            "simplified_french_name": "Lokhlass",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 131,
+          "regional_dex_number": null,
+          "icon": "lapras",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "lapras"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0131-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "lapras-gmax",
+          "labels": {
+            "name": "Gigantamax Lapras",
+            "french_name": "Gigamax Lokhlass",
+            "simplified_name": "Lapras",
+            "simplified_french_name": "Lokhlass",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 131,
+          "regional_dex_number": null,
+          "icon": "lapras-gmax",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "lapras"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0131-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ditto",
+          "labels": {
+            "name": "Ditto",
+            "french_name": "Métamorph",
+            "simplified_name": "Ditto",
+            "simplified_french_name": "Métamorph",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 132,
+          "regional_dex_number": null,
+          "icon": "ditto",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "ditto"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0132-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "eevee",
+          "labels": {
+            "name": "Eevee ♂️",
+            "french_name": "Évoli ♂️",
+            "simplified_name": "Eevee",
+            "simplified_french_name": "Évoli",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 133,
+          "regional_dex_number": null,
+          "icon": "eevee",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0133-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "eevee-f",
+          "labels": {
+            "name": "Eevee ♀",
+            "french_name": "Évoli ♀",
+            "simplified_name": "Eevee",
+            "simplified_french_name": "Évoli",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 133,
+          "regional_dex_number": null,
+          "icon": "eevee-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0133-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "eevee-gmax",
+          "labels": {
+            "name": "Gigantamax Eevee",
+            "french_name": "Gigamax Évoli",
+            "simplified_name": "Eevee",
+            "simplified_french_name": "Évoli",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 133,
+          "regional_dex_number": null,
+          "icon": "eevee-gmax",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0133-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "vaporeon",
+          "labels": {
+            "name": "Vaporeon",
+            "french_name": "Aquali",
+            "simplified_name": "Vaporeon",
+            "simplified_french_name": "Aquali",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 134,
+          "regional_dex_number": null,
+          "icon": "vaporeon",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0134-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "jolteon",
+          "labels": {
+            "name": "Jolteon",
+            "french_name": "Voltali",
+            "simplified_name": "Jolteon",
+            "simplified_french_name": "Voltali",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 135,
+          "regional_dex_number": null,
+          "icon": "jolteon",
+          "family_order": 7,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0135-007",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "flareon",
+          "labels": {
+            "name": "Flareon",
+            "french_name": "Pyroli",
+            "simplified_name": "Flareon",
+            "simplified_french_name": "Pyroli",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 136,
+          "regional_dex_number": null,
+          "icon": "flareon",
+          "family_order": 9,
+          "family_lead": {
+            "slug": "eevee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0136-009",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "porygon",
+          "labels": {
+            "name": "Porygon",
+            "french_name": "Porygon",
+            "simplified_name": "Porygon",
+            "simplified_french_name": "Porygon",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 137,
+          "regional_dex_number": null,
+          "icon": "porygon",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "porygon"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0137-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "omanyte",
+          "labels": {
+            "name": "Omanyte",
+            "french_name": "Amonita",
+            "simplified_name": "Omanyte",
+            "simplified_french_name": "Amonita",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 138,
+          "regional_dex_number": null,
+          "icon": "omanyte",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "omanyte"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0138-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "omastar",
+          "labels": {
+            "name": "Omastar",
+            "french_name": "Amonistar",
+            "simplified_name": "Omastar",
+            "simplified_french_name": "Amonistar",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 139,
+          "regional_dex_number": null,
+          "icon": "omastar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "omanyte"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0139-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kabuto",
+          "labels": {
+            "name": "Kabuto",
+            "french_name": "Kabuto",
+            "simplified_name": "Kabuto",
+            "simplified_french_name": "Kabuto",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 140,
+          "regional_dex_number": null,
+          "icon": "kabuto",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "kabuto"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0140-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kabutops",
+          "labels": {
+            "name": "Kabutops",
+            "french_name": "Kabutops",
+            "simplified_name": "Kabutops",
+            "simplified_french_name": "Kabutops",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 141,
+          "regional_dex_number": null,
+          "icon": "kabutops",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "kabuto"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0141-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "aerodactyl",
+          "labels": {
+            "name": "Aerodactyl",
+            "french_name": "Ptéra",
+            "simplified_name": "Aerodactyl",
+            "simplified_french_name": "Ptéra",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 142,
+          "regional_dex_number": null,
+          "icon": "aerodactyl",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "aerodactyl"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0142-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "snorlax",
+          "labels": {
+            "name": "Snorlax",
+            "french_name": "Ronflex",
+            "simplified_name": "Snorlax",
+            "simplified_french_name": "Ronflex",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 143,
+          "regional_dex_number": null,
+          "icon": "snorlax",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "snorlax"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0143-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "snorlax-gmax",
+          "labels": {
+            "name": "Gigantamax Snorlax",
+            "french_name": "Gigamax Ronflex",
+            "simplified_name": "Snorlax",
+            "simplified_french_name": "Ronflex",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 143,
+          "regional_dex_number": null,
+          "icon": "snorlax-gmax",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "snorlax"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0143-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      }
+    ],
+    "report": {
+      "total": 60,
+      "total_caught": 60,
+      "total_uncaught": 0,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 60
+        }
+      ]
+    },
+    "filtered_report": {
+      "total": 60,
+      "total_caught": 60,
+      "total_uncaught": 0,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 60
+        }
+      ]
+    }
+  },
+  "filters": []
+}

--- a/tests/resources/moco/Back/responses/album/default/homeshiny.json
+++ b/tests/resources/moco/Back/responses/album/default/homeshiny.json
@@ -1,0 +1,25751 @@
+{
+  "pokedex": {
+    "dex": {
+      "slug": "homeshiny",
+      "original_slug": "homeshiny",
+      "name": "Home Shiny",
+      "french_name": "Home Chromatique",
+      "flags": {
+        "is_shiny": true,
+        "is_private": false,
+        "is_on_home": true,
+        "is_display_form": true,
+        "is_released": true,
+        "is_premium": false,
+        "is_custom": false
+      },
+      "display_template": "box",
+      "region": null,
+      "selection_rule": "p.isShiny",
+      "description": "Shiny variants of every Pokémon transferable to Pokémon Home.",
+      "french_description": "Variantes chromatiques de tous les Pokémon transférables sur Pokémon Home.",
+      "version": "20230421.090014"
+    },
+    "pokemons": [
+      {
+        "pokemon": {
+          "slug": "bulbasaur",
+          "labels": {
+            "name": "Bulbasaur",
+            "french_name": "Bulbizarre",
+            "simplified_name": "Bulbasaur",
+            "simplified_french_name": "Bulbizarre",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 1,
+          "regional_dex_number": null,
+          "icon": "bulbasaur",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "bulbasaur"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0001-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": {
+          "name": "Yes",
+          "french_name": "Oui",
+          "slug": "yes",
+          "color": "#66bb6a"
+        },
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ivysaur",
+          "labels": {
+            "name": "Ivysaur",
+            "french_name": "Herbizarre",
+            "simplified_name": "Ivysaur",
+            "simplified_french_name": "Herbizarre",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 2,
+          "regional_dex_number": null,
+          "icon": "ivysaur",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "bulbasaur"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0002-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "venusaur",
+          "labels": {
+            "name": "Venusaur ♂️",
+            "french_name": "Florizarre ♂️",
+            "simplified_name": "Venusaur",
+            "simplified_french_name": "Florizarre",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 3,
+          "regional_dex_number": null,
+          "icon": "venusaur",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "bulbasaur"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0003-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "venusaur-f",
+          "labels": {
+            "name": "Venusaur ♀",
+            "french_name": "Florizarre ♀️",
+            "simplified_name": "Venusaur",
+            "simplified_french_name": "Florizarre",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 3,
+          "regional_dex_number": null,
+          "icon": "venusaur-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "bulbasaur"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0003-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "venusaur-gmax",
+          "labels": {
+            "name": "Gigantamax Venusaur",
+            "french_name": "Gigamax Florizarre",
+            "simplified_name": "Venusaur",
+            "simplified_french_name": "Florizarre",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 3,
+          "regional_dex_number": null,
+          "icon": "venusaur-gmax",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "bulbasaur"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0003-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "charmander",
+          "labels": {
+            "name": "Charmander",
+            "french_name": "Salamèche",
+            "simplified_name": "Charmander",
+            "simplified_french_name": "Salamèche",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 4,
+          "regional_dex_number": null,
+          "icon": "charmander",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "charmander"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0004-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "charmeleon",
+          "labels": {
+            "name": "Charmeleon",
+            "french_name": "Reptincel",
+            "simplified_name": "Charmeleon",
+            "simplified_french_name": "Reptincel",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 5,
+          "regional_dex_number": null,
+          "icon": "charmeleon",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "charmander"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0005-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "charizard",
+          "labels": {
+            "name": "Charizard",
+            "french_name": "Dracaufeu",
+            "simplified_name": "Charizard",
+            "simplified_french_name": "Dracaufeu",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 6,
+          "regional_dex_number": null,
+          "icon": "charizard",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "charmander"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0006-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "charizard-gmax",
+          "labels": {
+            "name": "Gigantamax Charizard",
+            "french_name": "Gigamax Dracaufeu",
+            "simplified_name": "Charizard",
+            "simplified_french_name": "Dracaufeu",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 6,
+          "regional_dex_number": null,
+          "icon": "charizard-gmax",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "charmander"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0006-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "squirtle",
+          "labels": {
+            "name": "Squirtle",
+            "french_name": "Carapuce",
+            "simplified_name": "Squirtle",
+            "simplified_french_name": "Carapuce",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 7,
+          "regional_dex_number": null,
+          "icon": "squirtle",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "squirtle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0007-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": {
+            "slug": "starter",
+            "name": "Starter",
+            "french_name": "de Départ"
+          },
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "wartortle",
+          "labels": {
+            "name": "Wartortle",
+            "french_name": "Carabaffe",
+            "simplified_name": "Wartortle",
+            "simplified_french_name": "Carabaffe",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 8,
+          "regional_dex_number": null,
+          "icon": "wartortle",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "squirtle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0008-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "blastoise",
+          "labels": {
+            "name": "Blastoise",
+            "french_name": "Tortank",
+            "simplified_name": "Blastoise",
+            "simplified_french_name": "Tortank",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 9,
+          "regional_dex_number": null,
+          "icon": "blastoise",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "squirtle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0009-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "blastoise-gmax",
+          "labels": {
+            "name": "Gigantamax Blastoise",
+            "french_name": "Gigamax Tortank",
+            "simplified_name": "Blastoise",
+            "simplified_french_name": "Tortank",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 9,
+          "regional_dex_number": null,
+          "icon": "blastoise-gmax",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "squirtle"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0009-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "caterpie",
+          "labels": {
+            "name": "Caterpie",
+            "french_name": "Chenipan",
+            "simplified_name": "Caterpie",
+            "simplified_french_name": "Chenipan",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 10,
+          "regional_dex_number": null,
+          "icon": "caterpie",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "caterpie"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0010-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "metapod",
+          "labels": {
+            "name": "Metapod",
+            "french_name": "Chrysacier",
+            "simplified_name": "Metapod",
+            "simplified_french_name": "Chrysacier",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 11,
+          "regional_dex_number": null,
+          "icon": "metapod",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "caterpie"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0011-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "butterfree",
+          "labels": {
+            "name": "Butterfree ♂️",
+            "french_name": "Papilusion ♂️",
+            "simplified_name": "Butterfree",
+            "simplified_french_name": "Papilusion",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 12,
+          "regional_dex_number": null,
+          "icon": "butterfree",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "caterpie"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0012-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "butterfree-f",
+          "labels": {
+            "name": "Butterfree ♀",
+            "french_name": "Papilusion ♀",
+            "simplified_name": "Butterfree",
+            "simplified_french_name": "Papilusion",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️️"
+          },
+          "national_dex_number": 12,
+          "regional_dex_number": null,
+          "icon": "butterfree-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "caterpie"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0012-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "butterfree-gmax",
+          "labels": {
+            "name": "Gigantamax Butterfree",
+            "french_name": "Gigamax Papilusion",
+            "simplified_name": "Butterfree",
+            "simplified_french_name": "Papilusion",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 12,
+          "regional_dex_number": null,
+          "icon": "butterfree-gmax",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "caterpie"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0012-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "weedle",
+          "labels": {
+            "name": "Weedle",
+            "french_name": "Aspicot",
+            "simplified_name": "Weedle",
+            "simplified_french_name": "Aspicot",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 13,
+          "regional_dex_number": null,
+          "icon": "weedle",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "weedle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0013-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kakuna",
+          "labels": {
+            "name": "Kakuna",
+            "french_name": "Coconfort",
+            "simplified_name": "Kakuna",
+            "simplified_french_name": "Coconfort",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 14,
+          "regional_dex_number": null,
+          "icon": "kakuna",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "weedle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0014-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "beedrill",
+          "labels": {
+            "name": "Beedrill",
+            "french_name": "Dardargnan",
+            "simplified_name": "Beedrill",
+            "simplified_french_name": "Dardargnan",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 15,
+          "regional_dex_number": null,
+          "icon": "beedrill",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "weedle"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0015-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pidgey",
+          "labels": {
+            "name": "Pidgey",
+            "french_name": "Roucool",
+            "simplified_name": "Pidgey",
+            "simplified_french_name": "Roucool",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 16,
+          "regional_dex_number": null,
+          "icon": "pidgey",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "pidgey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0016-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pidgeotto",
+          "labels": {
+            "name": "Pidgeotto",
+            "french_name": "Roucoups",
+            "simplified_name": "Pidgeotto",
+            "simplified_french_name": "Roucoups",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 17,
+          "regional_dex_number": null,
+          "icon": "pidgeotto",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "pidgey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0017-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pidgeot",
+          "labels": {
+            "name": "Pidgeot",
+            "french_name": "Roucarnage",
+            "simplified_name": "Pidgeot",
+            "simplified_french_name": "Roucarnage",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 18,
+          "regional_dex_number": null,
+          "icon": "pidgeot",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "pidgey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0018-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rattata",
+          "labels": {
+            "name": "Rattata ♂️",
+            "french_name": "Rattata ♂️",
+            "simplified_name": "Rattata",
+            "simplified_french_name": "Rattata",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 19,
+          "regional_dex_number": null,
+          "icon": "rattata",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0019-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rattata-f",
+          "labels": {
+            "name": "Rattata ♀️",
+            "french_name": "Rattata ♀️️",
+            "simplified_name": "Rattata",
+            "simplified_french_name": "Rattata",
+            "forms_label": "♀️️",
+            "forms_french_label": "♀️️"
+          },
+          "national_dex_number": 19,
+          "regional_dex_number": null,
+          "icon": "rattata-f",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0019-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rattata-alola",
+          "labels": {
+            "name": "Rattata-Alola",
+            "french_name": "Rattata d'Alola",
+            "simplified_name": "Rattata",
+            "simplified_french_name": "Rattata",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 19,
+          "regional_dex_number": null,
+          "icon": "rattata-alola",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0019-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raticate",
+          "labels": {
+            "name": "Raticate ♂️",
+            "french_name": "Rattatac ♂️",
+            "simplified_name": "Raticate",
+            "simplified_french_name": "Rattatac",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 20,
+          "regional_dex_number": null,
+          "icon": "raticate",
+          "family_order": 7,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0020-007",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raticate-f",
+          "labels": {
+            "name": "Raticate ♀️",
+            "french_name": "Rattatac ♀",
+            "simplified_name": "Raticate",
+            "simplified_french_name": "Rattatac",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 20,
+          "regional_dex_number": null,
+          "icon": "raticate-f",
+          "family_order": 8,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0020-008",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raticate-alola",
+          "labels": {
+            "name": "Raticate-Alola",
+            "french_name": "Rattatac d'Alola",
+            "simplified_name": "Raticate",
+            "simplified_french_name": "Rattatac",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 20,
+          "regional_dex_number": null,
+          "icon": "raticate-alola",
+          "family_order": 9,
+          "family_lead": {
+            "slug": "rattata"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0020-009",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "spearow",
+          "labels": {
+            "name": "Spearow",
+            "french_name": "Piafabec",
+            "simplified_name": "Spearow",
+            "simplified_french_name": "Piafabec",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 21,
+          "regional_dex_number": null,
+          "icon": "spearow",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "spearow"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0021-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "fearow",
+          "labels": {
+            "name": "Fearow",
+            "french_name": "Rapasdepic",
+            "simplified_name": "Fearow",
+            "simplified_french_name": "Rapasdepic",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 22,
+          "regional_dex_number": null,
+          "icon": "fearow",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "spearow"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0022-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ekans",
+          "labels": {
+            "name": "Ekans",
+            "french_name": "Abo",
+            "simplified_name": "Ekans",
+            "simplified_french_name": "Abo",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 23,
+          "regional_dex_number": null,
+          "icon": "ekans",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "ekans"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0023-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "arbok",
+          "labels": {
+            "name": "Arbok",
+            "french_name": "Arbok",
+            "simplified_name": "Arbok",
+            "simplified_french_name": "Arbok",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 24,
+          "regional_dex_number": null,
+          "icon": "arbok",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "ekans"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0024-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pikachu",
+          "labels": {
+            "name": "Pikachu ♂️",
+            "french_name": "Pikachu ♂️",
+            "simplified_name": "Pikachu",
+            "simplified_french_name": "Pikachu",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 25,
+          "regional_dex_number": null,
+          "icon": "pikachu",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0025-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pikachu-f",
+          "labels": {
+            "name": "Pikachu ♀",
+            "french_name": "Pikachu ♀",
+            "simplified_name": "Pikachu",
+            "simplified_french_name": "Pikachu",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 25,
+          "regional_dex_number": null,
+          "icon": "pikachu-f",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0025-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "pikachu-gmax",
+          "labels": {
+            "name": "Gigantamax Pikachu",
+            "french_name": "Gigamax Pikachu",
+            "simplified_name": "Pikachu",
+            "simplified_french_name": "Pikachu",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 25,
+          "regional_dex_number": null,
+          "icon": "pikachu-gmax",
+          "family_order": 20,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0025-020",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raichu",
+          "labels": {
+            "name": "Raichu ♂️",
+            "french_name": "Raichu ♂️",
+            "simplified_name": "Raichu",
+            "simplified_french_name": "Raichu",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 26,
+          "regional_dex_number": null,
+          "icon": "raichu",
+          "family_order": 21,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0026-021",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raichu-f",
+          "labels": {
+            "name": "Raichu ♀",
+            "french_name": "Raichu ♀",
+            "simplified_name": "Raichu",
+            "simplified_french_name": "Raichu",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 26,
+          "regional_dex_number": null,
+          "icon": "raichu-f",
+          "family_order": 23,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0026-023",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "raichu-alola",
+          "labels": {
+            "name": "Raichu-Alola",
+            "french_name": "Raichu d'Alola",
+            "simplified_name": "Raichu",
+            "simplified_french_name": "Raichu",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 26,
+          "regional_dex_number": null,
+          "icon": "raichu-alola",
+          "family_order": 25,
+          "family_lead": {
+            "slug": "pikachu"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0026-025",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sandshrew",
+          "labels": {
+            "name": "Sandshrew",
+            "french_name": "Sabelette",
+            "simplified_name": "Sandshrew",
+            "simplified_french_name": "Sabelette",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 27,
+          "regional_dex_number": null,
+          "icon": "sandshrew",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "sandshrew"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0027-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sandshrew-alola",
+          "labels": {
+            "name": "Sandshrew-Alola",
+            "french_name": "Sabelette d'Alola",
+            "simplified_name": "Sandshrew",
+            "simplified_french_name": "Sabelette",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 27,
+          "regional_dex_number": null,
+          "icon": "sandshrew-alola",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "sandshrew"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0027-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sandslash",
+          "labels": {
+            "name": "Sandslash",
+            "french_name": "Sablaireau",
+            "simplified_name": "Sandslash",
+            "simplified_french_name": "Sablaireau",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 28,
+          "regional_dex_number": null,
+          "icon": "sandslash",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "sandshrew"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0028-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "sandslash-alola",
+          "labels": {
+            "name": "Sandslash-Alola",
+            "french_name": "Sablaireau d'Alola",
+            "simplified_name": "Sandslash",
+            "simplified_french_name": "Sablaireau",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 28,
+          "regional_dex_number": null,
+          "icon": "sandslash-alola",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "sandshrew"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0028-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidoran-f",
+          "labels": {
+            "name": "Nidoran ♀",
+            "french_name": "Nidoran ♀",
+            "simplified_name": "Nidoran ♀",
+            "simplified_french_name": "Nidoran ♀",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 29,
+          "regional_dex_number": null,
+          "icon": "nidoran-f",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "nidoran-f"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0029-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidorina",
+          "labels": {
+            "name": "Nidorina",
+            "french_name": "Nidorina",
+            "simplified_name": "Nidorina",
+            "simplified_french_name": "Nidorina",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 30,
+          "regional_dex_number": null,
+          "icon": "nidorina",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "nidoran-f"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0030-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidoqueen",
+          "labels": {
+            "name": "Nidoqueen",
+            "french_name": "Nidoqueen",
+            "simplified_name": "Nidoqueen",
+            "simplified_french_name": "Nidoqueen",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 31,
+          "regional_dex_number": null,
+          "icon": "nidoqueen",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "nidoran-f"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0031-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidoran-m",
+          "labels": {
+            "name": "Nidoran ♂",
+            "french_name": "Nidoran ♂",
+            "simplified_name": "Nidoran ♂",
+            "simplified_french_name": "Nidoran ♂",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 32,
+          "regional_dex_number": null,
+          "icon": "nidoran-m",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "nidoran-m"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0032-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidorino",
+          "labels": {
+            "name": "Nidorino",
+            "french_name": "Nidorino",
+            "simplified_name": "Nidorino",
+            "simplified_french_name": "Nidorino",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 33,
+          "regional_dex_number": null,
+          "icon": "nidorino",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "nidoran-m"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0033-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "nidoking",
+          "labels": {
+            "name": "Nidoking",
+            "french_name": "Nidoking",
+            "simplified_name": "Nidoking",
+            "simplified_french_name": "Nidoking",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 34,
+          "regional_dex_number": null,
+          "icon": "nidoking",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "nidoran-m"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0034-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "clefairy",
+          "labels": {
+            "name": "Clefairy",
+            "french_name": "Mélofée",
+            "simplified_name": "Clefairy",
+            "simplified_french_name": "Mélofée",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 35,
+          "regional_dex_number": null,
+          "icon": "clefairy",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "clefairy"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0035-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "clefable",
+          "labels": {
+            "name": "Clefable",
+            "french_name": "Mélodelfe",
+            "simplified_name": "Clefable",
+            "simplified_french_name": "Mélodelfe",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 36,
+          "regional_dex_number": null,
+          "icon": "clefable",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "clefairy"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0036-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "vulpix",
+          "labels": {
+            "name": "Vulpix",
+            "french_name": "Goupix",
+            "simplified_name": "Vulpix",
+            "simplified_french_name": "Goupix",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 37,
+          "regional_dex_number": null,
+          "icon": "vulpix",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "vulpix"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0037-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "vulpix-alola",
+          "labels": {
+            "name": "Vulpix-Alola",
+            "french_name": "Goupix d'Alola",
+            "simplified_name": "Vulpix",
+            "simplified_french_name": "Goupix",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 37,
+          "regional_dex_number": null,
+          "icon": "vulpix-alola",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "vulpix"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0037-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ninetales",
+          "labels": {
+            "name": "Ninetales",
+            "french_name": "Feunard",
+            "simplified_name": "Ninetales",
+            "simplified_french_name": "Feunard",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 38,
+          "regional_dex_number": null,
+          "icon": "ninetales",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "vulpix"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0038-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ninetales-alola",
+          "labels": {
+            "name": "Ninetales-Alola",
+            "french_name": "Feunard d'Alola",
+            "simplified_name": "Ninetales",
+            "simplified_french_name": "Feunard",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 38,
+          "regional_dex_number": null,
+          "icon": "ninetales-alola",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "vulpix"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0038-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "jigglypuff",
+          "labels": {
+            "name": "Jigglypuff",
+            "french_name": "Rondoudou",
+            "simplified_name": "Jigglypuff",
+            "simplified_french_name": "Rondoudou",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 39,
+          "regional_dex_number": null,
+          "icon": "jigglypuff",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "jigglypuff"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0039-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "wigglytuff",
+          "labels": {
+            "name": "Wigglytuff",
+            "french_name": "Grodoudou",
+            "simplified_name": "Wigglytuff",
+            "simplified_french_name": "Grodoudou",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 40,
+          "regional_dex_number": null,
+          "icon": "wigglytuff",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "jigglypuff"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0040-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          },
+          "secondary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "zubat",
+          "labels": {
+            "name": "Zubat ♂️",
+            "french_name": "Nosferapti ♂️",
+            "simplified_name": "Zubat",
+            "simplified_french_name": "Nosferapti",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 41,
+          "regional_dex_number": null,
+          "icon": "zubat",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "zubat"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0041-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "zubat-f",
+          "labels": {
+            "name": "Zubat ♀",
+            "french_name": "Nosferapti ♀",
+            "simplified_name": "Zubat",
+            "simplified_french_name": "Nosferapti",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 41,
+          "regional_dex_number": null,
+          "icon": "zubat-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "zubat"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0041-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "golbat",
+          "labels": {
+            "name": "Golbat ♂️",
+            "french_name": "Nosferalto ♂️",
+            "simplified_name": "Golbat",
+            "simplified_french_name": "Nosferalto",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 42,
+          "regional_dex_number": null,
+          "icon": "golbat",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "zubat"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0042-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "golbat-f",
+          "labels": {
+            "name": "Golbat ♀",
+            "french_name": "Nosferalto ♀",
+            "simplified_name": "Golbat",
+            "simplified_french_name": "Nosferalto",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 42,
+          "regional_dex_number": null,
+          "icon": "golbat-f",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "zubat"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0042-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "oddish",
+          "labels": {
+            "name": "Oddish",
+            "french_name": "Mystherbe",
+            "simplified_name": "Oddish",
+            "simplified_french_name": "Mystherbe",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 43,
+          "regional_dex_number": null,
+          "icon": "oddish",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0043-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gloom",
+          "labels": {
+            "name": "Gloom ♂️",
+            "french_name": "Ortide ♂️",
+            "simplified_name": "Gloom",
+            "simplified_french_name": "Ortide",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 44,
+          "regional_dex_number": null,
+          "icon": "gloom",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0044-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gloom-f",
+          "labels": {
+            "name": "Gloom ♀",
+            "french_name": "Ortide ♀",
+            "simplified_name": "Gloom",
+            "simplified_french_name": "Ortide",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 44,
+          "regional_dex_number": null,
+          "icon": "gloom-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0044-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "vileplume",
+          "labels": {
+            "name": "Vileplume ♂️",
+            "french_name": "Rafflesia ♂️",
+            "simplified_name": "Vileplume",
+            "simplified_french_name": "Rafflesia",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 45,
+          "regional_dex_number": null,
+          "icon": "vileplume",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0045-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "vileplume-f",
+          "labels": {
+            "name": "Vileplume ♀",
+            "french_name": "Rafflesia ♀",
+            "simplified_name": "Vileplume",
+            "simplified_french_name": "Rafflesia",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 45,
+          "regional_dex_number": null,
+          "icon": "vileplume-f",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "oddish"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0045-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "paras",
+          "labels": {
+            "name": "Paras",
+            "french_name": "Paras",
+            "simplified_name": "Paras",
+            "simplified_french_name": "Paras",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 46,
+          "regional_dex_number": null,
+          "icon": "paras",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "paras"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0046-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "parasect",
+          "labels": {
+            "name": "Parasect",
+            "french_name": "Parasect",
+            "simplified_name": "Parasect",
+            "simplified_french_name": "Parasect",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 47,
+          "regional_dex_number": null,
+          "icon": "parasect",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "paras"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0047-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "venonat",
+          "labels": {
+            "name": "Venonat",
+            "french_name": "Mimitoss",
+            "simplified_name": "Venonat",
+            "simplified_french_name": "Mimitoss",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 48,
+          "regional_dex_number": null,
+          "icon": "venonat",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "venonat"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0048-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "venomoth",
+          "labels": {
+            "name": "Venomoth",
+            "french_name": "Aéromite",
+            "simplified_name": "Venomoth",
+            "simplified_french_name": "Aéromite",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 49,
+          "regional_dex_number": null,
+          "icon": "venomoth",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "venonat"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0049-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "bug",
+            "name": "Bug",
+            "french_name": "Insecte",
+            "color": "#91c22e"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "diglett",
+          "labels": {
+            "name": "Diglett",
+            "french_name": "Taupiqueur",
+            "simplified_name": "Diglett",
+            "simplified_french_name": "Taupiqueur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 50,
+          "regional_dex_number": null,
+          "icon": "diglett",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "diglett"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0050-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "diglett-alola",
+          "labels": {
+            "name": "Diglett-Alola",
+            "french_name": "Taupiqueur d'Alola",
+            "simplified_name": "Diglett",
+            "simplified_french_name": "Taupiqueur",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 50,
+          "regional_dex_number": null,
+          "icon": "diglett-alola",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "diglett"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0050-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dugtrio",
+          "labels": {
+            "name": "Dugtrio",
+            "french_name": "Triopikeur",
+            "simplified_name": "Dugtrio",
+            "simplified_french_name": "Triopikeur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 51,
+          "regional_dex_number": null,
+          "icon": "dugtrio",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "diglett"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0051-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dugtrio-alola",
+          "labels": {
+            "name": "Dugtrio-Alola",
+            "french_name": "Triopikeur d'Alola",
+            "simplified_name": "Dugtrio",
+            "simplified_french_name": "Triopikeur",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 51,
+          "regional_dex_number": null,
+          "icon": "dugtrio-alola",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "diglett"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0051-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meowth",
+          "labels": {
+            "name": "Meowth",
+            "french_name": "Miaouss",
+            "simplified_name": "Meowth",
+            "simplified_french_name": "Miaouss",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 52,
+          "regional_dex_number": null,
+          "icon": "meowth",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0052-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meowth-alola",
+          "labels": {
+            "name": "Meowth-Alola",
+            "french_name": "Miaouss d'Alola",
+            "simplified_name": "Meowth",
+            "simplified_french_name": "Miaouss",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 52,
+          "regional_dex_number": null,
+          "icon": "meowth-alola",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0052-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meowth-galar",
+          "labels": {
+            "name": "Meowth-Galar",
+            "french_name": "Miaouss de Galar",
+            "simplified_name": "Meowth",
+            "simplified_french_name": "Miaouss",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 52,
+          "regional_dex_number": null,
+          "icon": "meowth-galar",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0052-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "meowth-gmax",
+          "labels": {
+            "name": "Gigantamax Meowth",
+            "french_name": "Gigamax Miaouss",
+            "simplified_name": "Meowth",
+            "simplified_french_name": "Miaouss",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 52,
+          "regional_dex_number": null,
+          "icon": "meowth-gmax",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0052-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "persian",
+          "labels": {
+            "name": "Persian",
+            "french_name": "Persian",
+            "simplified_name": "Persian",
+            "simplified_french_name": "Persian",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 53,
+          "regional_dex_number": null,
+          "icon": "persian",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0053-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "persian-alola",
+          "labels": {
+            "name": "Persian-Alola",
+            "french_name": "Persian d'Alola",
+            "simplified_name": "Persian",
+            "simplified_french_name": "Persian",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 53,
+          "regional_dex_number": null,
+          "icon": "persian-alola",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "meowth"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0053-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "psyduck",
+          "labels": {
+            "name": "Psyduck",
+            "french_name": "Psykokwak",
+            "simplified_name": "Psyduck",
+            "simplified_french_name": "Psykokwak",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 54,
+          "regional_dex_number": null,
+          "icon": "psyduck",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "psyduck"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0054-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "golduck",
+          "labels": {
+            "name": "Golduck",
+            "french_name": "Akwakwak",
+            "simplified_name": "Golduck",
+            "simplified_french_name": "Akwakwak",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 55,
+          "regional_dex_number": null,
+          "icon": "golduck",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "psyduck"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0055-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "mankey",
+          "labels": {
+            "name": "Mankey",
+            "french_name": "Férosinge",
+            "simplified_name": "Mankey",
+            "simplified_french_name": "Férosinge",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 56,
+          "regional_dex_number": null,
+          "icon": "mankey",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "mankey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0056-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "primeape",
+          "labels": {
+            "name": "Primeape",
+            "french_name": "Colossinge",
+            "simplified_name": "Primeape",
+            "simplified_french_name": "Colossinge",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 57,
+          "regional_dex_number": null,
+          "icon": "primeape",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "mankey"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0057-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "growlithe",
+          "labels": {
+            "name": "Growlithe",
+            "french_name": "Caninos",
+            "simplified_name": "Growlithe",
+            "simplified_french_name": "Caninos",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 58,
+          "regional_dex_number": null,
+          "icon": "growlithe",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "growlithe"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0058-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "growlithe-hisui",
+          "labels": {
+            "name": "Growlithe-Hisui",
+            "french_name": "Caninos de Hisui",
+            "simplified_name": "Growlithe",
+            "simplified_french_name": "Caninos",
+            "forms_label": "Hisuian",
+            "forms_french_label": "de Hisui"
+          },
+          "national_dex_number": 58,
+          "regional_dex_number": null,
+          "icon": "growlithe-hisui",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "growlithe"
+          },
+          "original_game_bundle": {
+            "slug": "pokemonlegendsarceus"
+          },
+          "order_number": "9999-0058-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "hisuian",
+            "name": "Hisuian",
+            "french_name": "de Hisui"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "arcanine",
+          "labels": {
+            "name": "Arcanine",
+            "french_name": "Arcanin",
+            "simplified_name": "Arcanine",
+            "simplified_french_name": "Arcanin",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 59,
+          "regional_dex_number": null,
+          "icon": "arcanine",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "growlithe"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0059-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "arcanine-hisui",
+          "labels": {
+            "name": "Arcanine-Hisui",
+            "french_name": "Arcanin de Hisui",
+            "simplified_name": "Arcanine",
+            "simplified_french_name": "Arcanin",
+            "forms_label": "Hisuian",
+            "forms_french_label": "de Hisui"
+          },
+          "national_dex_number": 59,
+          "regional_dex_number": null,
+          "icon": "arcanine-hisui",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "growlithe"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0059-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "hisuian",
+            "name": "Hisuian",
+            "french_name": "de Hisui"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "poliwag",
+          "labels": {
+            "name": "Poliwag",
+            "french_name": "Ptitard",
+            "simplified_name": "Poliwag",
+            "simplified_french_name": "Ptitard",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 60,
+          "regional_dex_number": null,
+          "icon": "poliwag",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "poliwag"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0060-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "poliwhirl",
+          "labels": {
+            "name": "Poliwhirl",
+            "french_name": "Têtarte",
+            "simplified_name": "Poliwhirl",
+            "simplified_french_name": "Têtarte",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 61,
+          "regional_dex_number": null,
+          "icon": "poliwhirl",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "poliwag"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0061-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "poliwrath",
+          "labels": {
+            "name": "Poliwrath",
+            "french_name": "Tartard",
+            "simplified_name": "Poliwrath",
+            "simplified_french_name": "Tartard",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 62,
+          "regional_dex_number": null,
+          "icon": "poliwrath",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "poliwag"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0062-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "abra",
+          "labels": {
+            "name": "Abra",
+            "french_name": "Abra",
+            "simplified_name": "Abra",
+            "simplified_french_name": "Abra",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 63,
+          "regional_dex_number": null,
+          "icon": "abra",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "abra"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0063-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kadabra",
+          "labels": {
+            "name": "Kadabra ♂️",
+            "french_name": "Kadabra ♂️",
+            "simplified_name": "Kadabra",
+            "simplified_french_name": "Kadabra",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 64,
+          "regional_dex_number": null,
+          "icon": "kadabra",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "abra"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0064-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kadabra-f",
+          "labels": {
+            "name": "Kadabra ♀",
+            "french_name": "Kadabra ♀",
+            "simplified_name": "Kadabra",
+            "simplified_french_name": "Kadabra",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 64,
+          "regional_dex_number": null,
+          "icon": "kadabra-f",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "abra"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0064-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "alakazam",
+          "labels": {
+            "name": "Alakazam ♂️",
+            "french_name": "Alakazam ♂️",
+            "simplified_name": "Alakazam",
+            "simplified_french_name": "Alakazam",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 65,
+          "regional_dex_number": null,
+          "icon": "alakazam",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "abra"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0065-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "alakazam-f",
+          "labels": {
+            "name": "Alakazam ♀",
+            "french_name": "Alakazam ♀",
+            "simplified_name": "Alakazam",
+            "simplified_french_name": "Alakazam",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 65,
+          "regional_dex_number": null,
+          "icon": "alakazam-f",
+          "family_order": 8,
+          "family_lead": {
+            "slug": "abra"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0065-008",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "machop",
+          "labels": {
+            "name": "Machop",
+            "french_name": "Machoc",
+            "simplified_name": "Machop",
+            "simplified_french_name": "Machoc",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 66,
+          "regional_dex_number": null,
+          "icon": "machop",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "machop"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0066-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "machoke",
+          "labels": {
+            "name": "Machoke",
+            "french_name": "Machopeur",
+            "simplified_name": "Machoke",
+            "simplified_french_name": "Machopeur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 67,
+          "regional_dex_number": null,
+          "icon": "machoke",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "machop"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0067-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "machamp",
+          "labels": {
+            "name": "Machamp",
+            "french_name": "Mackogneur",
+            "simplified_name": "Machamp",
+            "simplified_french_name": "Mackogneur",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 68,
+          "regional_dex_number": null,
+          "icon": "machamp",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "machop"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0068-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "machamp-gmax",
+          "labels": {
+            "name": "Gigantamax Machamp",
+            "french_name": "Gigamax Mackogneur",
+            "simplified_name": "Machamp",
+            "simplified_french_name": "Mackogneur",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 68,
+          "regional_dex_number": null,
+          "icon": "machamp-gmax",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "machop"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0068-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "bellsprout",
+          "labels": {
+            "name": "Bellsprout",
+            "french_name": "Chétiflor",
+            "simplified_name": "Bellsprout",
+            "simplified_french_name": "Chétiflor",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 69,
+          "regional_dex_number": null,
+          "icon": "bellsprout",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "bellsprout"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0069-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "weepinbell",
+          "labels": {
+            "name": "Weepinbell",
+            "french_name": "Boustiflor",
+            "simplified_name": "Weepinbell",
+            "simplified_french_name": "Boustiflor",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 70,
+          "regional_dex_number": null,
+          "icon": "weepinbell",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "bellsprout"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0070-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "victreebel",
+          "labels": {
+            "name": "Victreebel",
+            "french_name": "Empiflor",
+            "simplified_name": "Victreebel",
+            "simplified_french_name": "Empiflor",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 71,
+          "regional_dex_number": null,
+          "icon": "victreebel",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "bellsprout"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0071-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tentacool",
+          "labels": {
+            "name": "Tentacool",
+            "french_name": "Tentacool",
+            "simplified_name": "Tentacool",
+            "simplified_french_name": "Tentacool",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 72,
+          "regional_dex_number": null,
+          "icon": "tentacool",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "tentacool"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0072-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "tentacruel",
+          "labels": {
+            "name": "Tentacruel",
+            "french_name": "Tentacruel",
+            "simplified_name": "Tentacruel",
+            "simplified_french_name": "Tentacruel",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 73,
+          "regional_dex_number": null,
+          "icon": "tentacruel",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "tentacool"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0073-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "geodude",
+          "labels": {
+            "name": "Geodude",
+            "french_name": "Racaillou",
+            "simplified_name": "Geodude",
+            "simplified_french_name": "Racaillou",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 74,
+          "regional_dex_number": null,
+          "icon": "geodude",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0074-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "geodude-alola",
+          "labels": {
+            "name": "Geodude-Alola",
+            "french_name": "Racaillou d'Alola",
+            "simplified_name": "Geodude",
+            "simplified_french_name": "Racaillou",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 74,
+          "regional_dex_number": null,
+          "icon": "geodude-alola",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0074-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "graveler",
+          "labels": {
+            "name": "Graveler",
+            "french_name": "Gravalanch",
+            "simplified_name": "Graveler",
+            "simplified_french_name": "Gravalanch",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 75,
+          "regional_dex_number": null,
+          "icon": "graveler",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0075-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "graveler-alola",
+          "labels": {
+            "name": "Graveler-Alola",
+            "french_name": "Gravalanch d'Alola",
+            "simplified_name": "Graveler",
+            "simplified_french_name": "Gravalanch",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 75,
+          "regional_dex_number": null,
+          "icon": "graveler-alola",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0075-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "golem",
+          "labels": {
+            "name": "Golem",
+            "french_name": "Grolem",
+            "simplified_name": "Golem",
+            "simplified_french_name": "Grolem",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 76,
+          "regional_dex_number": null,
+          "icon": "golem",
+          "family_order": 6,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0076-006",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "golem-alola",
+          "labels": {
+            "name": "Golem-Alola",
+            "french_name": "Grolem d'Alola",
+            "simplified_name": "Golem",
+            "simplified_french_name": "Grolem",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 76,
+          "regional_dex_number": null,
+          "icon": "golem-alola",
+          "family_order": 8,
+          "family_lead": {
+            "slug": "geodude"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0076-008",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ponyta",
+          "labels": {
+            "name": "Ponyta",
+            "french_name": "Ponyta",
+            "simplified_name": "Ponyta",
+            "simplified_french_name": "Ponyta",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 77,
+          "regional_dex_number": null,
+          "icon": "ponyta",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "ponyta"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0077-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "ponyta-galar",
+          "labels": {
+            "name": "Ponyta-Galar",
+            "french_name": "Ponyta de Galar",
+            "simplified_name": "Ponyta",
+            "simplified_french_name": "Ponyta",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 77,
+          "regional_dex_number": null,
+          "icon": "ponyta-galar",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "ponyta"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0077-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rapidash",
+          "labels": {
+            "name": "Rapidash",
+            "french_name": "Galopa",
+            "simplified_name": "Rapidash",
+            "simplified_french_name": "Galopa",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 78,
+          "regional_dex_number": null,
+          "icon": "rapidash",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "ponyta"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0078-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fire",
+            "name": "Fire",
+            "french_name": "Feu",
+            "color": "#ff9d55"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "rapidash-galar",
+          "labels": {
+            "name": "Rapidash-Galar",
+            "french_name": "Galopa de Galar",
+            "simplified_name": "Rapidash",
+            "simplified_french_name": "Galopa",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 78,
+          "regional_dex_number": null,
+          "icon": "rapidash-galar",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "ponyta"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0078-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": {
+            "slug": "fairy",
+            "name": "Fairy",
+            "french_name": "Fée",
+            "color": "#ef8fe7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "slowpoke",
+          "labels": {
+            "name": "Slowpoke",
+            "french_name": "Ramoloss",
+            "simplified_name": "Slowpoke",
+            "simplified_french_name": "Ramoloss",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 79,
+          "regional_dex_number": null,
+          "icon": "slowpoke",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "slowpoke"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0079-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "slowpoke-galar",
+          "labels": {
+            "name": "Slowpoke-Galar",
+            "french_name": "Ramoloss de Galar",
+            "simplified_name": "Slowpoke",
+            "simplified_french_name": "Ramoloss",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 79,
+          "regional_dex_number": null,
+          "icon": "slowpoke-galar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "slowpoke"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0079-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "slowbro",
+          "labels": {
+            "name": "Slowbro",
+            "french_name": "Flagadoss",
+            "simplified_name": "Slowbro",
+            "simplified_french_name": "Flagadoss",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 80,
+          "regional_dex_number": null,
+          "icon": "slowbro",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "slowpoke"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0080-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "slowbro-galar",
+          "labels": {
+            "name": "Slowbro-Galar",
+            "french_name": "Flagadoss de Galar",
+            "simplified_name": "Slowbro",
+            "simplified_french_name": "Flagadoss",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 80,
+          "regional_dex_number": null,
+          "icon": "slowbro-galar",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "slowpoke"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0080-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "magnemite",
+          "labels": {
+            "name": "Magnemite",
+            "french_name": "Magnéti",
+            "simplified_name": "Magnemite",
+            "simplified_french_name": "Magnéti",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 81,
+          "regional_dex_number": null,
+          "icon": "magnemite",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "magnemite"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0081-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "magneton",
+          "labels": {
+            "name": "Magneton",
+            "french_name": "Magnéton",
+            "simplified_name": "Magneton",
+            "simplified_french_name": "Magnéton",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 82,
+          "regional_dex_number": null,
+          "icon": "magneton",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "magnemite"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0082-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "steel",
+            "name": "Steel",
+            "french_name": "Acier",
+            "color": "#598fa2"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "farfetchd",
+          "labels": {
+            "name": "Farfetch'd",
+            "french_name": "Canarticho",
+            "simplified_name": "Farfetch'd",
+            "simplified_french_name": "Canarticho",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 83,
+          "regional_dex_number": null,
+          "icon": "farfetchd",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "farfetchd"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0083-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "farfetchd-galar",
+          "labels": {
+            "name": "Farfetch'd-Galar",
+            "french_name": "Canarticho de Galar",
+            "simplified_name": "Farfetch'd",
+            "simplified_french_name": "Canarticho",
+            "forms_label": "Galarian",
+            "forms_french_label": "de Galar"
+          },
+          "national_dex_number": 83,
+          "regional_dex_number": null,
+          "icon": "farfetchd-galar",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "farfetchd"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0083-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "galarian",
+            "name": "Galarian",
+            "french_name": "de Galar"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "fighting",
+            "name": "Fighting",
+            "french_name": "Combat",
+            "color": "#cf4069"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "doduo",
+          "labels": {
+            "name": "Doduo ♂️",
+            "french_name": "Doduo ♂️",
+            "simplified_name": "Doduo",
+            "simplified_french_name": "Doduo",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 84,
+          "regional_dex_number": null,
+          "icon": "doduo",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "doduo"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0084-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "doduo-f",
+          "labels": {
+            "name": "Doduo ♀",
+            "french_name": "Doduo ♀",
+            "simplified_name": "Doduo",
+            "simplified_french_name": "Doduo",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 84,
+          "regional_dex_number": null,
+          "icon": "doduo-f",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "doduo"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0084-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dodrio",
+          "labels": {
+            "name": "Dodrio ♂️",
+            "french_name": "Dodrio ♂️",
+            "simplified_name": "Dodrio",
+            "simplified_french_name": "Dodrio",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 85,
+          "regional_dex_number": null,
+          "icon": "dodrio",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "doduo"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0085-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dodrio-f",
+          "labels": {
+            "name": "Dodrio ♀",
+            "french_name": "Dodrio ♀",
+            "simplified_name": "Dodrio",
+            "simplified_french_name": "Dodrio",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 85,
+          "regional_dex_number": null,
+          "icon": "dodrio-f",
+          "family_order": 5,
+          "family_lead": {
+            "slug": "doduo"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0085-005",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "normal",
+            "name": "Normal",
+            "french_name": "Normal",
+            "color": "#9199a1"
+          },
+          "secondary": {
+            "slug": "flying",
+            "name": "Flying",
+            "french_name": "Vol",
+            "color": "#8ea9df"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "seel",
+          "labels": {
+            "name": "Seel",
+            "french_name": "Otaria",
+            "simplified_name": "Seel",
+            "simplified_french_name": "Otaria",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 86,
+          "regional_dex_number": null,
+          "icon": "seel",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "seel"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0086-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "dewgong",
+          "labels": {
+            "name": "Dewgong",
+            "french_name": "Lamantine",
+            "simplified_name": "Dewgong",
+            "simplified_french_name": "Lamantine",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 87,
+          "regional_dex_number": null,
+          "icon": "dewgong",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "seel"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0087-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "grimer",
+          "labels": {
+            "name": "Grimer",
+            "french_name": "Tadmorv",
+            "simplified_name": "Grimer",
+            "simplified_french_name": "Tadmorv",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 88,
+          "regional_dex_number": null,
+          "icon": "grimer",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "grimer"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0088-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "grimer-alola",
+          "labels": {
+            "name": "Grimer-Alola",
+            "french_name": "Tadmorv d'Alola",
+            "simplified_name": "Grimer",
+            "simplified_french_name": "Tadmorv",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 88,
+          "regional_dex_number": null,
+          "icon": "grimer-alola",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "grimer"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0088-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "muk",
+          "labels": {
+            "name": "Muk",
+            "french_name": "Grotadmorv",
+            "simplified_name": "Muk",
+            "simplified_french_name": "Grotadmorv",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 89,
+          "regional_dex_number": null,
+          "icon": "muk",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "grimer"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0089-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "muk-alola",
+          "labels": {
+            "name": "Muk-Alola",
+            "french_name": "Grotadmorv d'Alola",
+            "simplified_name": "Muk",
+            "simplified_french_name": "Grotadmorv",
+            "forms_label": "Alolan",
+            "forms_french_label": "d'Alola"
+          },
+          "national_dex_number": 89,
+          "regional_dex_number": null,
+          "icon": "muk-alola",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "grimer"
+          },
+          "original_game_bundle": {
+            "slug": "sunmoon"
+          },
+          "order_number": "9999-0089-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "alolan",
+            "name": "Alolan",
+            "french_name": "d'Alola"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          },
+          "secondary": {
+            "slug": "dark",
+            "name": "Dark",
+            "french_name": "Ténèbre",
+            "color": "#595265"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "shellder",
+          "labels": {
+            "name": "Shellder",
+            "french_name": "Kokiyas",
+            "simplified_name": "Shellder",
+            "simplified_french_name": "Kokiyas",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 90,
+          "regional_dex_number": null,
+          "icon": "shellder",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "shellder"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0090-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "cloyster",
+          "labels": {
+            "name": "Cloyster",
+            "french_name": "Crustabri",
+            "simplified_name": "Cloyster",
+            "simplified_french_name": "Crustabri",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 91,
+          "regional_dex_number": null,
+          "icon": "cloyster",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "shellder"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0091-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": {
+            "slug": "ice",
+            "name": "Ice",
+            "french_name": "Glace",
+            "color": "#71cfbe"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gastly",
+          "labels": {
+            "name": "Gastly",
+            "french_name": "Fantominus",
+            "simplified_name": "Gastly",
+            "simplified_french_name": "Fantominus",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 92,
+          "regional_dex_number": null,
+          "icon": "gastly",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "gastly"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0092-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "haunter",
+          "labels": {
+            "name": "Haunter",
+            "french_name": "Spectrum",
+            "simplified_name": "Haunter",
+            "simplified_french_name": "Spectrum",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 93,
+          "regional_dex_number": null,
+          "icon": "haunter",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "gastly"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0093-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gengar",
+          "labels": {
+            "name": "Gengar",
+            "french_name": "Ectoplasma",
+            "simplified_name": "Gengar",
+            "simplified_french_name": "Ectoplasma",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 94,
+          "regional_dex_number": null,
+          "icon": "gengar",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "gastly"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0094-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "gengar-gmax",
+          "labels": {
+            "name": "Gigantamax Gengar",
+            "french_name": "Gigamax Ectoplasma",
+            "simplified_name": "Gengar",
+            "simplified_french_name": "Ectoplasma",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 94,
+          "regional_dex_number": null,
+          "icon": "gengar-gmax",
+          "family_order": 7,
+          "family_lead": {
+            "slug": "gastly"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0094-007",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "ghost",
+            "name": "Ghost",
+            "french_name": "Spectre",
+            "color": "#5568aa"
+          },
+          "secondary": {
+            "slug": "poison",
+            "name": "Poison",
+            "french_name": "Poison",
+            "color": "#aa6ac7"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "onix",
+          "labels": {
+            "name": "Onix",
+            "french_name": "Onix",
+            "simplified_name": "Onix",
+            "simplified_french_name": "Onix",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 95,
+          "regional_dex_number": null,
+          "icon": "onix",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "onix"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0095-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "rock",
+            "name": "Rock",
+            "french_name": "Roche",
+            "color": "#c7b78a"
+          },
+          "secondary": {
+            "slug": "ground",
+            "name": "Ground",
+            "french_name": "Sol",
+            "color": "#db7645"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "drowzee",
+          "labels": {
+            "name": "Drowzee",
+            "french_name": "Soporifik",
+            "simplified_name": "Drowzee",
+            "simplified_french_name": "Soporifik",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 96,
+          "regional_dex_number": null,
+          "icon": "drowzee",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "drowzee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0096-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hypno",
+          "labels": {
+            "name": "Hypno ♂️",
+            "french_name": "Hypnomade ♂️",
+            "simplified_name": "Hypno",
+            "simplified_french_name": "Hypnomade",
+            "forms_label": "♂️",
+            "forms_french_label": "♂️"
+          },
+          "national_dex_number": 97,
+          "regional_dex_number": null,
+          "icon": "hypno",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "drowzee"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0097-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "hypno-f",
+          "labels": {
+            "name": "Hypno ♀",
+            "french_name": "Hypnomade ♀",
+            "simplified_name": "Hypno",
+            "simplified_french_name": "Hypnomade",
+            "forms_label": "♀️",
+            "forms_french_label": "♀️"
+          },
+          "national_dex_number": 97,
+          "regional_dex_number": null,
+          "icon": "hypno-f",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "drowzee"
+          },
+          "original_game_bundle": {
+            "slug": "diamondpearlplatinium"
+          },
+          "order_number": "9999-0097-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": {
+            "slug": "gender",
+            "name": "Gender",
+            "french_name": "Genre"
+          }
+        },
+        "types": {
+          "primary": {
+            "slug": "psychic",
+            "name": "Psychic",
+            "french_name": "Psy",
+            "color": "#fb7075"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "krabby",
+          "labels": {
+            "name": "Krabby",
+            "french_name": "Krabby",
+            "simplified_name": "Krabby",
+            "simplified_french_name": "Krabby",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 98,
+          "regional_dex_number": null,
+          "icon": "krabby",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "krabby"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0098-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kingler",
+          "labels": {
+            "name": "Kingler",
+            "french_name": "Krabboss",
+            "simplified_name": "Kingler",
+            "simplified_french_name": "Krabboss",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 99,
+          "regional_dex_number": null,
+          "icon": "kingler",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "krabby"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0099-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "kingler-gmax",
+          "labels": {
+            "name": "Gigantamax Kingler",
+            "french_name": "Gigamax Krabboss",
+            "simplified_name": "Kingler",
+            "simplified_french_name": "Krabboss",
+            "forms_label": "Gigantamax",
+            "forms_french_label": "Gigamax"
+          },
+          "national_dex_number": 99,
+          "regional_dex_number": null,
+          "icon": "kingler-gmax",
+          "family_order": 2,
+          "family_lead": {
+            "slug": "krabby"
+          },
+          "original_game_bundle": {
+            "slug": "swordshield"
+          },
+          "order_number": "9999-0099-002",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": {
+            "slug": "gigantamax",
+            "name": "Gigantamax",
+            "french_name": "Gigamax"
+          },
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "water",
+            "name": "Water",
+            "french_name": "Eau",
+            "color": "#4d91d7"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "voltorb",
+          "labels": {
+            "name": "Voltorb",
+            "french_name": "Voltorbe",
+            "simplified_name": "Voltorb",
+            "simplified_french_name": "Voltorbe",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 100,
+          "regional_dex_number": null,
+          "icon": "voltorb",
+          "family_order": 0,
+          "family_lead": {
+            "slug": "voltorb"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0100-000",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "voltorb-hisui",
+          "labels": {
+            "name": "Voltorb-Hisui",
+            "french_name": "Voltorbe de Hisui",
+            "simplified_name": "Voltorb",
+            "simplified_french_name": "Voltorbe",
+            "forms_label": "Hisuian",
+            "forms_french_label": "de Hisui"
+          },
+          "national_dex_number": 100,
+          "regional_dex_number": null,
+          "icon": "voltorb-hisui",
+          "family_order": 1,
+          "family_lead": {
+            "slug": "voltorb"
+          },
+          "original_game_bundle": {
+            "slug": "pokemonlegendsarceus"
+          },
+          "order_number": "9999-0100-001",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "hisuian",
+            "name": "Hisuian",
+            "french_name": "de Hisui"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": {
+            "slug": "grass",
+            "name": "Grass",
+            "french_name": "Plante",
+            "color": "#61bb59"
+          }
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "electrode",
+          "labels": {
+            "name": "Electrode",
+            "french_name": "Électrode",
+            "simplified_name": "Electrode",
+            "simplified_french_name": "Électrode",
+            "forms_label": "",
+            "forms_french_label": ""
+          },
+          "national_dex_number": 101,
+          "regional_dex_number": null,
+          "icon": "electrode",
+          "family_order": 3,
+          "family_lead": {
+            "slug": "voltorb"
+          },
+          "original_game_bundle": {
+            "slug": "redgreenblueyellow"
+          },
+          "order_number": "9999-0101-003",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": null,
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      },
+      {
+        "pokemon": {
+          "slug": "electrode-hisui",
+          "labels": {
+            "name": "Electrode-Hisui",
+            "french_name": "Électrode de Hisui",
+            "simplified_name": "Electrode",
+            "simplified_french_name": "Électrode",
+            "forms_label": "Hisuian",
+            "forms_french_label": "de Hisui"
+          },
+          "national_dex_number": 101,
+          "regional_dex_number": null,
+          "icon": "electrode-hisui",
+          "family_order": 4,
+          "family_lead": {
+            "slug": "voltorb"
+          },
+          "original_game_bundle": {
+            "slug": "pokemonlegendsarceus"
+          },
+          "order_number": "9999-0101-004",
+          "game_bundles": {
+            "normal": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ],
+            "shiny": [
+              {
+                "slug": "redgreenblueyellow"
+              },
+              {
+                "slug": "goldsilvercrystal"
+              },
+              {
+                "slug": "rubysapphireemerald"
+              },
+              {
+                "slug": "fireredleafgreen"
+              },
+              {
+                "slug": "diamondpearlplatinium"
+              },
+              {
+                "slug": "heartgoldsoulsilver"
+              },
+              {
+                "slug": "blackwhite"
+              },
+              {
+                "slug": "black2white2"
+              },
+              {
+                "slug": "xy"
+              },
+              {
+                "slug": "omegarubyalphasapphire"
+              },
+              {
+                "slug": "sunmoon"
+              },
+              {
+                "slug": "ultrasunultramoon"
+              },
+              {
+                "slug": "letsgopikachuletsgoeevee"
+              },
+              {
+                "slug": "pokemongo"
+              },
+              {
+                "slug": "swordshield"
+              },
+              {
+                "slug": "swordshieldexpansionpass"
+              },
+              {
+                "slug": "brilliantdiamondshiningpearl"
+              },
+              {
+                "slug": "pokemonlegendsarceus"
+              },
+              {
+                "slug": "scarletviolet"
+              },
+              {
+                "slug": "scarletvioletthehiddentreasureofareazero"
+              }
+            ]
+          }
+        },
+        "catch_state": null,
+        "forms": {
+          "category": null,
+          "regional": {
+            "slug": "hisuian",
+            "name": "Hisuian",
+            "french_name": "de Hisui"
+          },
+          "special": null,
+          "variant": null
+        },
+        "types": {
+          "primary": {
+            "slug": "electric",
+            "name": "Electric",
+            "french_name": "Electrik",
+            "color": "#f3d33c"
+          },
+          "secondary": null
+        }
+      }
+    ],
+    "report": {
+      "total": 151,
+      "total_caught": 1,
+      "total_uncaught": 150,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 1
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 150
+        }
+      ]
+    },
+    "filtered_report": {
+      "total": 151,
+      "total_caught": 1,
+      "total_uncaught": 150,
+      "detail": [
+        {
+          "catch_state": {
+            "name": "Yes",
+            "french_name": "Oui",
+            "slug": "yes",
+            "color": "#66bb6a"
+          },
+          "count": 1
+        },
+        {
+          "catch_state": {
+            "name": "No",
+            "french_name": "Non",
+            "slug": "no",
+            "color": "#e57373"
+          },
+          "count": 150
+        }
+      ]
+    }
+  },
+  "filters": []
+}

--- a/tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json
+++ b/tests/resources/moco/Back/responses/dex/77de68daecd823babbb58edb1c8e14d7106e83bb.json
@@ -24,6 +24,10 @@
         {
           "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" },
           "count": 1
+        },
+        {
+          "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" },
+          "count": 3
         }
       ]
     }

--- a/tests/resources/moco/Back/responses/dex/admin.json
+++ b/tests/resources/moco/Back/responses/dex/admin.json
@@ -5,15 +5,10 @@
     "flags": { "is_shiny": true, "is_private": true, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": false, "is_custom": false },
     "report": {
       "total": 151,
-      "total_caught": 90,
-      "total_uncaught": 20,
+      "total_caught": 0,
+      "total_uncaught": 151,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 90 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 8 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 8 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 10 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 15 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 20 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 151 }
       ]
     }
   },
@@ -22,16 +17,11 @@
     "settings": { "name": "Gold, Silver, Crystal", "french_name": "Or, Argent, Cristal", "slug": "goldsilvercrystal", "display_template": "box" },
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": false, "is_premium": false, "is_custom": false },
     "report": {
-      "total": 251,
-      "total_caught": 140,
-      "total_uncaught": 40,
+      "total": 278,
+      "total_caught": 0,
+      "total_uncaught": 278,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 140 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 11 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 15 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 20 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 25 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 40 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 278 }
       ]
     }
   },
@@ -292,16 +282,11 @@
     "settings": { "name": "Home", "french_name": "Home", "slug": "home", "display_template": "box" },
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": false, "is_custom": false },
     "report": {
-      "total": 151,
-      "total_caught": 68,
-      "total_uncaught": 30,
+      "total": 1477,
+      "total_caught": 0,
+      "total_uncaught": 1477,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 68 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 8 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 10 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 15 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 20 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 30 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 1477 }
       ]
     }
   },
@@ -311,15 +296,11 @@
     "flags": { "is_shiny": true, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": true, "is_custom": false },
     "report": {
       "total": 151,
-      "total_caught": 0,
-      "total_uncaught": 140,
+      "total_caught": 1,
+      "total_uncaught": 150,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 0 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 1 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 2 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 3 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 5 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 140 }
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 1 },
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 150 }
       ]
     }
   },
@@ -347,14 +328,11 @@
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": true, "is_custom": false },
     "report": {
       "total": 50,
-      "total_caught": 15,
+      "total_caught": 25,
       "total_uncaught": 10,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 15 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 5 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 5 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 7 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 8 },
+        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 25 },
+        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 15 },
         { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 10 }
       ]
     }
@@ -364,16 +342,11 @@
     "settings": { "name": "Mega", "french_name": "Méga", "slug": "mega", "display_template": "list-3" },
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": true, "is_custom": false },
     "report": {
-      "total": 46,
-      "total_caught": 21,
-      "total_uncaught": 5,
+      "total": 50,
+      "total_caught": 0,
+      "total_uncaught": 50,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 21 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 5 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 5 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 5 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 5 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 5 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 50 }
       ]
     }
   }

--- a/tests/resources/moco/Back/responses/dex/trainer.json
+++ b/tests/resources/moco/Back/responses/dex/trainer.json
@@ -69,16 +69,11 @@
     "settings": { "name": "Sword, Shield", "french_name": "Épée, Bouclier", "slug": "swordshield", "display_template": "box" },
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": false, "is_custom": false },
     "report": {
-      "total": 400,
-      "total_caught": 50,
-      "total_uncaught": 140,
+      "total": 935,
+      "total_caught": 0,
+      "total_uncaught": 935,
       "detail": [
-        { "catch_state": { "name": "Yes", "french_name": "Oui", "slug": "yes", "color": "#66bb6a" }, "count": 50 },
-        { "catch_state": { "name": "To trade", "french_name": "À échanger", "slug": "totrade", "color": "#ff9100" }, "count": 30 },
-        { "catch_state": { "name": "To transfer", "french_name": "à transférer", "slug": "totransfer", "color": "#ffd54f" }, "count": 50 },
-        { "catch_state": { "name": "To breed", "french_name": "af. reproduire", "slug": "tobreed", "color": "#4fc3f7" }, "count": 60 },
-        { "catch_state": { "name": "To evolve", "french_name": "af. évoluer", "slug": "toevolve", "color": "#9575cd" }, "count": 70 },
-        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 140 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 935 }
       ]
     }
   },
@@ -97,12 +92,11 @@
     "settings": { "name": "Home", "french_name": "Home", "slug": "home", "display_template": "box" },
     "flags": { "is_shiny": false, "is_private": false, "is_on_home": true, "is_display_form": true, "is_released": true, "is_premium": false, "is_custom": false },
     "report": {
-      "total": 151,
-      "total_caught": 88,
-      "total_uncaught": 63,
+      "total": 1477,
+      "total_caught": 0,
+      "total_uncaught": 1477,
       "detail": [
-        { "catch_state": { "name": "Caught", "french_name": "Attrapé", "slug": "yes", "color": "#198754" }, "count": 88 },
-        { "catch_state": { "name": "Not caught", "french_name": "Pas attrapé", "slug": "no", "color": "#dc3545" }, "count": 63 }
+        { "catch_state": { "name": "No", "french_name": "Non", "slug": "no", "color": "#e57373" }, "count": 1477 }
       ]
     }
   },

--- a/tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
+++ b/tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
@@ -10,6 +10,7 @@ use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * @internal
@@ -53,7 +54,7 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.dex_is_custom');
 
         $firstAlbum = $crawler->filter('.dex-item')->first();
-        $this->assertEquals('Épée, Bouclier 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('Épée, Bouclier 100%', $firstAlbum->text());
         $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
         $this->assertEquals('https://icon.pokenini.fr/banner/swordshield.png', $firstAlbum->filter('img')->attr('src'));
 
@@ -63,11 +64,10 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertEquals('https://icon.pokenini.fr/banner/homeshiny.png', $secondAlbum->filter('img')->attr('src'));
 
         $this->assertCountFilter($crawler, 5, '.dex-item .progress');
-        $this->assertCountFilter($crawler, 14, '.dex-item .progress-bar');
+        $this->assertCountFilter($crawler, 8, '.dex-item .progress-bar');
 
         $homeAlbum = $crawler->filter('.dex-item')->eq(1);
-        $this->assertEquals('41.72%', $homeAlbum->filter('.progress-bar.catch-state-no')->text());
-        $this->assertEquals('58.28%', $homeAlbum->filter('.progress-bar.catch-state-yes')->text());
+        $this->assertEquals('100%', $homeAlbum->filter('.progress-bar.catch-state-no')->text());
 
         $megaAlbum = $crawler->filter('.dex-item')->eq(5);
         $this->assertCountFilter($megaAlbum, 0, '.progress');
@@ -76,6 +76,33 @@ final class AlbumDexListTest extends WebTestCase
 
         $this->assertStringNotContainsString('const catchStates = JSON.parse', $crawler->outerHtml());
         $this->assertStringNotContainsString('watchCatchStates();', $crawler->outerHtml());
+    }
+
+    public function testAlbumDexListTilesAreAllClickable(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/dex');
+
+        $this->assertResponseIsSuccessful();
+
+        $hrefs = array_unique(array_filter($crawler->filter('.dex-item a')->each(
+            static fn (Crawler $node): ?string => $node->attr('href')
+        )));
+
+        self::assertNotEmpty($hrefs);
+
+        foreach ($hrefs as $href) {
+            $client->request('GET', $href);
+            self::assertTrue(
+                $client->getResponse()->isSuccessful(),
+                sprintf('Expected %s to be reachable, got status %d', $href, $client->getResponse()->getStatusCode())
+            );
+        }
     }
 
     public function testNonConnectedHome(): void
@@ -199,7 +226,7 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.dex-item h3');
 
         $firstAlbum = $crawler->filter('.dex-item')->first();
-        $this->assertEquals('Épée, Bouclier 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('Épée, Bouclier 100%', $firstAlbum->text());
         $this->assertEquals('/fr/album/swordshield', $firstAlbum->filter('a')->attr('href'));
 
         $secondAlbum = $crawler->filter('.dex-item')->eq(2);
@@ -247,7 +274,7 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.dex-item h3');
 
         $firstAlbum = $crawler->filter('.dex-item')->first();
-        $this->assertEquals('Sword, Shield 12.5% 35%', $firstAlbum->text());
+        $this->assertEquals('Sword, Shield 100%', $firstAlbum->text());
         $this->assertEquals('/en/album/swordshield', $firstAlbum->filter('a')->attr('href'));
 
         $secondAlbum = $crawler->filter('.dex-item')->eq(2);
@@ -287,5 +314,8 @@ final class AlbumDexListTest extends WebTestCase
         // uniquely identifies this trainer_dex row, so navigation must use it.
         $this->assertEquals('/fr/album/home-shiny-custom', $album->filter('a')->attr('href'));
         $this->assertEquals('https://icon.pokenini.fr/banner/homeshiny.png', $album->filter('img')->attr('src'));
+
+        $client->request('GET', '/fr/album/home-shiny-custom');
+        self::assertTrue($client->getResponse()->isSuccessful());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes 4 home-page dex tiles that linked to a pokedex page returning 404 (`homeshiny`, `homepogo`, `alpha`, `home-shiny-custom` had no backing moco route/fixture)
- Fixes 2 tiles (`swordshield`, `home` on the default trainer, plus their shared counterparts in `admin.json`) whose progress percentage didn't match the real data behind the page they linked to — recomputed from the actual pokemon lists instead of hand-typed fiction
- Adds `testAlbumDexListTilesAreAllClickable`, a regression test that actually follows every home-tile link (previously only the href *text* was asserted, never requested)

See `docs/superpowers/specs/2026-07-13-mock-coherence-design.md` for the design and `docs/superpowers/plans/2026-07-13-mock-coherence-implementation.md` for the task-by-task implementation plan.

## Test plan
- [x] `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/` — 91/91 passing
- [x] `docker compose exec php php vendor/bin/phpunit --group api-mocked-testing` — 222/222 passing
- [x] Chrome + Firefox browser suites — 45/45 passing each
- [x] `make a` (infra-quality, code-quality, tests, measures incl. 100% coverage/MSI, security) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNKYwLHWv4jGEVJYXK89Kr