### PR TITLE
Add admin button to trigger the update_images pipeline

### DIFF
--- a/docs/superpowers/plans/2026-07-14-trigger-images-admin-button.md
+++ b/docs/superpowers/plans/2026-07-14-trigger-images-admin-button.md
@@ -1,0 +1,417 @@
+# Trigger Images Admin Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a button on `/istration/actions` that calls `pokenini-back`'s new `update_images` trigger endpoint, following the existing update/calculate/invalidate button pattern.
+
+**Architecture:** A 4th verb (`trigger`) alongside the existing `update`/`calculate`/`invalidate` methods on `AdminActionController`, reusing the already-generic `AdminActionService::execute()` (no change needed there) and the existing `admin.action(...)` Twig macro (no change needed there either — it already degrades gracefully when `actionLogsData` has no matching entry, which is always true for this action since `pokenini-api` never logs it).
+
+**Tech Stack:** Symfony 8.0 / PHP ≥ 8.5, Twig, PHPUnit, Moco (HTTP mock server) for integration tests.
+
+## Global Constraints
+
+- `declare(strict_types=1)` in every new/modified PHP file (workspace-wide convention). `AdminActionController` is already `final`.
+- 100% line coverage and 100% Mutation Score Index are required (`make measures`); `make quality` must be green.
+- The response means "GitHub accepted the dispatch", not "images are updated" — any user-facing copy must not imply completion (see companion spec, "Fire-and-forget, deliberately"). This plan does not add custom flash-message copy beyond what the existing macro already renders (the existing `admin.actions.*.cta` / `.title` translation strings are short button labels, not status copy — see Task 2).
+- Companion spec: `docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md` (this repo).
+- Companion plan this depends on for the endpoint contract (must exist first — this task only needs its documented contract, not the running code, to write and test against): `../pokenini-back/docs/superpowers/plans/2026-07-14-trigger-images-pipeline-endpoint.md` — route `POST /istration/action/trigger/{name}` (condition `name in ['update_images']`), response `{"action":"trigger","item":"update_images","state":"ok"|"ko","content":"","error":"..."}`, status `202`/`500`.
+
+---
+
+### Task 1: `AdminActionController::trigger()` — the new admin action verb
+
+**Files:**
+- Modify: `src/Controller/AdminActionController.php`
+- Modify: `tests/src/Unit/Controller/AdminActionControllerTest.php`
+
+**Interfaces:**
+- Consumes: `AdminActionService::execute(string $action, string $item, string $method): AdminAction` (existing, unchanged).
+- Produces: `AdminActionController::trigger(string $name, Request $request): RedirectResponse`, route `POST /{_locale}/istration/action/trigger/{name}` (condition `name in ['update_images']`), CSRF token id `admin_trigger`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three test methods to `tests/src/Unit/Controller/AdminActionControllerTest.php`, right after `testInvalidateReportsRedirectsToReportsPage` and before the `private function assertFailActionLogs` method:
+
+```php
+    public function testTriggerAction(): void
+    {
+        $adminActionService = $this->createMock(AdminActionService::class);
+        $adminActionService
+            ->expects($this->once())
+            ->method('execute')
+            ->with('trigger', 'update_images')
+            ->willReturn(new AdminAction('trigger', 'update_images', 'ok', '', ''))
+        ;
+
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('set')
+        ;
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack
+            ->expects($this->once())
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->never())
+            ->method('critical')
+        ;
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(AdminActionSucceededEvent::class))
+        ;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('app_admin_actions', ['_fragment' => 'trigger_update_images'])
+            ->willReturn('/admin')
+        ;
+
+        $csrfManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfManager->method('isTokenValid')->willReturn(true);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.csrf.token_manager')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['security.csrf.token_manager', $csrfManager],
+                ['router', $router],
+            ])
+        ;
+
+        $controller = new AdminActionController(
+            $adminActionService,
+            $requestStack,
+            $logger,
+            $eventDispatcher,
+        );
+        $controller->setContainer($container);
+
+        $response = $controller->trigger('update_images', new Request([], ['_token' => 'valid_token']));
+
+        $this->assertSame('/admin', $response->getTargetUrl());
+    }
+
+    public function testFailTriggerLogs(): void
+    {
+        $controller = $this->assertFailActionLogs('trigger');
+
+        $controller->trigger('update_images', new Request([], ['_token' => 'valid_token']));
+    }
+
+    public function testTriggerInvalidCsrfToken(): void
+    {
+        $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfManager
+            ->expects($this->once())
+            ->method('isTokenValid')
+            ->willReturn(false)
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.csrf.token_manager')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->willReturnMap([['security.csrf.token_manager', $csrfManager]])
+        ;
+
+        $adminActionService = $this->createMock(AdminActionService::class);
+        $adminActionService
+            ->expects($this->never())
+            ->method('execute')
+        ;
+
+        $controller = new AdminActionController(
+            $adminActionService,
+            $this->createStub(RequestStack::class),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(EventDispatcherInterface::class),
+        );
+        $controller->setContainer($container);
+
+        $this->expectException(AccessDeniedException::class);
+        $controller->trigger('update_images', new Request([], ['_token' => 'bad_token']));
+    }
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter 'testTriggerAction|testFailTriggerLogs|testTriggerInvalidCsrfToken' tests/src/Unit/Controller/AdminActionControllerTest.php`
+Expected: FAIL — `Call to undefined method App\Controller\AdminActionController::trigger()`.
+
+- [ ] **Step 3: Add the `trigger()` method**
+
+In `src/Controller/AdminActionController.php`, add this method right after `invalidate()` and before the `private function execute(...)` method:
+
+```php
+    #[Route(
+        '/trigger/{name}',
+        methods: ['POST'],
+        condition: "params['name']
+            in [
+                'update_images',
+            ]"
+    )]
+    public function trigger(
+        string $name,
+        Request $request,
+    ): RedirectResponse {
+        if (!$this->isCsrfTokenValid('admin_trigger', $request->request->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        return $this->execute($name, 'trigger', 'POST');
+    }
+```
+
+No new `use` imports are needed — `Route`, `Request`, and `RedirectResponse` are already imported for the other three methods.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Unit/Controller/AdminActionControllerTest.php`
+Expected: `OK (11 tests, ...)` (8 existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Controller/AdminActionController.php tests/src/Unit/Controller/AdminActionControllerTest.php
+git commit -m "Add trigger() admin action verb for the update_images button"
+```
+
+---
+
+### Task 2: Template and translations — render the button
+
+**Files:**
+- Modify: `templates/Admin/_actions.html.twig`
+- Modify: `translations/messages+intl-icu.en.yaml`
+- Modify: `translations/messages+intl-icu.fr.yaml`
+
+**Interfaces:**
+- Consumes: the existing `admin.action(action, actionPrefix, item, icon, updatedItem, updatedAction, updatedState, actionLogsData)` macro from `Admin/_macros.html.twig` (no changes to the macro itself — see Global Constraints / companion spec).
+
+- [ ] **Step 1: Add the new section to `_actions.html.twig`**
+
+Append this block at the end of the file (after the existing "invalidate_data" `<div class="row px-4 py-5">...</div>` block):
+
+```twig
+
+<div class="row px-4 py-5">
+  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
+  {% set triggerPipelineItems = {
+    'update_images': 'images',
+  } %}
+  {% for item, icon in triggerPipelineItems %}
+    {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+  {% endfor %}
+</div>
+```
+
+- [ ] **Step 2: Add English translation keys**
+
+In `translations/messages+intl-icu.en.yaml`, find the `invalidate_data:` block under `admin: actions:` (it ends with the `actions:` sub-key's `cta: "Invalidate!"` line, right before the `reports_data:` key). Insert this new block immediately after it, at the same 4-space indent as `update_data:`/`calculate_data:`/`invalidate_data:`:
+
+```yaml
+    trigger_pipeline:
+      title: "Trigger pipelines"
+      update_images:
+        title: "Update Pokémon images"
+        cta: "Trigger!"
+```
+
+- [ ] **Step 3: Add French translation keys**
+
+In `translations/messages+intl-icu.fr.yaml`, in the equivalent spot (right after the `invalidate_data:` block's `actions:` sub-key `cta: "Invalider"` line, right before `reports_data:`):
+
+```yaml
+    trigger_pipeline:
+      title: "Déclenchement de pipelines"
+      update_images:
+        title: "Mettre à jour les images des Pokémon"
+        cta: "Déclencher"
+```
+
+- [ ] **Step 4: Validate the YAML and Twig**
+
+Run: `make jsonlint` (also lints YAML in this project's Makefile target) — if that target only covers JSON, instead run:
+```bash
+docker compose exec php php -r "Symfony\Component\Yaml\Yaml::parseFile('translations/messages+intl-icu.en.yaml'); Symfony\Component\Yaml\Yaml::parseFile('translations/messages+intl-icu.fr.yaml'); echo 'VALID';"
+```
+Expected: `VALID` printed, no exception.
+
+- [ ] **Step 5: Manually verify the button renders**
+
+Run: `make start` (if not already running), then visit `http://localhost/fr/connect/f/c?t=admin` followed by `http://localhost/fr/istration/actions`.
+Expected: a new "Déclenchement de pipelines" section appears with one button, "Mettre à jour les images des Pokémon" / "Déclencher".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/Admin/_actions.html.twig translations/messages+intl-icu.en.yaml translations/messages+intl-icu.fr.yaml
+git commit -m "Render the update_images trigger button on the admin actions page"
+```
+
+---
+
+### Task 3: Integration test against a Moco fixture
+
+**Files:**
+- Modify: `tests/resources/moco/Back/moco.json`
+- Create: `tests/src/Integration/Controller/Admin/ActionTriggerTest.php`
+
+**Interfaces:**
+- Consumes: `GetUserToken::getFakeUserToken()`, `TestNavTrait` (existing test utilities, same as `ActionUpdateTest.php`).
+
+- [ ] **Step 1: Add the Moco fixture entry**
+
+In `tests/resources/moco/Back/moco.json`, insert this entry right after the `/istration/action/invalidate/reports` entry and before the `/istration/reports` entry (matching the existing entries' exact shape):
+
+```json
+  {
+    "request": {
+      "uri": {
+        "match": "/istration/action/trigger/update_images"
+      },
+      "method": "post",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "202",
+      "json": {
+        "action": "trigger",
+        "item": "update_images",
+        "state": "ok",
+        "content": "",
+        "error": ""
+      }
+    }
+  },
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `tests/src/Integration/Controller/Admin/ActionTriggerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller\Admin;
+
+use App\Controller\AdminActionController;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(AdminActionController::class)]
+#[Group('api-mocked-testing')]
+final class ActionTriggerTest extends WebTestCase
+{
+    use TestNavTrait;
+
+    public function testAdminTriggerUpdateImages(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('8764532', 'TestProvider');
+        $user->addAdminRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/istration/actions');
+        $form = $crawler->filter('#trigger_update_images form')->form();
+        $client->submit($form);
+
+        $this->assertResponseStatusCodeSame(302);
+        $crawler = $client->followRedirect();
+        $this->assertSame('http://localhost/fr/istration/actions', $client->getRequest()->getUri());
+
+        $this->assertCountFilter($crawler, 1, '.icon-square.bg-success');
+
+        $this->assertConnectedNavBar($crawler);
+        $this->assertFrenchLangSwitch($crawler);
+    }
+}
+```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin/ActionTriggerTest.php`
+Expected: FAIL — either a `Crawler` filter finding no `#trigger_update_images form` element (if Task 1/2 weren't done yet) or a Moco 404/mismatch if the fixture doesn't match yet. Given Tasks 1–2 in this plan are already done by this point, this should actually fail only if Step 1 (the Moco fixture) is missing or malformed — restore step ordering if you're executing tasks out of order.
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin/ActionTriggerTest.php`
+Expected: `OK (1 test, ...)`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/resources/moco/Back/moco.json tests/src/Integration/Controller/Admin/ActionTriggerTest.php
+git commit -m "Add integration test for the update_images trigger button"
+```
+
+---
+
+### Task 4: Full quality and measures gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `make tests`
+Expected: all unit, integration, and browser tests pass, including the new tests from Tasks 1 and 3.
+
+- [ ] **Step 2: Run quality checks**
+
+Run: `make quality`
+Expected: editorconfig, jsonlint, PHP CS Fixer, PHPMD, Psalm, PHPStan, Deptrac, and w3c all pass. If PHP CS Fixer reports formatting differences, run `make phpcsfixer-fix` and re-run `make quality`.
+
+- [ ] **Step 3: Run coverage and mutation testing**
+
+Run: `make measures`
+Expected: coverage 100%, mutation score (Infection) 100% MSI. If a mutant survives (e.g. the CSRF token id `'admin_trigger'`, the route condition list, or the `'trigger'`/`'update_images'` literals), add an assertion in the relevant Task 1/3 test that pins down that exact value, then re-run.
+
+- [ ] **Step 4: Commit any fixes from Steps 2–3**
+
+```bash
+git add -A
+git commit -m "Fix quality/coverage findings for the update_images trigger button"
+```
+
+(Skip this step if Steps 2–3 already passed cleanly with nothing to fix.)

--- a/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
+++ b/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
@@ -71,7 +71,7 @@ pokenini-web (admin button)
               (PR body includes the check_size report)
 
   [you review & merge that PR — this is the real risk checkpoint:
-   mis-detected sprite numbers, missing entries]
+  mis-detected sprite numbers, missing entries]
 
           → Workflow B runs in pokenini-icon (push to main, paths: images/**):
               checkout pokenini-resources as a sibling checkout

--- a/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
+++ b/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
@@ -1,0 +1,205 @@
+# Trigger the image-update pipeline from the admin page
+
+## Context
+
+Pokémon sprite images ("big" and "small") are produced by scripts in the
+private `pokenini-icon` repository (a separate project, sibling to this
+workspace):
+
+- `make pdb_dl pdb_convert pdb_copy` — downloads "big" sprites from
+  pokemondb.net for every entry in `src/download-from-pokemon-db/pokemons-list.txt`,
+  converts them to WebP, and copies changed files into `images/big/{regular,shiny}`.
+- `make mbc_prepare mbc_cut mbc_copy` — cuts "small" sprites out of a static,
+  hand-sourced spritesheet (`resources/regulars.png` / `shinies.png`) via a
+  dockerized Python/character-recognition tool, copying changed files into
+  `images/small/{regular,shiny}`.
+- `make placeholders` — fills in missing shiny placeholders.
+- `make check_size` — reports (but does not fail on) images with the wrong
+  dimensions.
+
+Today this all runs by hand on the author's machine, followed by a manual
+`make copy` in `pokenini-resources` (the public static-assets repo serving
+images for pokénin.fr) and a manual commit/release to publish.
+
+This is entirely separate from `AdminActionApiService` in `pokenini-back`,
+which proxies admin buttons in `pokenini-web` to endpoints on `pokenini-api`
+(update/calculate/invalidate). The image pipeline doesn't touch
+`pokenini-api` at all — it's a GitHub Actions job in a different repo.
+
+## Goal
+
+Add a button on the pokenini-web admin page that triggers the full
+`pokenini-icon` pipeline remotely (so it works from prod, not just a local
+dev machine) and lands the result as a **pull request** on
+`pokenini-resources` for review — it must not publish automatically, since
+the pipeline has known manual-correction cases (mis-detected sprite
+numbers, missing entries) that need a human look before going live.
+
+## Non-goals (explicitly out of scope for this iteration)
+
+- Auto-detecting which Pokémon/forms are new. `pokemons-list.txt` and the
+  static spritesheets stay manually curated in `pokenini-icon`, as today.
+  The button just re-runs the pipeline against whatever is currently
+  committed there.
+- Rewriting the bash/Python scripts. They run unmodified inside GitHub
+  Actions; only a new workflow file wraps them.
+- Live progress/completion feedback in pokenini-web. The button reports
+  whether the *trigger* succeeded, not whether the pipeline finished — see
+  "Fire-and-forget, deliberately" below.
+
+## Design
+
+### Overall flow
+
+```
+pokenini-web (admin button)
+  → pokenini-back (POST /istration/action/trigger/update_images)
+      → GitHub API: POST /repos/{owner}/pokenini-icon/actions/workflows/update-images.yml/dispatches
+          → GitHub Actions runner, in pokenini-icon:
+              make pdb_dl pdb_convert pdb_copy
+              make mbc_prepare mbc_cut mbc_copy
+              make placeholders
+              make check_size            (output captured, non-blocking)
+              checkout pokenini-resources as a sibling checkout
+              make copy                  (existing Makefile target: cp -R ../pokenini-icon/images/* .)
+              commit changed files to a new branch, push with a
+              resources-scoped token, open a PR against pokenini-resources
+              (PR body includes the check_size report)
+```
+
+Merging that PR and cutting a release in `pokenini-resources` stays exactly
+as it is today (unchanged, manual).
+
+### pokenini-icon
+
+- New `.github/workflows/update-images.yml`, triggered only by
+  `workflow_dispatch` (no push/schedule trigger — this is meant to be
+  explicitly button-triggered).
+- Steps: checkout `pokenini-icon`; checkout `pokenini-resources` into a
+  sibling directory in the same job (so the existing relative path in
+  `pokenini-resources`'s `make copy` — `../pokenini-icon/images/*` — keeps
+  working unmodified); install `imagemagick`/`webp` via `apt-get`; run the
+  Makefile targets above; capture `make check_size` output to a file; diff
+  `pokenini-resources`; if there are changes, commit to a new branch
+  (`update-images-<run-id>` or similar) and open a PR (e.g. via
+  `peter-evans/create-pull-request`), with the check_size report pasted
+  into the PR body; if there are no changes, the job ends without opening
+  a PR.
+- New repository secret `RESOURCES_PUSH_TOKEN`: a fine-grained PAT scoped
+  **only** to `pokenini-resources`, with `contents: write` +
+  `pull-requests: write`. The default `GITHUB_TOKEN` can't push to a
+  different repo, hence the dedicated token.
+
+### pokenini-back
+
+New, separate from the existing `AdminActionApiService` (which is
+hard-wired to pokenini-api's host/auth scheme — Basic auth, `apiUrl`,
+`apiCafilePath` — none of which apply to the GitHub API).
+
+- `src/Service/Api/GithubActionsApiService.php` — small dedicated HTTP
+  client. One method, `dispatchWorkflow(): void`, `POST`s to
+  `https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches`
+  with `Authorization: Bearer <token>` and
+  `Accept: application/vnd.github+json`. Wraps transport/HTTP exceptions
+  into the existing `App\Exception\ModifyFailedException`, same as
+  `AdminActionApiService`.
+- New config: `GITHUB_IMAGES_WORKFLOW_TOKEN` (env secret — a fine-grained
+  PAT scoped only to `pokenini-icon`, `actions: write`), plus
+  non-secret config for the repo (`douzeensemble/pokenini-icon`) and
+  workflow filename (`update-images.yml`).
+- `src/Service/TriggerImagesPipelineService.php` — thin `Service` layer
+  wrapping `GithubActionsApiService`, satisfying the Deptrac rule that
+  controllers must not call `Service\Api` directly.
+- `src/Controller/Admin/AdminActionTriggerController.php` — new sibling to
+  `AdminActionUpdateController`/`AdminActionCalculateController`/
+  `AdminActionInvalidateController`, route
+  `POST /istration/action/trigger/{name}`, condition
+  `name in ['update_images']`, same CSRF/rate-limit conventions as the
+  others.
+- `AbstractAdminActionController::doAction()` gets a new `case 'trigger'`
+  that calls `TriggerImagesPipelineService::trigger($name)`. Unlike
+  `update`/`calculate`, this case must **not** fall through to
+  `$this->cacheInvalidatorService->invalidate($name)` — there's no cache
+  invalidator registered for `update_images`, and `CacheInvalidatorService::invalidate()`
+  throws `InvalidArgumentException` for unmatched types, which would
+  incorrectly report the trigger as failed even when the GitHub dispatch
+  succeeded. The invalidate call must be scoped to only the
+  `update`/`calculate` cases.
+- Response shape is unchanged: `AdminAction('trigger', 'update_images', 'ok'|'ko', '', $error)`.
+  `ok` means "GitHub accepted the dispatch", not "images are updated" —
+  this must not be reworded to imply completion.
+
+### pokenini-web
+
+- `src/Controller/AdminActionController.php`: new `trigger()` method,
+  mirroring `update()`/`calculate()`/`invalidate()` — CSRF-checks token
+  `admin_trigger`, condition `name in ['update_images']`, calls
+  `$this->execute($name, 'trigger', 'POST')`. `AdminActionService::execute()`
+  is already generic (`POST /istration/action/{action}/{item}`) and needs
+  no change.
+- `templates/Admin/_actions.html.twig`: new section using the existing
+  `admin.action(...)` macro, e.g.:
+
+  ```twig
+  <div class="row px-4 py-5">
+    <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
+    {% set triggerPipelineItems = { 'update_images': 'images' } %}
+    {% for item, icon in triggerPipelineItems %}
+      {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+    {% endfor %}
+  </div>
+  ```
+
+  Since `pokenini-api` never logs a `trigger_update_images` entry in
+  `actionLogsData`, the macro's existing fallback (`entry is null` →
+  `idle` state) applies automatically — no template logic changes needed
+  for that. This button will always render as a plain idle
+  button-then-flash-message, never the pending/progress-bar UI the other
+  buttons can show; that's intentional (see "Fire-and-forget,
+  deliberately" below), not a bug to fix later.
+- New translation keys (`messages+intl-icu.{en,fr}.yaml`):
+  `admin.actions.trigger_pipeline.title`,
+  `admin.actions.trigger_pipeline.update_images.title`,
+  `admin.actions.trigger_pipeline.update_images.cta`.
+
+### Fire-and-forget, deliberately
+
+`workflow_dispatch` only confirms GitHub *accepted* the request — it
+doesn't return a run ID or block until the workflow finishes. So:
+
+- Success in the UI means "triggered", not "done". The button's
+  surrounding copy/flash message must say so explicitly (e.g. "Pipeline
+  déclenché — voir l'onglet Actions de pokenini-icon et la PR ouverte sur
+  pokenini-resources").
+- If the pipeline itself fails inside GitHub Actions (script error, Docker
+  build failure), pokenini-web has no way to know — that's only visible in
+  the GitHub Actions tab. No polling/webhook-back-channel is being built
+  for this; if that gap turns out to matter in practice, it's a follow-up.
+
+### Error handling
+
+- Dispatch failures (bad/expired token, workflow renamed, GitHub API
+  outage) surface as `ko` through the existing `AdminAction`/flash-message
+  machinery — no new error-handling UI needed.
+- `check_size.sh` never exits non-zero, so dimension mismatches never fail
+  the GitHub Actions job; its output is only informational text in the PR
+  body.
+- If nothing changed since the last run (e.g. re-clicking the button with
+  no new Pokémon added), the workflow completes without opening a PR —
+  this is a normal, non-error outcome.
+
+### Testing
+
+- `pokenini-back`: unit-test `GithubActionsApiService` (mocked
+  `HttpClientInterface`, matching the existing pattern for
+  `AdminActionApiService`) and `TriggerImagesPipelineService`; unit-test
+  the new controller and the modified `doAction()` branching (cover: the
+  `trigger` case does *not* call `CacheInvalidatorService::invalidate()`).
+  Must keep the project's 100% coverage / 100% MSI bar.
+- `pokenini-web`: unit-test the new `trigger()` controller method the same
+  way the existing `update()`/`calculate()`/`invalidate()` methods are
+  tested (CSRF check, redirect target, session state).
+- `pokenini-icon`: no existing automated-test convention for the
+  Makefile/workflow layer. Validate the new workflow by actually running
+  it once (`gh workflow run update-images.yml`) and checking the resulting
+  PR, rather than writing CI-for-CI tests.

--- a/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
+++ b/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
@@ -110,22 +110,27 @@ hard-wired to pokenini-api's host/auth scheme — Basic auth, `apiUrl`,
 - `src/Service/TriggerImagesPipelineService.php` — thin `Service` layer
   wrapping `GithubActionsApiService`, satisfying the Deptrac rule that
   controllers must not call `Service\Api` directly.
-- `src/Controller/Admin/AdminActionTriggerController.php` — new sibling to
-  `AdminActionUpdateController`/`AdminActionCalculateController`/
-  `AdminActionInvalidateController`, route
+- `src/Controller/Admin/AdminActionTriggerController.php` — a **standalone**
+  controller, deliberately *not* extending `AbstractAdminActionController`.
+  That abstract class's constructor is hard-typed to the concrete
+  `AdminActionApiService` and its `doAction()` unconditionally ends with
+  `$this->cacheInvalidatorService->invalidate($name)` — there's no cache
+  invalidator registered for `update_images`, and
+  `CacheInvalidatorService::invalidate()` throws `InvalidArgumentException`
+  for unmatched types, which would incorrectly report the trigger as
+  failed even when the GitHub dispatch succeeded. Reusing/branching the
+  abstract class to accommodate this would mean adding a constructor
+  parameter that ripples into the three existing, unrelated
+  update/calculate/invalidate controllers and their tests. Instead, the
+  new controller re-implements the same small try/catch → `AdminAction`
+  DTO → `JsonResponse` shape on its own (it only needs `TriggerImagesPipelineService`
+  and a logger — no `CacheInvalidatorService`). Route
   `POST /istration/action/trigger/{name}`, condition
   `name in ['update_images']`, same CSRF/rate-limit conventions as the
-  others.
-- `AbstractAdminActionController::doAction()` gets a new `case 'trigger'`
-  that calls `TriggerImagesPipelineService::trigger($name)`. Unlike
-  `update`/`calculate`, this case must **not** fall through to
-  `$this->cacheInvalidatorService->invalidate($name)` — there's no cache
-  invalidator registered for `update_images`, and `CacheInvalidatorService::invalidate()`
-  throws `InvalidArgumentException` for unmatched types, which would
-  incorrectly report the trigger as failed even when the GitHub dispatch
-  succeeded. The invalidate call must be scoped to only the
-  `update`/`calculate` cases.
-- Response shape is unchanged: `AdminAction('trigger', 'update_images', 'ok'|'ko', '', $error)`.
+  others (`RateLimit` with the `write_api` limiter).
+- Response shape matches the existing `AdminAction` DTO:
+  `AdminAction('trigger', 'update_images', 'ok'|'ko', '', $error)`, same
+  202/500 status code convention as `AbstractAdminActionController::execute()`.
   `ok` means "GitHub accepted the dispatch", not "images are updated" —
   this must not be reworded to imply completion.
 
@@ -193,8 +198,9 @@ doesn't return a run ID or block until the workflow finishes. So:
 - `pokenini-back`: unit-test `GithubActionsApiService` (mocked
   `HttpClientInterface`, matching the existing pattern for
   `AdminActionApiService`) and `TriggerImagesPipelineService`; unit-test
-  the new controller and the modified `doAction()` branching (cover: the
-  `trigger` case does *not* call `CacheInvalidatorService::invalidate()`).
+  the new standalone controller the same way the other
+  `AdminAction*Controller` tests work (success → 202, exception → 500 +
+  `critical` log), with no `CacheInvalidatorService` involved at all.
   Must keep the project's 100% coverage / 100% MSI bar.
 - `pokenini-web`: unit-test the new `trigger()` controller method the same
   way the existing `update()`/`calculate()`/`invalidate()` methods are

--- a/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
+++ b/docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md
@@ -30,10 +30,16 @@ which proxies admin buttons in `pokenini-web` to endpoints on `pokenini-api`
 
 Add a button on the pokenini-web admin page that triggers the full
 `pokenini-icon` pipeline remotely (so it works from prod, not just a local
-dev machine) and lands the result as a **pull request** on
-`pokenini-resources` for review — it must not publish automatically, since
-the pipeline has known manual-correction cases (mis-detected sprite
-numbers, missing entries) that need a human look before going live.
+dev machine) and lands the result as **pull requests** for review — it
+must not publish automatically, since the pipeline has known
+manual-correction cases (mis-detected sprite numbers, missing entries)
+that need a human look before going live.
+
+Note there are two separate git-tracked destinations, not one:
+`pokenini-icon/images/` (committed in `pokenini-icon` itself — the actual
+output of the scripts) and its copy in `pokenini-resources` (what
+pokénin.fr serves). Both need review, and the second can only meaningfully
+happen once the first is merged (see "Two chained workflows" below).
 
 ## Non-goals (explicitly out of scope for this iteration)
 
@@ -55,40 +61,61 @@ numbers, missing entries) that need a human look before going live.
 pokenini-web (admin button)
   → pokenini-back (POST /istration/action/trigger/update_images)
       → GitHub API: POST /repos/{owner}/pokenini-icon/actions/workflows/update-images.yml/dispatches
-          → GitHub Actions runner, in pokenini-icon:
+          → Workflow A runs in pokenini-icon (workflow_dispatch):
               make pdb_dl pdb_convert pdb_copy
               make mbc_prepare mbc_cut mbc_copy
               make placeholders
               make check_size            (output captured, non-blocking)
+              commit changed files under images/ to a new branch,
+              open a PR against pokenini-icon's main
+              (PR body includes the check_size report)
+
+  [you review & merge that PR — this is the real risk checkpoint:
+   mis-detected sprite numbers, missing entries]
+
+          → Workflow B runs in pokenini-icon (push to main, paths: images/**):
               checkout pokenini-resources as a sibling checkout
-              make copy                  (existing Makefile target: cp -R ../pokenini-icon/images/* .)
+              make copy   (existing Makefile target: cp -R ../pokenini-icon/images/* .)
               commit changed files to a new branch, push with a
               resources-scoped token, open a PR against pokenini-resources
-              (PR body includes the check_size report)
 ```
 
-Merging that PR and cutting a release in `pokenini-resources` stays exactly
-as it is today (unchanged, manual).
+Merging the `pokenini-resources` PR and cutting a release there stays
+exactly as it is today (unchanged, manual).
 
 ### pokenini-icon
 
-- New `.github/workflows/update-images.yml`, triggered only by
-  `workflow_dispatch` (no push/schedule trigger — this is meant to be
-  explicitly button-triggered).
-- Steps: checkout `pokenini-icon`; checkout `pokenini-resources` into a
-  sibling directory in the same job (so the existing relative path in
-  `pokenini-resources`'s `make copy` — `../pokenini-icon/images/*` — keeps
-  working unmodified); install `imagemagick`/`webp` via `apt-get`; run the
-  Makefile targets above; capture `make check_size` output to a file; diff
-  `pokenini-resources`; if there are changes, commit to a new branch
-  (`update-images-<run-id>` or similar) and open a PR (e.g. via
-  `peter-evans/create-pull-request`), with the check_size report pasted
-  into the PR body; if there are no changes, the job ends without opening
-  a PR.
-- New repository secret `RESOURCES_PUSH_TOKEN`: a fine-grained PAT scoped
-  **only** to `pokenini-resources`, with `contents: write` +
-  `pull-requests: write`. The default `GITHUB_TOKEN` can't push to a
-  different repo, hence the dedicated token.
+**Workflow A — `.github/workflows/update-images.yml`**, triggered only by
+`workflow_dispatch` (no push/schedule trigger — this is the one the admin
+button fires).
+
+- Steps: checkout `pokenini-icon`; install `imagemagick`/`webp` via
+  `apt-get`; run `make pdb_dl pdb_convert pdb_copy`,
+  `make mbc_prepare mbc_cut mbc_copy`, `make placeholders`; run
+  `make check_size` and capture its output; if `git status --porcelain
+  images/` shows changes, commit them to a new branch
+  (`update-images-<run-id>` or similar), push, and open a PR against
+  `pokenini-icon`'s own `main` (e.g. via `peter-evans/create-pull-request`),
+  with the check_size report pasted into the PR body; if there are no
+  changes, the job ends without opening a PR.
+- Uses the default `GITHUB_TOKEN` (the job only needs write access to its
+  own repo) — no new secret required for this workflow.
+
+**Workflow B — `.github/workflows/publish-images-to-resources.yml`**,
+triggered by `push` to `main` with `paths: ['images/**']` — so it only
+fires once a Workflow-A PR (or any other images/ change) is actually
+merged, never on the unmerged branch.
+
+- Steps: checkout `pokenini-icon` (`main`, already has the merged images);
+  checkout `pokenini-resources` into a sibling directory (so its existing
+  `make copy` target — `cp -R ../pokenini-icon/images/* .` — keeps working
+  unmodified); run `make copy`; if there are changes, commit to a new
+  branch, push, and open a PR against `pokenini-resources`.
+- New repository secret `RESOURCES_PUSH_TOKEN` (set in `pokenini-icon`,
+  since that's where Workflow B runs): a fine-grained PAT scoped **only**
+  to `pokenini-resources`, with `contents: write` + `pull-requests: write`.
+  The default `GITHUB_TOKEN` can't push to a different repo, hence the
+  dedicated token.
 
 ### pokenini-back
 
@@ -172,14 +199,18 @@ hard-wired to pokenini-api's host/auth scheme — Basic auth, `apiUrl`,
 `workflow_dispatch` only confirms GitHub *accepted* the request — it
 doesn't return a run ID or block until the workflow finishes. So:
 
-- Success in the UI means "triggered", not "done". The button's
-  surrounding copy/flash message must say so explicitly (e.g. "Pipeline
-  déclenché — voir l'onglet Actions de pokenini-icon et la PR ouverte sur
-  pokenini-resources").
+- Success in the UI means "triggered", not "done" — and definitely not
+  "published". The button's surrounding copy/flash message must say so
+  explicitly (e.g. "Pipeline déclenché — voir l'onglet Actions de
+  pokenini-icon puis la PR qui y sera ouverte ; une fois cette PR mergée,
+  une seconde PR sera ouverte automatiquement sur pokenini-resources").
 - If the pipeline itself fails inside GitHub Actions (script error, Docker
   build failure), pokenini-web has no way to know — that's only visible in
   the GitHub Actions tab. No polling/webhook-back-channel is being built
   for this; if that gap turns out to matter in practice, it's a follow-up.
+- Workflow B (the `pokenini-resources` PR) is not triggered by
+  pokenini-web at all — it's a consequence of merging the Workflow-A PR.
+  There's no "second button."
 
 ### Error handling
 
@@ -187,11 +218,16 @@ doesn't return a run ID or block until the workflow finishes. So:
   outage) surface as `ko` through the existing `AdminAction`/flash-message
   machinery — no new error-handling UI needed.
 - `check_size.sh` never exits non-zero, so dimension mismatches never fail
-  the GitHub Actions job; its output is only informational text in the PR
-  body.
+  the GitHub Actions job; its output is only informational text in the
+  Workflow-A PR body.
 - If nothing changed since the last run (e.g. re-clicking the button with
-  no new Pokémon added), the workflow completes without opening a PR —
-  this is a normal, non-error outcome.
+  no new Pokémon added), Workflow A completes without opening a PR — this
+  is a normal, non-error outcome, and Workflow B never fires since nothing
+  was pushed to `images/**`.
+- If Workflow A's PR is merged with further manual edits (fixing a
+  mis-detected sprite) after the bot's commit, Workflow B still triggers
+  correctly off the merge commit to `main`, not off the bot's original
+  commit — it always builds from current `main`.
 
 ### Testing
 
@@ -206,6 +242,8 @@ doesn't return a run ID or block until the workflow finishes. So:
   way the existing `update()`/`calculate()`/`invalidate()` methods are
   tested (CSRF check, redirect target, session state).
 - `pokenini-icon`: no existing automated-test convention for the
-  Makefile/workflow layer. Validate the new workflow by actually running
-  it once (`gh workflow run update-images.yml`) and checking the resulting
-  PR, rather than writing CI-for-CI tests.
+  Makefile/workflow layer. Validate Workflow A by actually running it once
+  (`gh workflow run update-images.yml`) and checking the resulting PR;
+  validate Workflow B by merging that PR (or a trivial test PR touching
+  `images/`) and checking that it fires and opens the expected PR on
+  `pokenini-resources` — rather than writing CI-for-CI tests.

--- a/src/Controller/AdminActionController.php
+++ b/src/Controller/AdminActionController.php
@@ -100,6 +100,25 @@ final class AdminActionController extends AbstractController
         return $this->execute($name, 'invalidate', 'DELETE');
     }
 
+    #[Route(
+        '/trigger/{name}',
+        methods: ['POST'],
+        condition: "params['name']
+            in [
+                'update_images',
+            ]"
+    )]
+    public function trigger(
+        string $name,
+        Request $request,
+    ): RedirectResponse {
+        if (!$this->isCsrfTokenValid('admin_trigger', $request->request->getString('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        return $this->execute($name, 'trigger', 'POST');
+    }
+
     private function execute(
         string $name,
         string $action,

--- a/templates/Admin/_actions.html.twig
+++ b/templates/Admin/_actions.html.twig
@@ -53,3 +53,13 @@
     {{ admin.action('invalidate_data', 'invalidate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
   {% endfor %}
 </div>
+
+<div class="row px-4 py-5">
+  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
+  {% set triggerPipelineItems = {
+    'update_images': 'images',
+  } %}
+  {% for item, icon in triggerPipelineItems %}
+    {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+  {% endfor %}
+</div>

--- a/templates/Admin/_actions.html.twig
+++ b/templates/Admin/_actions.html.twig
@@ -56,6 +56,7 @@
 
 <div class="row px-4 py-5">
   <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
+  <p class="text-body-secondary small">{{ 'admin.actions.trigger_pipeline.help'|trans }}</p>
   {% set triggerPipelineItems = {
     'update_images': 'images',
   } %}

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -620,6 +620,32 @@
   {
     "request": {
       "uri": {
+        "match": "/istration/action/trigger/update_images"
+      },
+      "method": "post",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "202",
+      "json": {
+        "action": "trigger",
+        "item": "update_images",
+        "state": "ok",
+        "content": "",
+        "error": ""
+      }
+    }
+  },
+  {
+    "request": {
+      "uri": {
         "match": "/istration/reports"
       },
       "method": "get",

--- a/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
@@ -29,6 +29,12 @@ final class ActionTriggerTest extends WebTestCase
         $client->loginUser($user, 'web');
 
         $crawler = $client->request('GET', '/fr/istration/actions');
+
+        $this->assertStringContainsString(
+            'Ceci ne fait que lancer le pipeline sur GitHub Actions',
+            $crawler->outerHtml()
+        );
+
         $form = $crawler->filter('#trigger_update_images form')->form();
         $client->submit($form);
 

--- a/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller\Admin;
+
+use App\Controller\AdminActionController;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(AdminActionController::class)]
+#[Group('api-mocked-testing')]
+final class ActionTriggerTest extends WebTestCase
+{
+    use TestNavTrait;
+
+    public function testAdminTriggerUpdateImages(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('8764532', 'TestProvider');
+        $user->addAdminRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/istration/actions');
+        $form = $crawler->filter('#trigger_update_images form')->form();
+        $client->submit($form);
+
+        $this->assertResponseStatusCodeSame(302);
+        $crawler = $client->followRedirect();
+        $this->assertSame('http://localhost/fr/istration/actions', $client->getRequest()->getUri());
+
+        $this->assertCountFilter($crawler, 1, '.icon-square.bg-success');
+
+        $this->assertConnectedNavBar($crawler);
+        $this->assertFrenchLangSwitch($crawler);
+    }
+}

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -78,13 +78,15 @@ final class AdminPageTest extends WebTestCase
     {
         $crawler = $this->getAdminHomeConnected();
 
-        $this->assertCountFilter($crawler, 5, 'h2');
-        $this->assertCountFilter($crawler, 14, 'h3');
-        $this->assertCountFilter($crawler, 14, '.admin-item button.admin-item-cta');
+        $this->assertCountFilter($crawler, 6, 'h2');
+        $this->assertCountFilter($crawler, 15, 'h3');
+        $this->assertCountFilter($crawler, 15, '.admin-item button.admin-item-cta');
 
         $this->assertCountFilter($crawler, 7, '.admin-item-update button.admin-item-cta');
         $this->assertCountFilter($crawler, 4, '.admin-item-calculate button.admin-item-cta');
         $this->assertCountFilter($crawler, 3, '.admin-item-invalidate button.admin-item-cta');
+        $this->assertCountFilter($crawler, 1, '.admin-item-trigger button.admin-item-cta');
+        $this->assertCountFilter($crawler, 1, '#trigger_update_images button.admin-item-cta');
 
         $this->assertCountFilter($crawler, 3, '.admin-item-cta.disabled');
         $this->assertCountFilter($crawler, 1, '#update_games_collections_and_dex .admin-item-cta.disabled');

--- a/tests/src/Unit/Controller/AdminActionControllerTest.php
+++ b/tests/src/Unit/Controller/AdminActionControllerTest.php
@@ -433,7 +433,130 @@ final class AdminActionControllerTest extends TestCase
         $this->assertSame('/admin', $response->getTargetUrl());
     }
 
-    private function assertFailActionLogs(string $action): AdminActionController
+    public function testTriggerAction(): void
+    {
+        $adminActionService = $this->createMock(AdminActionService::class);
+        $adminActionService
+            ->expects($this->once())
+            ->method('execute')
+            ->with('trigger', 'update_images')
+            ->willReturn(new AdminAction('trigger', 'update_images', 'ok', '', ''))
+        ;
+
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('set')
+        ;
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack
+            ->expects($this->once())
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->never())
+            ->method('critical')
+        ;
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(AdminActionSucceededEvent::class))
+        ;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('app_admin_actions', ['_fragment' => 'trigger_update_images'])
+            ->willReturn('/admin')
+        ;
+
+        $csrfManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfManager->method('isTokenValid')->willReturn(true);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.csrf.token_manager')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['security.csrf.token_manager', $csrfManager],
+                ['router', $router],
+            ])
+        ;
+
+        $controller = new AdminActionController(
+            $adminActionService,
+            $requestStack,
+            $logger,
+            $eventDispatcher,
+        );
+        $controller->setContainer($container);
+
+        $response = $controller->trigger('update_images', new Request([], ['_token' => 'valid_token']));
+
+        $this->assertSame('/admin', $response->getTargetUrl());
+    }
+
+    public function testFailTriggerLogs(): void
+    {
+        $controller = $this->assertFailActionLogs('trigger', 'update_images');
+
+        $controller->trigger('update_images', new Request([], ['_token' => 'valid_token']));
+    }
+
+    public function testTriggerInvalidCsrfToken(): void
+    {
+        $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfManager
+            ->expects($this->once())
+            ->method('isTokenValid')
+            ->willReturn(false)
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('security.csrf.token_manager')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->willReturnMap([['security.csrf.token_manager', $csrfManager]])
+        ;
+
+        $adminActionService = $this->createMock(AdminActionService::class);
+        $adminActionService
+            ->expects($this->never())
+            ->method('execute')
+        ;
+
+        $controller = new AdminActionController(
+            $adminActionService,
+            $this->createStub(RequestStack::class),
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(EventDispatcherInterface::class),
+        );
+        $controller->setContainer($container);
+
+        $this->expectException(AccessDeniedException::class);
+        $controller->trigger('update_images', new Request([], ['_token' => 'bad_token']));
+    }
+
+    private function assertFailActionLogs(string $action, string $name = 'something'): AdminActionController
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -462,7 +585,7 @@ final class AdminActionControllerTest extends TestCase
             ->with(
                 $this->isString(),
                 $this->equalTo([
-                    'name' => 'something',
+                    'name' => $name,
                     'action' => $action,
                 ])
             )
@@ -478,7 +601,7 @@ final class AdminActionControllerTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with('app_admin_actions', ['_fragment' => $action.'_something'])
+            ->with('app_admin_actions', ['_fragment' => $action.'_'.$name])
             ->willReturn('/admin')
         ;
 

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -456,6 +456,7 @@ admin:
         cta: "Invalidate!"
     trigger_pipeline:
       title: "Trigger pipelines"
+      help: "This only starts the pipeline in GitHub Actions — it does not publish anything by itself. Once it finishes, review and merge the pull request it opens on pokenini-icon (and, after that, the follow-up one on pokenini-resources)."
       update_images:
         title: "Update Pokémon images"
         cta: "Trigger!"

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -454,6 +454,11 @@ admin:
       actions:
         title: "Invalidate actions cache"
         cta: "Invalidate!"
+    trigger_pipeline:
+      title: "Trigger pipelines"
+      update_images:
+        title: "Update Pokémon images"
+        cta: "Trigger!"
     reports_data:
       reports:
         title: "Invalidate reports cache"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -462,6 +462,7 @@ admin:
 
     trigger_pipeline:
       title: "Déclenchement de pipelines"
+      help: "Ceci ne fait que lancer le pipeline sur GitHub Actions, sans rien publier directement. Une fois terminé, relis et merge la pull request qu'il ouvre sur pokenini-icon (puis celle qui suivra sur pokenini-resources)."
       update_images:
         title: "Mettre à jour les images des Pokémon"
         cta: "Déclencher"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -459,7 +459,11 @@ admin:
       actions:
         title: "Invalidation du cache des actions"
         cta: "Invalider"
-
+    trigger_pipeline:
+      title: "Déclenchement de pipelines"
+      update_images:
+        title: "Mettre à jour les images des Pokémon"
+        cta: "Déclencher"
     reports_data:
       reports:
         title: "Invalidation du cache des rapports"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -459,11 +459,13 @@ admin:
       actions:
         title: "Invalidation du cache des actions"
         cta: "Invalider"
+
     trigger_pipeline:
       title: "Déclenchement de pipelines"
       update_images:
         title: "Mettre à jour les images des Pokémon"
         cta: "Déclencher"
+
     reports_data:
       reports:
         title: "Invalidation du cache des rapports"


### PR DESCRIPTION
## Summary

- Adds a `trigger()` verb to `AdminActionController` (alongside `update`/`calculate`/`invalidate`), calling the new `POST /istration/action/trigger/update_images` endpoint in the companion `pokenini-back` PR.
- Adds a "Trigger pipelines" section to the admin actions page, reusing the existing `admin.action(...)` Twig macro unchanged.
- Adds explicit help text under the button making clear that success only means "the pipeline was triggered", not "images are updated" — this button can never reach the pending/done states the other admin actions can (pokenini-api never logs it), so its success icon would otherwise look identical to "done".
- Adds a Moco-backed integration test (`ActionTriggerTest`) exercising the real rendered form end-to-end.

See the design spec at `docs/superpowers/specs/2026-07-14-update-images-pipeline-trigger-design.md` in this repo for the full 3-repo picture (this PR → the `pokenini-back` PR → the `pokenini-icon` PR).

## Notable fixes along the way

- A bug in the original plan's test code (`assertFailActionLogs()` hardcoded `'something'` in both the logger and router mock expectations, but the real test needed `'update_images'`) was caught and fixed by parameterizing the shared helper with a default, preserving all 3 existing call sites.
- The new admin section changed the page's h2/h3/button element counts, breaking a pre-existing test (`AdminPageTest::testAdminHome`) that hardcoded those totals — fixed with arithmetically-verified counts plus new section-specific assertions.
- A whole-branch review flagged that the design spec explicitly required this "fire-and-forget" copy, which an earlier planning decision had skipped — added after the fact (see above).

## Test plan

- [x] `make tests`: unit 347/347, integration 262/262 green (browser suite has pre-existing, unrelated flakiness, confirmed reproducible on `main`-inherited code)
- [x] `make quality`: clean
- [x] `make measures`: 100% coverage, 100% MSI
- [x] Independent whole-branch review: fixes applied for the one Important finding (help text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eoUziDvCda8N3aEHAQQn5