### PR TITLE
Add privacy toggles, admin descriptions, and prevent-leave guard for pending catch-state changes

### DIFF
--- a/docs/superpowers/plans/2026-07-28-pokedex-privacy-home-toggle.md
+++ b/docs/superpowers/plans/2026-07-28-pokedex-privacy-home-toggle.md
@@ -1,0 +1,483 @@
+# Pokédex Privacy & Add-to-Home Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a trainer toggle their album's `is_private` and `is_on_home` flags directly from the Pokédex page (`/album/{dexSlug}`), instead of only from `/trainer`.
+
+**Architecture:** Pure frontend addition. The offcanvas informations panel gains two `form-switch` checkboxes, gated on the page's existing `allowedToEdit` boolean. They reuse the already-generic `public/js/trainer_dex.js` (no JS changes) which `PUT`s to the existing `/trainer/dex/{dexSlug}` route (`TrainerUpsertController`, unchanged) and reuse existing `trainer.dex.attributes.*` / `trainer.dex.update.*` translation keys (no new translations).
+
+**Tech Stack:** Symfony 8 Twig templates, vanilla JS (`trainer_dex.js`), PHPUnit `WebTestCase` (integration, Moco-mocked), Panther (`AbstractBrowserTestCase`, Selenium Chrome/Firefox).
+
+**Design doc:** `docs/superpowers/specs/2026-07-28-pokedex-privacy-home-toggle-design.md`
+
+## Global Constraints
+
+- All commands run inside the `php` Docker container, never on the host (no local PHP toolchain).
+- Never create git commits — leave changes staged/unstaged for the user (standing user preference, overrides this skill's default per-step commit instruction).
+- Reuse `trainer.dex.attributes.is_private.{label,help}`, `trainer.dex.attributes.is_on_home.{label,help}`, `trainer.dex.update.success.{prefix,radical,suffix}`, `trainer.dex.update.error.{prefix,radical,suffix}` — already defined in both `translations/messages+intl-icu.en.yaml` and `translations/messages+intl-icu.fr.yaml`. No new translation keys.
+- Reuse `public/js/trainer_dex.js` verbatim — no JS file changes.
+- No backend or BFF changes — `PUT /trainer/dex/{dexSlug}` (`TrainerUpsertController` → `ModifyTrainerDexService` → `Service/Back/ModifyDexService`) is untouched.
+- Do not change the existing read-only `.album-private` lock badge or its visibility rule in `Album/_offcanvas.html.twig`.
+- Every new/modified integration test class stays `final`, `@internal`, with `#[CoversClass(...)]`; browser test classes use `#[CoversNothing]` (matching every existing file in `tests/src/Browser/`).
+
+---
+
+### Task 1: Render the `is_private`/`is_on_home` switches in the offcanvas
+
+**Files:**
+- Modify: `templates/Album/_offcanvas.html.twig` (informations block, right after the `<h2>{{ 'album.offcanvas.informations.title'|trans }}</h2>` line, before the existing `<ul class="list-group ...">` icons list)
+- Test: `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+
+**Interfaces:**
+- Consumes: `currentDexSlug` (string), `dex.isPrivate` (bool), `dex.isOnHome` (bool), `allowedToEdit` (bool) — all already passed to `Album/_offcanvas.html.twig` today via `Album/index.html.twig`'s render call in `AlbumIndexController::index()`.
+- Produces: a `<form data-dex="{{ currentDexSlug }}">` containing two checkboxes with `name="{{ currentDexSlug }}-is_private"` / `name="{{ currentDexSlug }}-is_on_home"` — Task 3's JS wiring depends on this exact `data-dex`/`name` convention (identical to `Trainer/Section/_dex.html.twig`'s existing markup).
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Open `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php` and add two new test methods (do not touch the existing 6 methods):
+
+```php
+    public function testSwitchesForOwner(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertCountFilter($crawler, 1, '#offcanvas form[data-dex="goldsilvercrystal"]');
+
+        $isPrivate = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"] input[name="goldsilvercrystal-is_private"]');
+        $this->assertCount(1, $isPrivate);
+        $this->assertNotNull($isPrivate->attr('checked'));
+
+        $isOnHome = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"] input[name="goldsilvercrystal-is_on_home"]');
+        $this->assertCount(1, $isOnHome);
+        $this->assertNull($isOnHome->attr('checked'));
+    }
+
+    public function testSwitchesAbsentForAnotherTrainer(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('13', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
+
+        $this->assertCountFilter($crawler, 0, '#offcanvas form[data-dex]');
+    }
+```
+
+These reuse the exact same login/route setup as the existing `testIntroGoldSilverCrystal` (owner, `allowedToEdit` true, `goldsilvercrystal` fixture has `is_private: true`, `is_on_home: false`) and `testIntroDemoAnotherTrainer` (non-owner, `allowedToEdit` false) methods further down in the same file — no new Moco fixtures needed.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter 'testSwitchesForOwner|testSwitchesAbsentForAnotherTrainer' tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+Expected: `testSwitchesForOwner` FAILs (`#offcanvas form[data-dex="goldsilvercrystal"]` not found, count 0 instead of 1). `testSwitchesAbsentForAnotherTrainer` PASSes trivially (nothing to render yet) — that's fine, it becomes a real regression guard once Step 3 is done.
+
+- [ ] **Step 3: Add the switches markup**
+
+In `templates/Album/_offcanvas.html.twig`, locate:
+
+```twig
+    <div>
+      <h2>
+        {{ 'album.offcanvas.informations.title'|trans }}
+      </h2>
+
+      <ul
+        class="list-group list-group-horizontal group-icons">
+```
+
+Insert the switches form between the `<h2>` and the `<ul>`:
+
+```twig
+    <div>
+      <h2>
+        {{ 'album.offcanvas.informations.title'|trans }}
+      </h2>
+
+      {% if allowedToEdit %}
+        <form data-dex="{{ currentDexSlug }}">
+          {% set flagAttributes = ['is_private', 'is_on_home'] %}
+          {% set flagAttributesIcons = {'is_private': 'incognito', 'is_on_home': 'house-check'} %}
+          {% set flagMap = {'is_private': dex.isPrivate, 'is_on_home': dex.isOnHome} %}
+          {% for flagAttribute in flagAttributes %}
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" role="switch"
+                name="{{ currentDexSlug }}-{{ flagAttribute }}"
+                id="offcanvas-{{ currentDexSlug }}-{{ flagAttribute }}"
+                {{ flagMap[flagAttribute] ? 'checked' : '' }}>
+              <label class="form-check-label" for="offcanvas-{{ currentDexSlug }}-{{ flagAttribute }}">
+                <i class="bi bi-{{ flagAttributesIcons[flagAttribute] }}"></i>
+                {{ ('trainer.dex.attributes.'~flagAttribute~'.label')|trans }}
+              </label>
+              <p class="form-text">
+                {{ ('trainer.dex.attributes.'~flagAttribute~'.help')|trans }}
+              </p>
+            </div>
+          {% endfor %}
+        </form>
+      {% endif %}
+
+      <ul
+        class="list-group list-group-horizontal group-icons">
+```
+
+(Variable names are prefixed `flag` to avoid shadowing the offcanvas's own filter-form `attribute`-less scope — this offcanvas file has no pre-existing `attributes`/`flagMap` variables, so there's no actual collision today, but the prefix keeps intent clear if the file grows.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+Expected: all 8 methods (6 existing + 2 new) PASS.
+
+---
+
+### Task 2: Add success/error toasts for the flag update
+
+**Files:**
+- Modify: `templates/Album/_toasts.html.twig`
+- Test: `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+
+**Interfaces:**
+- Consumes: `allowedToEdit` (bool), `currentDexSlug` (string), `dex.frenchName` / `dex.name` (string), `locale` (string) — `locale` is set in `Album/index.html.twig` (`{% set locale = app.request.locale %}`) and available to includes.
+- Produces: `#successToast-{{ currentDexSlug }}` and `#errorToast-{{ currentDexSlug }}` DOM elements — Task 3's browser tests assert visibility of these exact ids, matching the id convention `trainer_dex.js`'s `saveChange()` already hardcodes (`'successToast-'+dexSlug`, `'errorToast-'+dexSlug`).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`:
+
+```php
+    public function testFlagToastsForOwner(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertCountFilter($crawler, 1, '#successToast-goldsilvercrystal');
+        $this->assertCountFilter($crawler, 1, '#errorToast-goldsilvercrystal');
+    }
+
+    public function testFlagToastsAbsentForAnotherTrainer(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('13', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
+
+        $this->assertCountFilter($crawler, 0, '#successToast-demo');
+        $this->assertCountFilter($crawler, 0, '#errorToast-demo');
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter 'testFlagToastsForOwner|testFlagToastsAbsentForAnotherTrainer' tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+Expected: `testFlagToastsForOwner` FAILs (toast ids not found, count 0 instead of 1). `testFlagToastsAbsentForAnotherTrainer` PASSes trivially.
+
+- [ ] **Step 3: Add the toast markup**
+
+Current `templates/Album/_toasts.html.twig`:
+
+```twig
+{% import "Album/_album_macros.html.twig" as macro %}
+
+{% if allowedToEdit or not dex.isPrivate %}
+    <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
+        {% if allowedToEdit %}
+            {% for item in list %}
+                {{ macro.toasts(item) }}
+            {% endfor %}
+        {% endif %}
+
+        {% if not dex.isPrivate %}
+            {{ macro.shareToasts() }}
+        {% endif %}
+    </div>
+{% endif %}
+```
+
+Replace the `{% if allowedToEdit %}` per-Pokémon block with:
+
+```twig
+{% import "Album/_album_macros.html.twig" as macro %}
+
+{% if allowedToEdit or not dex.isPrivate %}
+    <div class="toast-container position-fixed bottom-0 mb-5 end-0 p-3">
+        {% if allowedToEdit %}
+            {% for item in list %}
+                {{ macro.toasts(item) }}
+            {% endfor %}
+
+            {% set dexName = locale is same as('fr') ? dex.frenchName : dex.name %}
+            <div id="successToast-{{ currentDexSlug }}" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+              <div class="d-flex">
+                <div class="toast-body">
+                  {{ 'trainer.dex.update.success.prefix'|trans }}
+                  <strong>{{ 'trainer.dex.update.success.radical'|trans({'dexName': dexName}) }}</strong>
+                  {{ 'trainer.dex.update.success.suffix'|trans }}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+              </div>
+            </div>
+
+            <div id="errorToast-{{ currentDexSlug }}" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+              <div class="d-flex">
+                <div class="toast-body">
+                  {{ 'trainer.dex.update.error.prefix'|trans }}
+                  <strong>{{ 'trainer.dex.update.error.radical'|trans({'dexName': dexName}) }}</strong>
+                  {{ 'trainer.dex.update.error.suffix'|trans }}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+              </div>
+            </div>
+        {% endif %}
+
+        {% if not dex.isPrivate %}
+            {{ macro.shareToasts() }}
+        {% endif %}
+    </div>
+{% endif %}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`
+Expected: all 10 methods PASS.
+
+---
+
+### Task 3: Wire the existing `trainer_dex.js` into the Album page
+
+**Files:**
+- Modify: `templates/Album/index.html.twig` (the existing `{% if allowedToEdit %}` block inside `foot_javascript`)
+- Test: new `tests/src/Browser/Album/PrivacyHomeToggleTest.php`
+
+**Interfaces:**
+- Consumes: `public/js/trainer_dex.js`'s global `watchAttributes()` function (no signature change — it already binds every `input[type="checkbox"]` on the page to `onChangeAttributes`/`saveChange`, which reads `form[data-dex]` and PUTs to `/trainer/dex/{dexSlug}`); the global `const locale` already defined in this same script block.
+- Produces: none for later tasks — this is the last task in the plan.
+
+- [ ] **Step 1: Write the failing browser test**
+
+Create `tests/src/Browser/Album/PrivacyHomeToggleTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Album;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+#[Group('api-mocked-testing')]
+final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testSuccessTickIsOnHome(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertSelectorIsNotVisible('#successToast-goldsilvercrystal');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('goldsilvercrystal-is_on_home');
+        $field->tick();
+
+        $this->assertSelectorWillBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
+    }
+
+    public function testSuccessUntickIsPrivate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertSelectorIsNotVisible('#successToast-goldsilvercrystal');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('goldsilvercrystal-is_private');
+        $field->untick();
+
+        $this->assertSelectorWillBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
+    }
+
+    public function testErrorTickIsOnHome(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/redgreenblueyellow');
+
+        $this->assertSelectorIsNotVisible('#errorToast-redgreenblueyellow');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="redgreenblueyellow"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('redgreenblueyellow-is_on_home');
+        $field->tick();
+
+        $this->assertSelectorWillBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
+    }
+
+    public function testErrorUntickIsPrivate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/redgreenblueyellow');
+
+        $this->assertSelectorIsNotVisible('#errorToast-redgreenblueyellow');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="redgreenblueyellow"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('redgreenblueyellow-is_private');
+        $field->untick();
+
+        $this->assertSelectorWillBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
+    }
+}
+```
+
+This mirrors `tests/src/Browser/Trainer/CustomAlbumTrainerTest.php` exactly (same slugs, same tick/untick pairing), reusing its proven Moco fixtures: `PUT /trainer/dex/goldsilvercrystal` falls through to the generic `put /trainer/dex/[\w-]* → 201` rule (success); `PUT /trainer/dex/redgreenblueyellow` matches a specific rule returning `500` (error) for the roles/token this test logs in with.
+
+`redgreenblueyellow`'s fixture has `is_released: false`, so the test logs in as admin (`addAdminRole()`) rather than plain trainer — `AlbumIndexController::accessDexIsGranted()` blocks non-admins from unreleased dexes with a 404, but doesn't affect `editDexIsGranted()` (which only cares about ownership + premium, and this dex has `is_premium: false`), so the switches still render and are editable.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run each in turn (the container needs the `chrome` service up, started by `make start`):
+```bash
+docker compose exec -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub -e PANTHER_BROWSER_NAME=chrome php php vendor/bin/phpunit tests/src/Browser/Album/PrivacyHomeToggleTest.php
+```
+Expected: FAIL — `$crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"]')->form()` throws because that form doesn't exist yet without the JS being wired (the switches markup exists from Task 1, but ticking them does nothing without `watchAttributes()` being called, so no toast ever appears and `assertSelectorWillBeVisible` times out).
+
+- [ ] **Step 3: Wire `trainer_dex.js`**
+
+In `templates/Album/index.html.twig`, the existing `{% if allowedToEdit %}` block in `foot_javascript` currently reads:
+
+```twig
+    {% if allowedToEdit %}
+    <script src="{{ asset('js/album-edit.js') }}"></script>
+
+    <script>
+    const catchStates = JSON.parse('{{ catchStates | map(cs => {name: cs.name, frenchName: cs.frenchName, slug: cs.slug, color: cs.color}) | json_encode | raw }}');
+    const locale = '{{ locale }}';
+    const dex = '{{ currentDexSlug }}';
+    </script>
+
+    <script>
+    (function() {
+        watchToggleEditMode();
+        watchCatchStates();
+        watchToggleShinyMode();
+        watchToAdjustSelectSizes();
+    })();
+    </script>
+    {% endif %}
+```
+
+Change it to:
+
+```twig
+    {% if allowedToEdit %}
+    <script src="{{ asset('js/album-edit.js') }}"></script>
+    <script src="{{ asset('js/trainer_dex.js') }}"></script>
+
+    <script>
+    const catchStates = JSON.parse('{{ catchStates | map(cs => {name: cs.name, frenchName: cs.frenchName, slug: cs.slug, color: cs.color}) | json_encode | raw }}');
+    const locale = '{{ locale }}';
+    const dex = '{{ currentDexSlug }}';
+    </script>
+
+    <script>
+    (function() {
+        watchToggleEditMode();
+        watchCatchStates();
+        watchToggleShinyMode();
+        watchToAdjustSelectSizes();
+        watchAttributes();
+    })();
+    </script>
+    {% endif %}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+docker compose exec -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub -e PANTHER_BROWSER_NAME=chrome php php vendor/bin/phpunit --display-all --cache-directory=.phpunit.cache/chrome tests/src/Browser/Album/PrivacyHomeToggleTest.php
+docker compose exec -e PANTHER_SELENIUM_HOST=http://firefox:4444/wd/hub -e PANTHER_BROWSER_NAME=firefox php php vendor/bin/phpunit --display-all --cache-directory=.phpunit.cache/firefox tests/src/Browser/Album/PrivacyHomeToggleTest.php
+```
+Expected: all 4 methods PASS against both Chrome and Firefox.
+
+- [ ] **Step 5: Run the full test suite and quality gates**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Integration
+```
+Expected: PASS (no regressions in `OffcanvasTest.php` or elsewhere).
+
+```bash
+docker compose exec php php tools/phpstan/vendor/bin/phpstan analyse
+docker compose exec php php tools/psalm/vendor/bin/psalm --show-info=false
+docker compose exec php php tools/phpcsfixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+```
+Expected: no new errors (only Twig/JS files changed, so PHPStan/Psalm should be unaffected; CS Fixer only touches PHP, and the one new PHP file — `PrivacyHomeToggleTest.php` — should already follow the style of its sibling `CustomAlbumTrainerTest.php`).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Design doc's four numbered "Changes" sections map 1:1 to Tasks 1–3 (offcanvas markup → Task 1, toasts → Task 2, JS wiring → Task 3); translations needed no task since no new keys are introduced.
+- **Placeholder scan:** none — every step has literal file paths, literal Twig/PHP code, and literal run commands.
+- **Type/name consistency:** `data-dex` / `name="{slug}-{attribute}"` convention is identical across Task 1 (Twig), Task 3 (browser test's `$form->get(...)`), and the untouched `trainer_dex.js`; toast ids (`successToast-{slug}` / `errorToast-{slug}`) are identical across Task 2 (Twig) and Task 3 (test assertions).

--- a/docs/superpowers/plans/2026-07-28-prevent-leave-pending-catch-state.md
+++ b/docs/superpowers/plans/2026-07-28-prevent-leave-pending-catch-state.md
@@ -1,0 +1,339 @@
+# Prevent Leaving Page During Pending Catch-State Change Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the user from silently navigating away (closing the tab, reloading, clicking a link) from the album page while a catch-state PATCH request is still in flight, by showing the browser's native `beforeunload` confirmation dialog.
+
+**Architecture:** `public/js/album-edit.js` already handles catch-state `<select>` changes with an optimistic-UI `fetch()` PATCH per change (`saveChange`). This plan adds a module-level `pendingChangesCount` counter (incremented on change, decremented once the request settles via `.finally()`) and a `beforeunload` listener that calls `event.preventDefault()` only while the counter is above zero. No Twig or backend changes are needed — the listener is registered inside the existing `watchCatchStates()` function, which already only runs when the user is allowed to edit.
+
+**Tech Stack:** Plain vanilla JS (no bundler/framework) served from `public/js/`, PHPUnit + Symfony Panther browser tests against Chrome/Firefox via Selenium, Moco HTTP mock fixtures.
+
+## Global Constraints
+
+- Full spec: `docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md`.
+- **Do not run `git commit` at any point while executing this plan.** The user's standing instruction is to never commit proactively — leave all changes staged/unstaged for the user to review and commit themselves. Each task ends with "verify tests pass", not "commit".
+- **Empirically confirmed (spiked against this project's real Chrome and Firefox Selenium containers before writing this plan):** WebDriver-initiated navigation bypasses the native `beforeunload` dialog entirely on both browsers — no dialog appears, no exception is thrown. Tests must NOT attempt to trigger real navigation and observe a native dialog (e.g. via `switchTo()->alert()`); they must instead dispatch a synthetic `beforeunload` event via `executeScript` and read back `event.defaultPrevented`.
+- Do not add debouncing, request queueing, or any "unsaved edit mode" tracking — only actual in-flight PATCH requests should ever block navigation. This is out of scope per the spec.
+- No custom `beforeunload` dialog text — modern browsers force their own generic wording regardless of what's set on `event.returnValue`, so don't try to work around this.
+
+---
+
+## Task 1: Write failing browser tests for the pending-change guard
+
+**Files:**
+- Modify: `tests/resources/moco/Back/moco.json`
+- Modify: `tests/src/Browser/Album/SelectAndLabelTest.php`
+
+**Interfaces:**
+- Consumes: `AbstractBrowserTestCase::getNewClient()`, `GetUserToken::getFakeUserToken()`, `User::addTrainerRole()`, `AbstractBrowserTestCase::loginUser()`, PHPUnit/Panther's `assertSelectorWillBeVisible()` — all already used elsewhere in this file.
+- Produces: two new test methods (`testActionCatchStatePendingChangeBlocksUnload`, `testActionCatchStateResolvedChangeAllowsUnload`) that Task 2's JS implementation must make pass, unmodified.
+
+The existing generic catch-state PATCH stub in `moco.json` responds instantly. To observe the "still pending" state, one specific Pokémon (`ivysaur`, present in the `demo.json` fixture already used by this test file) gets its own stub with an artificial 3-second `latency`, using the same override pattern already used for `squirtle`/`blastoise`.
+
+- [ ] **Step 1: Add the `ivysaur` latency stub to the Moco fixture**
+
+In `tests/resources/moco/Back/moco.json`, find this exact block (the `blastoise` 500 stub, immediately followed by the generic catch-state stub):
+
+```json
+      "text": {
+        "match": "tobreed"
+      }
+    },
+    "response": {
+      "status": "500"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/[\\w-]*/[\\w-]*"
+```
+
+Replace it with (inserting a new `ivysaur` stub between the two, same indentation style as the surrounding stubs):
+
+```json
+      "text": {
+        "match": "tobreed"
+      }
+    },
+    "response": {
+      "status": "500"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/[\\w-]*/ivysaur"
+      },
+      "method": "patch",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      },
+      "text": {
+        "match": "no|toevolve|tobreed|totransfer|totrade|yes"
+      }
+    },
+    "response": {
+      "status": "200",
+      "latency": 3000
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album/[\\w-]*/[\\w-]*"
+```
+
+- [ ] **Step 2: Validate the JSON is still well-formed**
+
+Run: `docker compose exec php php tools/jsonlint/vendor/bin/jsonlint tests/resources/moco/Back/moco.json` (or `make jsonlint` if you prefer the Makefile target)
+Expected: no syntax errors reported.
+
+- [ ] **Step 3: Add the two new test methods**
+
+In `tests/src/Browser/Album/SelectAndLabelTest.php`, add these two methods at the end of the class, just before the closing `}` (after `testActionCatchStateChangeError`):
+
+```php
+    public function testActionCatchStatePendingChangeBlocksUnload(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demo');
+
+        $client->executeScript("document.getElementById('ivysaur').scrollIntoView();");
+
+        $client->click(
+            $client
+                ->getCrawler()
+                ->filter('#ivysaur-catch-state-edit-action')
+                ->link()
+        );
+
+        $form = $client->getCrawler()->filter('#album-form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('catch-state[ivysaur]');
+        $field->setValue('toevolve');
+
+        $blocksUnload = $client->executeScript(<<<'JS'
+                const event = new Event('beforeunload', {cancelable: true});
+                window.dispatchEvent(event);
+                return event.defaultPrevented;
+            JS);
+
+        $this->assertTrue($blocksUnload);
+    }
+
+    public function testActionCatchStateResolvedChangeAllowsUnload(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demo');
+
+        $client->executeScript("document.getElementById('ivysaur').scrollIntoView();");
+
+        $client->click(
+            $client
+                ->getCrawler()
+                ->filter('#ivysaur-catch-state-edit-action')
+                ->link()
+        );
+
+        $form = $client->getCrawler()->filter('#album-form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('catch-state[ivysaur]');
+        $field->setValue('toevolve');
+
+        $this->assertSelectorWillBeVisible('#successToast-ivysaur');
+
+        $blocksUnload = $client->executeScript(<<<'JS'
+                const event = new Event('beforeunload', {cancelable: true});
+                window.dispatchEvent(event);
+                return event.defaultPrevented;
+            JS);
+
+        $this->assertFalse($blocksUnload);
+    }
+```
+
+- [ ] **Step 4: Run the new tests to verify the first one fails**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter "testActionCatchStatePendingChangeBlocksUnload|testActionCatchStateResolvedChangeAllowsUnload" tests/src/Browser/Album/SelectAndLabelTest.php`
+
+Expected: `testActionCatchStatePendingChangeBlocksUnload` FAILS (`Failed asserting that false is true`) — there is no `beforeunload` listener yet, so `event.defaultPrevented` is always `false`. `testActionCatchStateResolvedChangeAllowsUnload` passes trivially (there's no listener to prevent anything either way) — that's expected at this stage; it becomes a meaningful regression guard once Task 2 adds the listener, and must stay green afterwards.
+
+---
+
+## Task 2: Implement the pending-changes counter and `beforeunload` guard
+
+**Files:**
+- Modify: `public/js/album-edit.js`
+
+**Interfaces:**
+- Consumes: nothing new — only browser globals (`window`, `fetch`, `Event`) and the existing DOM structure.
+- Produces: module-level `pendingChangesCount` and `onBeforeUnload`, used only internally by this file.
+
+- [ ] **Step 1: Add the counter and the `beforeunload` handler**
+
+In `public/js/album-edit.js`, replace:
+
+```js
+function watchCatchStates() {
+  document.querySelectorAll(".album-container select").forEach(function (element) {
+    element.dataset.committedValue = element.value;
+    element.addEventListener("change", onChangeCatchState);
+  });
+}
+```
+
+with:
+
+```js
+let pendingChangesCount = 0;
+
+function watchCatchStates() {
+  document.querySelectorAll(".album-container select").forEach(function (element) {
+    element.dataset.committedValue = element.value;
+    element.addEventListener("change", onChangeCatchState);
+  });
+
+  window.addEventListener("beforeunload", onBeforeUnload);
+}
+
+function onBeforeUnload(event) {
+  if (pendingChangesCount > 0) {
+    event.preventDefault();
+    event.returnValue = "";
+  }
+}
+```
+
+- [ ] **Step 2: Increment the counter when a change is submitted**
+
+Replace:
+
+```js
+function onChangeCatchState(event) {
+  const target = event.target;
+  const previousValue = target.dataset.committedValue ?? target.value;
+
+  target.disabled = true;
+
+  saveChange(target, previousValue);
+}
+```
+
+with:
+
+```js
+function onChangeCatchState(event) {
+  const target = event.target;
+  const previousValue = target.dataset.committedValue ?? target.value;
+
+  target.disabled = true;
+  pendingChangesCount++;
+
+  saveChange(target, previousValue);
+}
+```
+
+- [ ] **Step 3: Decrement the counter exactly once per request, regardless of outcome**
+
+Replace:
+
+```js
+  fetch(request)
+    .then((response) => {
+      if (response.status !== 200) {
+        throw new Error("Something went wrong on api server!");
+      }
+
+      target.dataset.committedValue = catchState;
+      changeClass(target);
+      target.disabled = false;
+
+      new bootstrap.Toast(
+        document.getElementById("successToast-" + pokemon)
+      ).show();
+    })
+    .catch((error) => {
+      console.error(error);
+
+      target.value = previousValue;
+      changeClass(target);
+      target.disabled = false;
+
+      new bootstrap.Toast(
+        document.getElementById("errorToast-" + pokemon)
+      ).show();
+    });
+}
+```
+
+with:
+
+```js
+  fetch(request)
+    .then((response) => {
+      if (response.status !== 200) {
+        throw new Error("Something went wrong on api server!");
+      }
+
+      target.dataset.committedValue = catchState;
+      changeClass(target);
+      target.disabled = false;
+
+      new bootstrap.Toast(
+        document.getElementById("successToast-" + pokemon)
+      ).show();
+    })
+    .catch((error) => {
+      console.error(error);
+
+      target.value = previousValue;
+      changeClass(target);
+      target.disabled = false;
+
+      new bootstrap.Toast(
+        document.getElementById("errorToast-" + pokemon)
+      ).show();
+    })
+    .finally(() => {
+      pendingChangesCount--;
+    });
+}
+```
+
+Note: decrementing must happen in a single `.finally()`, not once each in `.then` and `.catch` — on a non-200 response, the existing code `throw`s *inside* `.then`, which then also falls through to `.catch`; decrementing in both branches would double-count for that path.
+
+- [ ] **Step 4: Run the two new tests to verify they now pass**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter "testActionCatchStatePendingChangeBlocksUnload|testActionCatchStateResolvedChangeAllowsUnload" tests/src/Browser/Album/SelectAndLabelTest.php`
+
+Expected: both PASS.
+
+- [ ] **Step 5: Run the full `SelectAndLabelTest.php` file to check for regressions**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Browser/Album/SelectAndLabelTest.php`
+
+Expected: all tests PASS, including the pre-existing `testActionCatchStateChangeSuccess` and `testActionCatchStateChangeError` (their toast/rollback assertions are unaffected by the new counter, but this confirms the `.finally()` change didn't break the existing success/error flows).
+
+- [ ] **Step 6: Run the same file against Firefox**
+
+Run: `docker compose exec -e PANTHER_BROWSER_NAME=firefox -e PANTHER_SELENIUM_HOST=http://firefox:4444/wd/hub php php vendor/bin/phpunit tests/src/Browser/Album/SelectAndLabelTest.php`
+
+Expected: all tests PASS (matches `make tests-browser-firefox` coverage for this file).

--- a/docs/superpowers/specs/2026-07-28-pokedex-privacy-home-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-28-pokedex-privacy-home-toggle-design.md
@@ -1,0 +1,140 @@
+# Design — Toggle privacy & "add to home" from the Pokédex page
+
+**Date:** 2026-07-28
+**Branch:** dev-20260728
+
+## Context
+
+The trainer-owned flags `is_private` and `is_on_home` (see `DexFlags.php`) can today only be toggled from the "my albums" management page (`/trainer`, `templates/Trainer/Section/_dex.html.twig`), via a `PUT /trainer/dex/{dexSlug}` request (`TrainerUpsertController` → `ModifyTrainerDexService` → `Service/Back/ModifyDexService`). The Pokédex/album page itself (`/album/{dexSlug}`) only *displays* `is_private` read-only, as a lock badge in the offcanvas informations panel (`Album/_offcanvas.html.twig`); `is_on_home` isn't shown there at all.
+
+The user wants to add an album to the home page, and toggle its public/private status, directly from the Pokédex page instead of having to go to `/trainer`.
+
+Both flags are already exposed on the Album page's `Dex` response object (`isPrivate()`, `isOnHome()`), and the page already computes `allowedToEdit` (`AlbumIndexController::editDexIsGranted()`), which is the exact same ownership + premium/`ROLE_COLLECTOR` rule as the Trainer page's `canEdit`. No backend or BFF change is needed — this is a frontend-only addition that reuses an existing, already-tested endpoint.
+
+## Chosen approach
+
+Add a `form-switch` pair (`is_private`, `is_on_home`) to the offcanvas "informations" panel, shown only when `allowedToEdit` is true, reusing:
+- the exact markup/icon pattern already used on the Trainer page (`bi-incognito`, `bi-house-check`),
+- the exact same JS (`public/js/trainer_dex.js`, already generic — keys off `data-dex` on the closest `<form>`, listens on any checkbox, PUTs to `/trainer/dex/{slug}`, shows a toast by id) — no JS file changes needed, just include the script and call `watchAttributes()`,
+- the exact same translation keys already defined under `trainer.dex.attributes.is_private.*` / `is_on_home.*` and `trainer.dex.update.success` / `error` (the latter already parameterized with `dexName`, not tied to the Trainer page semantically) — no new translation keys needed.
+
+The existing read-only lock badge (`.album-private`, driven by `dex.isPrivate`) is left untouched and keeps rendering unconditionally (for every visitor, owner or not) exactly as today — it is already asserted on by five tests in `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`, all of which exercise the owner's own album (where `allowedToEdit` is true). Gating that badge on `not allowedToEdit` would hide it in exactly the cases those tests cover, forcing changes to well-established, unrelated assertions. Showing both a read-only status badge *and* an editable switch to the owner is not a new pattern either — the Trainer page already does exactly that (position-absolute badges for `is_shiny`/`is_premium`/`is_custom`/`not_released`, alongside editable switches for `is_private`/`is_on_home` in the same card).
+
+Two alternatives considered and rejected:
+- **Replace the lock badge with the switch when `allowedToEdit`** — more "correct" looking (no redundancy) but forces edits to 5 existing, unrelated integration test assertions for no functional gain, and diverges from the Trainer page's own established pattern of badge + switch coexisting.
+- **Icon buttons in `_intro.html.twig`'s action bar instead of the offcanvas** — considered during brainstorming; rejected by the user in favor of the offcanvas, which is also where the read-only privacy info already lives.
+
+## Behavior
+
+In `Album/_offcanvas.html.twig`, inside the "informations" block, right after the `<h2>{{ 'album.offcanvas.informations.title'|trans }}</h2>` heading and before the existing icons list:
+
+```twig
+{% if allowedToEdit %}
+  <form data-dex="{{ currentDexSlug }}">
+    {% set attributes = ['is_private', 'is_on_home'] %}
+    {% set attributesIcons = {'is_private': 'incognito', 'is_on_home': 'house-check'} %}
+    {% set flagMap = {'is_private': dex.isPrivate, 'is_on_home': dex.isOnHome} %}
+    {% for attribute in attributes %}
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" role="switch"
+          name="{{ currentDexSlug }}-{{ attribute }}"
+          id="offcanvas-{{ currentDexSlug }}-{{ attribute }}"
+          {{ flagMap[attribute] ? 'checked' : '' }}>
+        <label class="form-check-label" for="offcanvas-{{ currentDexSlug }}-{{ attribute }}">
+          <i class="bi bi-{{ attributesIcons[attribute] }}"></i>
+          {{ ('trainer.dex.attributes.'~attribute~'.label')|trans }}
+        </label>
+        <p class="form-text">
+          {{ ('trainer.dex.attributes.'~attribute~'.help')|trans }}
+        </p>
+      </div>
+    {% endfor %}
+  </form>
+{% endif %}
+```
+
+Note the input `id` is prefixed `offcanvas-` (unlike the Trainer page's bare `{{ dex.settings.slug }}-{{ attribute }}`) purely to avoid a DOM id clash if a user ever has both an offcanvas switch and — hypothetically — another element sharing the slug-based id; the `name` attribute (what `trainer_dex.js` actually reads via `FormData`) stays exactly `{{ currentDexSlug }}-{{ attribute }}` so the existing JS needs no changes.
+
+On change of either checkbox: `trainer_dex.js`'s existing `onChangeAttributes` → `saveChange` fires, disables the checkbox, `PUT`s `{"is_private": true}` (or `is_on_home`) to `/trainer/dex/{dexSlug}`, re-enables it and shows `#successToast-{dexSlug}` on success, or reverts the checked state and shows `#errorToast-{dexSlug}` on failure (HTTP status ≠ 200, e.g. the controller's 404 when premium+non-collector, or a 500).
+
+## Changes
+
+### 1. `templates/Album/_offcanvas.html.twig`
+Add the switches form shown above, gated on `allowedToEdit`. No change to the existing icons list, description, template text, or version block.
+
+### 2. `templates/Album/_toasts.html.twig`
+Currently: `{% if allowedToEdit %}` renders per-Pokémon catch-state toasts (`macro.toasts(item)`); `{% if not dex.isPrivate %}` renders the share toasts. Add, inside the existing `{% if allowedToEdit %}` branch, the two dex-flag toasts (success/error), reusing `trainer.dex.update.success` / `.error` (parameterized with `dexName`, taken from `locale is same as('fr') ? dex.frenchName : dex.name`):
+
+```twig
+{% if allowedToEdit %}
+    {% for item in list %}
+        {{ macro.toasts(item) }}
+    {% endfor %}
+
+    {% set dexName = locale is same as('fr') ? dex.frenchName : dex.name %}
+    <div id="successToast-{{ currentDexSlug }}" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          {{ 'trainer.dex.update.success.prefix'|trans }}
+          <strong>{{ 'trainer.dex.update.success.radical'|trans({'dexName': dexName}) }}</strong>
+          {{ 'trainer.dex.update.success.suffix'|trans }}
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+
+    <div id="errorToast-{{ currentDexSlug }}" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          {{ 'trainer.dex.update.error.prefix'|trans }}
+          <strong>{{ 'trainer.dex.update.error.radical'|trans({'dexName': dexName}) }}</strong>
+          {{ 'trainer.dex.update.error.suffix'|trans }}
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+{% endif %}
+```
+
+(`locale` is already set at the top of `Album/index.html.twig` as `{% set locale = app.request.locale %}` and passed down to includes.)
+
+### 3. `templates/Album/index.html.twig`
+Inside the existing `{% if allowedToEdit %}` block in `foot_javascript` (the one that already includes `album-edit.js` and defines `const locale`), add:
+
+```twig
+<script src="{{ asset('js/trainer_dex.js') }}"></script>
+```
+
+and add `watchAttributes();` to the existing IIFE, next to `watchToggleEditMode(); watchCatchStates(); ...`.
+
+No changes to `public/js/trainer_dex.js`, `public/js/album.js`, or `public/js/album-edit.js` — `trainer_dex.js`'s `watchAttributes()` binds to every `input[type="checkbox"]` on the page, and the Album page has no other checkboxes today, so this is safe to reuse verbatim.
+
+### 4. Translations
+None needed — reusing `trainer.dex.attributes.is_private.{label,help}`, `trainer.dex.attributes.is_on_home.{label,help}`, `trainer.dex.update.success.{prefix,radical,suffix}`, `trainer.dex.update.error.{prefix,radical,suffix}` as-is in both `messages+intl-icu.en.yaml` and `messages+intl-icu.fr.yaml`.
+
+## Testing
+
+- **`tests/src/Integration/Controller/Album/Display/OffcanvasTest.php`**: existing 6 tests are unaffected (no assertions on the new switches; the lock badge markup is untouched). Add new test methods:
+  - Owner viewing own private album (`/fr/album/goldsilvercrystal` as trainer `12`, `allowedToEdit` true): assert `#offcanvas form[data-dex="goldsilvercrystal"] input#offcanvas-goldsilvercrystal-is_private` exists and is `checked`; assert the `is_on_home` switch exists too.
+  - Another trainer's album (`testIntroDemoAnotherTrainer`'s scenario, `allowedToEdit` false): assert the switches form is absent (`assertCountFilter($crawler, 0, '#offcanvas form[data-dex]')`).
+- **`tests/src/Browser/Album/OffcanvasTest.php`** (or a new `tests/src/Browser/Album/PrivacyHomeToggleTest.php`, mirroring `tests/src/Browser/Trainer/CustomAlbumTrainerTest.php` exactly): reuse the same Moco-mocked slugs, no new fixtures needed —
+  - `goldsilvercrystal` (`PUT /trainer/dex/goldsilvercrystal` already mocked to succeed for the roles used in `GetUserToken::getFakeUserToken()`): tick/untick `is_private` and `is_on_home` on `/fr/album/goldsilvercrystal`, assert `#successToast-goldsilvercrystal` becomes visible then hides, `#errorToast-goldsilvercrystal` never shows.
+  - `redgreenblueyellow` (`PUT /trainer/dex/redgreenblueyellow` already mocked to return 500): same interaction, assert `#errorToast-redgreenblueyellow` shows and the checkbox reverts to its previous state.
+- No changes needed to `TrainerUpsertController`, `ModifyTrainerDexService`, `Service/Back/ModifyDexService`, or their existing unit tests — untouched code path.
+
+## Files to create/modify
+
+| File | Action |
+|---|---|
+| `templates/Album/_offcanvas.html.twig` | Add `is_private`/`is_on_home` switches form, gated on `allowedToEdit` |
+| `templates/Album/_toasts.html.twig` | Add success/error toasts for the dex-flag update, inside existing `allowedToEdit` branch |
+| `templates/Album/index.html.twig` | Include `trainer_dex.js`, call `watchAttributes();` inside existing `allowedToEdit` script block |
+| `tests/src/Integration/Controller/Album/Display/OffcanvasTest.php` | Add tests for switches presence/checked-state, gated on `allowedToEdit` |
+| `tests/src/Browser/Album/OffcanvasTest.php` or new `PrivacyHomeToggleTest.php` | Add tick/untick success + error browser tests, reusing existing Moco fixtures |
+
+## Out of scope
+
+- No "create a brand new album/dex" flow — confirmed with the user this feature is only about toggling `is_on_home` (and `is_private`) for the album currently being viewed, not creating a new dex entity (which has no existing creation endpoint in this frontend or, apparently, a dedicated one in the backend either — album "creation" today is implicit, triggered by the first `GET`).
+- No change to the Trainer page (`/trainer`), `TrainerUpsertController`, or any backend/BFF code — the existing `PUT /trainer/dex/{dexSlug}` contract is reused unchanged.
+- No new Moco fixtures — existing `goldsilvercrystal` (success) / `redgreenblueyellow` (error) mocks for `PUT /trainer/dex/{slug}`, already used by `CustomAlbumTrainerTest`, are reused as-is.
+- No change to the read-only `.album-private` lock badge or its visibility rule.

--- a/docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md
+++ b/docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md
@@ -1,0 +1,98 @@
+# Design — Prevent leaving the album page during a pending catch-state change
+
+**Date:** 2026-07-28
+**Branch:** dev-20260728
+
+## Context
+
+`public/js/album-edit.js` handles catch-state changes on the album display page (`templates/Album/index.html.twig`). Each `<select>` change fires an independent `fetch()` PATCH to `/{locale}/album/{dex}/{pokemon}` (`saveChange`, `album-edit.js:93-127`). The `<select>` is disabled while its own request is in flight and re-enabled with a success/error toast once it resolves — but there is no aggregate signal of "at least one request is still pending", and nothing stops the user from navigating away (closing the tab, reloading, clicking a link) while a PATCH is mid-flight.
+
+The app is plain server-rendered Twig with vanilla JS — no bundler, no Stimulus/Turbo, no SPA routing. Every navigation is a real browser navigation, so the native `beforeunload` event is the only (and sufficient) hook needed to cover all ways of leaving the page.
+
+## Chosen approach
+
+Track in-flight catch-state PATCH requests with a simple module-level counter in `album-edit.js`, and register a `beforeunload` listener that blocks navigation (via the native confirmation dialog) only while that counter is greater than zero.
+
+No debouncing, no request queue, no "unsaved changes" concept beyond in-flight requests — confirmed as out of scope: as soon as all responses come back (success or error, since error already rolls back optimistically), the page is free to leave again.
+
+## Behavior
+
+1. Module-level `let pendingChangesCount = 0;` in `album-edit.js`.
+2. `onChangeCatchState` increments `pendingChangesCount` before calling `saveChange`.
+3. `saveChange`'s `fetch(...)` chain gets a `.finally()` that decrements `pendingChangesCount` exactly once per request. (Decrementing in both `.then` and `.catch` would double-count: on a non-200 response, the existing code `throw`s *inside* `.then`, which then also falls through to `.catch` — so a single `.finally()` is required, not one decrement per branch.)
+4. `watchCatchStates()` (already only invoked when `allowedToEdit` is true, `templates/Album/index.html.twig:93`) additionally registers:
+   ```js
+   window.addEventListener("beforeunload", onBeforeUnload);
+   ```
+5. `onBeforeUnload(event)`: if `pendingChangesCount > 0`, calls `event.preventDefault()` and sets `event.returnValue = ""` to trigger the browser's native confirmation dialog. Modern browsers ignore any custom message text and show their own generic wording — this is expected and not worked around.
+
+No Twig changes needed: the listener piggybacks on the existing `watchCatchStates()` call, which is already gated correctly.
+
+## Changes
+
+### 1. `public/js/album-edit.js`
+
+```js
+let pendingChangesCount = 0;
+
+function watchCatchStates() {
+  document.querySelectorAll(".album-container select").forEach(function (element) {
+    element.dataset.committedValue = element.value;
+    element.addEventListener("change", onChangeCatchState);
+  });
+
+  window.addEventListener("beforeunload", onBeforeUnload);
+}
+
+function onBeforeUnload(event) {
+  if (pendingChangesCount > 0) {
+    event.preventDefault();
+    event.returnValue = "";
+  }
+}
+
+function onChangeCatchState(event) {
+  const target = event.target;
+  const previousValue = target.dataset.committedValue ?? target.value;
+
+  target.disabled = true;
+  pendingChangesCount++;
+
+  saveChange(target, previousValue);
+}
+```
+
+In `saveChange`, add `.finally(() => { pendingChangesCount--; })` after the existing `.then(...).catch(...)` chain.
+
+## Testing
+
+**Empirical finding (spiked against this project's actual Chrome and Firefox Selenium containers before writing the plan):** WebDriver-initiated navigation (`Client::request()`) bypasses the `beforeunload` prompt entirely on both browsers — no dialog appears, no exception is thrown, navigation just succeeds. This is standard WebDriver-spec behavior (automated navigation is defined to skip the prompt), not a bug in this app or this test setup. A test that navigates away and asserts a native dialog via `switchTo()->alert()` is therefore not viable here.
+
+**Chosen test approach:** exercise the real handler logic through a real browser, but observe it via a synthetic `beforeunload` event dispatched with `executeScript`, instead of relying on WebDriver's navigation/dialog interception. This still runs the actual `pendingChangesCount` counter and `onBeforeUnload` function shipped in `album-edit.js` — only the "is a real dialog shown" step is replaced with reading `event.defaultPrevented` back from the page.
+
+New tests in `tests/src/Browser/Album/SelectAndLabelTest.php`, alongside `testActionCatchStateChangeSuccess`/`testActionCatchStateChangeError`, reusing the `demo.json` Moco fixture:
+
+1. **Moco fixture with latency**: add an `ivysaur`-specific PATCH stub in `tests/resources/moco/Back/moco.json` (same pattern as the existing `squirtle`/`blastoise` overrides, inserted right before the generic catch-state stub so it takes priority), with `"response": {"status": "200", "latency": 3000}` so the request stays in flight long enough for the test to check the pending state.
+2. **Handler prevents unload while a request is pending**: login, open `/fr/album/demo`, activate edit mode on `#ivysaur`, change its catch-state select to `toevolve` (fires the slow PATCH), then immediately run `executeScript` to dispatch a `beforeunload` event on `window` and read back `.defaultPrevented`. Assert it is `true`.
+3. **Handler does not prevent unload once the request has resolved**: same flow, but wait for `assertSelectorWillBeVisible('#successToast-ivysaur')` first, then dispatch the same synthetic event and assert `.defaultPrevented` is `false`.
+
+`executeScript` runs arbitrary JS in the page and can return a value, so the dispatch + read-back happens in one call, e.g.:
+```js
+const event = new Event('beforeunload', {cancelable: true});
+window.dispatchEvent(event);
+return event.defaultPrevented;
+```
+
+## Files to create/modify
+
+| File | Action |
+|---|---|
+| `public/js/album-edit.js` | Add `pendingChangesCount` counter, `onBeforeUnload`, wire increments/decrements |
+| `tests/resources/moco/Back/moco.json` | Add a Pokemon-specific PATCH stub with `"latency"` |
+| `tests/src/Browser/Album/SelectAndLabelTest.php` | Add the two new tests above |
+
+## Out of scope
+
+- No debouncing/queueing of catch-state changes.
+- No "unsaved edit mode" tracking — only actual in-flight PATCH requests block navigation.
+- No custom dialog text (browsers force their own generic wording).

--- a/public/js/album-edit.js
+++ b/public/js/album-edit.js
@@ -45,9 +45,8 @@ function onChangeCatchState(event) {
   const previousValue = target.dataset.committedValue ?? target.value;
 
   target.disabled = true;
-  pendingChangesCount++;
 
-  saveChange(target, previousValue);
+  saveCatchStateChange(target, previousValue);
 }
 
 function onActivateEditMode(event) {
@@ -102,7 +101,7 @@ function onActivateAllReadMode(event) {
   readMode.setAttribute("hidden", true);
 }
 
-function saveChange(target, previousValue) {
+function saveCatchStateChange(target, previousValue) {
   const pokemon = target.closest(".album-case").getAttribute("id");
   const catchState = target.value;
 
@@ -110,6 +109,8 @@ function saveChange(target, previousValue) {
     method: "PATCH",
     body: catchState,
   });
+
+  pendingChangesCount++;
 
   fetch(request)
     .then((response) => {

--- a/public/js/album-edit.js
+++ b/public/js/album-edit.js
@@ -1,8 +1,19 @@
+let pendingChangesCount = 0;
+
 function watchCatchStates() {
   document.querySelectorAll(".album-container select").forEach(function (element) {
     element.dataset.committedValue = element.value;
     element.addEventListener("change", onChangeCatchState);
   });
+
+  window.addEventListener("beforeunload", onBeforeUnload);
+}
+
+function onBeforeUnload(event) {
+  if (pendingChangesCount > 0) {
+    event.preventDefault();
+    event.returnValue = "";
+  }
 }
 
 function watchToggleEditMode() {
@@ -34,6 +45,7 @@ function onChangeCatchState(event) {
   const previousValue = target.dataset.committedValue ?? target.value;
 
   target.disabled = true;
+  pendingChangesCount++;
 
   saveChange(target, previousValue);
 }
@@ -123,6 +135,9 @@ function saveChange(target, previousValue) {
       new bootstrap.Toast(
         document.getElementById("errorToast-" + pokemon)
       ).show();
+    })
+    .finally(() => {
+      pendingChangesCount--;
     });
 }
 

--- a/templates/Admin/_macros.html.twig
+++ b/templates/Admin/_macros.html.twig
@@ -93,6 +93,7 @@
     icon,
 ) %}
   <h3 class="text-body-emphasis">{{ ('admin.actions.'~action~'.'~item~'.title')|trans }}</h3>
+  <p class="admin-item-description text-body-secondary small">{{ ('admin.actions.'~action~'.'~item~'.description')|trans }}</p>
 {% endmacro %}
 
 {% macro actionIcon (

--- a/templates/Album/_offcanvas.html.twig
+++ b/templates/Album/_offcanvas.html.twig
@@ -75,6 +75,35 @@
 
     <div>
       <h2>
+        {{ 'album.offcanvas.parameters.title'|trans }}
+      </h2>
+
+      {% if allowedToEdit %}
+        <form data-dex="{{ currentDexSlug }}">
+          {% set flagAttributes = ['is_private', 'is_on_home'] %}
+          {% set flagAttributesIcons = {'is_private': 'incognito', 'is_on_home': 'house-check'} %}
+          {% set flagMap = {'is_private': dex.isPrivate, 'is_on_home': dex.isOnHome} %}
+          {% for flagAttribute in flagAttributes %}
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" role="switch"
+                name="{{ currentDexSlug }}-{{ flagAttribute }}"
+                id="offcanvas-{{ currentDexSlug }}-{{ flagAttribute }}"
+                {{ flagMap[flagAttribute] ? 'checked' : '' }}>
+              <label class="form-check-label" for="offcanvas-{{ currentDexSlug }}-{{ flagAttribute }}">
+                <i class="bi bi-{{ flagAttributesIcons[flagAttribute] }}"></i>
+                {{ ('trainer.dex.attributes.'~flagAttribute~'.label')|trans }}
+              </label>
+              <p class="form-text">
+                {{ ('trainer.dex.attributes.'~flagAttribute~'.help')|trans }}
+              </p>
+            </div>
+          {% endfor %}
+        </form>
+      {% endif %}
+    </div>
+
+    <div>
+      <h2>
         {{ 'album.offcanvas.informations.title'|trans }}
       </h2>
 

--- a/templates/Album/_toasts.html.twig
+++ b/templates/Album/_toasts.html.twig
@@ -6,6 +6,29 @@
             {% for item in list %}
                 {{ macro.toasts(item) }}
             {% endfor %}
+
+            {% set dexName = locale is same as('fr') ? dex.frenchName : dex.name %}
+            <div id="successToast-{{ currentDexSlug }}" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+              <div class="d-flex">
+                <div class="toast-body">
+                  {{ 'trainer.dex.update.success.prefix'|trans }}
+                  <strong>{{ 'trainer.dex.update.success.radical'|trans({'dexName': dexName}) }}</strong>
+                  {{ 'trainer.dex.update.success.suffix'|trans }}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+              </div>
+            </div>
+
+            <div id="errorToast-{{ currentDexSlug }}" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+              <div class="d-flex">
+                <div class="toast-body">
+                  {{ 'trainer.dex.update.error.prefix'|trans }}
+                  <strong>{{ 'trainer.dex.update.error.radical'|trans({'dexName': dexName}) }}</strong>
+                  {{ 'trainer.dex.update.error.suffix'|trans }}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+              </div>
+            </div>
         {% endif %}
 
         {% if not dex.isPrivate %}

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -79,6 +79,7 @@
 
     {% if allowedToEdit %}
     <script src="{{ asset('js/album-edit.js') }}"></script>
+    <script src="{{ asset('js/trainer_dex.js') }}"></script>
 
     <script>
     const catchStates = JSON.parse('{{ catchStates | map(cs => {name: cs.name, frenchName: cs.frenchName, slug: cs.slug, color: cs.color}) | json_encode | raw }}');
@@ -92,6 +93,7 @@
         watchCatchStates();
         watchToggleShinyMode();
         watchToAdjustSelectSizes();
+        watchAttributes();
     })();
     </script>
     {% endif %}

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -1570,6 +1570,28 @@
           "match": ".*"
         },
         "authorization": {
+          "match": "Bearer admin"
+        }
+      },
+      "text": {
+        "match": "\\{(\"is_private\": ?(?:true|false),? ?)?(\"is_on_home\": ?(?:true|false))?\\}"
+      }
+    },
+    "response": {
+      "status": "500"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/trainer/dex/redgreenblueyellow"
+      },
+      "method": "put",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
           "match": "Bearer 6c33064427a5b419ca8eb3f7d11a0807f66cab22"
         }
       },

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -2242,6 +2242,29 @@
   {
     "request": {
       "uri": {
+        "match": "/album/[\\w-]*/ivysaur"
+      },
+      "method": "patch",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      },
+      "text": {
+        "match": "no|toevolve|tobreed|totransfer|totrade|yes"
+      }
+    },
+    "response": {
+      "status": "200",
+      "latency": 3000
+    }
+  },
+  {
+    "request": {
+      "uri": {
         "match": "/album/[\\w-]*/[\\w-]*"
       },
       "method": "patch",

--- a/tests/src/Browser/Album/PrivacyHomeToggleTest.php
+++ b/tests/src/Browser/Album/PrivacyHomeToggleTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Album;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+#[Group('api-mocked-testing')]
+final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testSuccessTickIsOnHome(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertSelectorIsNotVisible('#successToast-goldsilvercrystal');
+
+        $client->executeScript("document.querySelector('.open-offcanvas').click()");
+        $this->assertSelectorWillBeVisible('#offcanvas');
+        $client->waitFor('#offcanvas.show:not(.showing)');
+
+        $client->executeScript("document.getElementById('offcanvas-goldsilvercrystal-is_on_home').scrollIntoView({block: 'center'});");
+
+        $form = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('goldsilvercrystal-is_on_home');
+        $field->tick();
+
+        $this->assertSelectorWillBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
+    }
+
+    public function testSuccessUntickIsPrivate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertSelectorIsNotVisible('#successToast-goldsilvercrystal');
+
+        $client->executeScript("document.querySelector('.open-offcanvas').click()");
+        $this->assertSelectorWillBeVisible('#offcanvas');
+        $client->waitFor('#offcanvas.show:not(.showing)');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('goldsilvercrystal-is_private');
+        $field->untick();
+
+        $this->assertSelectorWillBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#successToast-goldsilvercrystal');
+        $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
+    }
+
+    public function testErrorTickIsOnHome(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/redgreenblueyellow');
+
+        $this->assertSelectorIsNotVisible('#errorToast-redgreenblueyellow');
+
+        $client->executeScript("document.querySelector('.open-offcanvas').click()");
+        $this->assertSelectorWillBeVisible('#offcanvas');
+        $client->waitFor('#offcanvas.show:not(.showing)');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="redgreenblueyellow"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('redgreenblueyellow-is_on_home');
+        $field->tick();
+
+        $this->assertSelectorWillBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
+    }
+
+    public function testErrorUntickIsPrivate(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $crawler = $client->request('GET', '/fr/album/redgreenblueyellow');
+
+        $this->assertSelectorIsNotVisible('#errorToast-redgreenblueyellow');
+
+        $client->executeScript("document.querySelector('.open-offcanvas').click()");
+        $this->assertSelectorWillBeVisible('#offcanvas');
+        $client->waitFor('#offcanvas.show:not(.showing)');
+
+        $form = $crawler->filter('#offcanvas form[data-dex="redgreenblueyellow"]')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('redgreenblueyellow-is_private');
+        $field->untick();
+
+        $this->assertSelectorWillBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#errorToast-redgreenblueyellow');
+        $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
+    }
+}

--- a/tests/src/Browser/Album/SelectAndLabelTest.php
+++ b/tests/src/Browser/Album/SelectAndLabelTest.php
@@ -358,4 +358,74 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorAttributeContains('#squirtle', 'class', 'catch-state-no');
         $this->assertSelectorAttributeNotContains('#squirtle', 'class', 'catch-state-tobreed');
     }
+
+    public function testActionCatchStatePendingChangeBlocksUnload(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demo');
+
+        $client->executeScript("document.getElementById('ivysaur').scrollIntoView();");
+
+        $client->click(
+            $client
+                ->getCrawler()
+                ->filter('#ivysaur-catch-state-edit-action')
+                ->link()
+        );
+
+        $form = $client->getCrawler()->filter('#album-form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('catch-state[ivysaur]');
+        $field->setValue('toevolve');
+
+        $blocksUnload = $client->executeScript(<<<'JS'
+                const event = new Event('beforeunload', {cancelable: true});
+                window.dispatchEvent(event);
+                return event.defaultPrevented;
+            JS);
+
+        $this->assertTrue($blocksUnload);
+    }
+
+    public function testActionCatchStateResolvedChangeAllowsUnload(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demo');
+
+        $client->executeScript("document.getElementById('ivysaur').scrollIntoView();");
+
+        $client->click(
+            $client
+                ->getCrawler()
+                ->filter('#ivysaur-catch-state-edit-action')
+                ->link()
+        );
+
+        $form = $client->getCrawler()->filter('#album-form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('catch-state[ivysaur]');
+        $field->setValue('toevolve');
+
+        $this->assertSelectorWillBeVisible('#successToast-ivysaur');
+
+        $blocksUnload = $client->executeScript(<<<'JS'
+                const event = new Event('beforeunload', {cancelable: true});
+                window.dispatchEvent(event);
+                return event.defaultPrevented;
+            JS);
+
+        $this->assertFalse($blocksUnload);
+    }
 }

--- a/tests/src/Browser/Album/SelectAndLabelTest.php
+++ b/tests/src/Browser/Album/SelectAndLabelTest.php
@@ -428,4 +428,40 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
 
         $this->assertFalse($blocksUnload);
     }
+
+    public function testActionCatchStateFailedChangeAllowsUnload(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demo');
+
+        $client->executeScript("document.getElementById('squirtle').scrollIntoView();");
+
+        $client->click(
+            $client
+                ->getCrawler()
+                ->filter('#squirtle-catch-state-edit-action')
+                ->link()
+        );
+
+        $form = $client->getCrawler()->filter('#album-form')->form();
+
+        /** @var ChoiceFormField $field */
+        $field = $form->get('catch-state[squirtle]');
+        $field->setValue('tobreed');
+
+        $this->assertSelectorWillBeVisible('#errorToast-squirtle');
+
+        $blocksUnload = $client->executeScript(<<<'JS'
+                const event = new Event('beforeunload', {cancelable: true});
+                window.dispatchEvent(event);
+                return event.defaultPrevented;
+            JS);
+
+        $this->assertFalse($blocksUnload);
+    }
 }

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -80,7 +80,15 @@ final class AdminPageTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 6, 'h2');
         $this->assertCountFilter($crawler, 15, 'h3');
+        $this->assertCountFilter($crawler, 15, '.admin-item-description');
         $this->assertCountFilter($crawler, 15, '.admin-item button.admin-item-cta');
+
+        foreach ($this->getExpectedDescriptions() as $itemId => $description) {
+            $this->assertSame(
+                $description,
+                $crawler->filter("#{$itemId} .admin-item-description")->text()
+            );
+        }
 
         $this->assertCountFilter($crawler, 7, '.admin-item-update button.admin-item-cta');
         $this->assertCountFilter($crawler, 4, '.admin-item-calculate button.admin-item-cta');
@@ -149,6 +157,30 @@ final class AdminPageTest extends WebTestCase
                 );
             }
         }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getExpectedDescriptions(): array
+    {
+        return [
+            'update_labels' => 'Recharge les labels (traductions, catégories, tags) depuis la source Google Sheets.',
+            'update_games_collections_and_dex' => 'Recharge les jeux, les collections et les dex depuis la source Google Sheets.',
+            'update_pokemons' => 'Recharge les données des Pokémon (espèces, formes, statistiques) depuis la source Google Sheets.',
+            'update_regional_dex_numbers' => 'Recharge les numéros de dex régionaux de chaque Pokémon depuis la source Google Sheets.',
+            'update_games_availabilities' => 'Recalcule quels Pokémon sont disponibles dans chaque jeu.',
+            'update_games_shinies_availabilities' => 'Recalcule quels Pokémon chromatiques sont disponibles dans chaque jeu.',
+            'update_collections_availabilities' => 'Recalcule quels Pokémon sont disponibles dans chaque collection.',
+            'calculate_game_bundles_availabilities' => 'Agrège les disponibilités des jeux au niveau des bundles de jeux.',
+            'calculate_game_bundles_shinies_availabilities' => 'Agrège les disponibilités chromatiques des jeux au niveau des bundles de jeux.',
+            'calculate_dex_availabilities' => 'Agrège les disponibilités des jeux et des collections au niveau des dex.',
+            'calculate_pokemon_availabilities' => "Agrège toutes les disponibilités en un résumé par Pokémon, utilisé dans toute l'application.",
+            'invalidate_labels' => "Vide le cache des labels pour qu'ils soient rechargés au prochain accès.",
+            'invalidate_dex' => "Vide le cache des pages de dex pour qu'elles soient rechargées au prochain accès.",
+            'invalidate_albums' => "Vide le cache des pages d'album pour qu'elles soient rechargées au prochain accès.",
+            'trigger_update_images' => "Régénère le jeu d'images des Pokémon à partir des dernières données.",
+        ];
     }
 
     private function getAdminHomeConnected(): Crawler

--- a/tests/src/Integration/Controller/Admin/AdminReportsTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminReportsTest.php
@@ -20,6 +20,9 @@ final class AdminReportsTest extends WebTestCase
 {
     use TestNavTrait;
 
+    /**
+     * @SuppressWarnings("PHPMD.ExcessiveMethodLength")
+     */
     public function testAdminHome(): void
     {
         $client = self::createClient();
@@ -44,6 +47,10 @@ final class AdminReportsTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 2, 'table.report-table');
         $this->assertCountFilter($crawler, 1, '.admin-item-invalidate_reports button.admin-item-cta');
+        $this->assertSame(
+            'Vide le cache des rapports admin pour recharger des chiffres à jour au prochain accès.',
+            $crawler->filter('#invalidate_reports .admin-item-description')->text()
+        );
 
         $this->assertCountFilter($crawler, 1, 'canvas#catch_state_counts_defined_by_trainer');
         $this->assertCountFilter($crawler, 1, 'table#report-table-catch_state_counts_defined_by_trainer');

--- a/tests/src/Integration/Controller/Album/Display/CommonTest.php
+++ b/tests/src/Integration/Controller/Album/Display/CommonTest.php
@@ -172,10 +172,10 @@ final class CommonTest extends WebTestCase
         $this->assertCountFilter($crawler, 41, '.album-case .album-case-catch-state a.album-case-catch-state-label');
         $this->assertCountFilter($crawler, 0, '.album-case .album-case-catch-state span.album-case-catch-state-label');
 
-        $this->assertCountFilter($crawler, 84, '.toast');
-        $this->assertCountFilter($crawler, 41, '.toast.text-bg-success');
+        $this->assertCountFilter($crawler, 86, '.toast');
+        $this->assertCountFilter($crawler, 42, '.toast.text-bg-success');
         $this->assertCountFilter($crawler, 1, '.toast.text-bg-light');
-        $this->assertCountFilter($crawler, 42, '.toast.text-bg-danger');
+        $this->assertCountFilter($crawler, 43, '.toast.text-bg-danger');
 
         $this->assertCountFilter($crawler, 1, 'script[src="/js/album.js"]');
 

--- a/tests/src/Integration/Controller/Album/Display/OffcanvasTest.php
+++ b/tests/src/Integration/Controller/Album/Display/OffcanvasTest.php
@@ -356,6 +356,68 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
     }
 
+    public function testSwitchesForOwner(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertCountFilter($crawler, 1, '#offcanvas form[data-dex="goldsilvercrystal"]');
+
+        $isPrivate = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"] input[name="goldsilvercrystal-is_private"]');
+        $this->assertCount(1, $isPrivate);
+        $this->assertNotNull($isPrivate->attr('checked'));
+
+        $isOnHome = $crawler->filter('#offcanvas form[data-dex="goldsilvercrystal"] input[name="goldsilvercrystal-is_on_home"]');
+        $this->assertCount(1, $isOnHome);
+        $this->assertNull($isOnHome->attr('checked'));
+    }
+
+    public function testSwitchesAbsentForAnotherTrainer(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('13', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
+
+        $this->assertCountFilter($crawler, 0, '#offcanvas form[data-dex]');
+    }
+
+    public function testFlagToastsForOwner(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('12', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/goldsilvercrystal');
+
+        $this->assertCountFilter($crawler, 1, '#successToast-goldsilvercrystal');
+        $this->assertCountFilter($crawler, 1, '#errorToast-goldsilvercrystal');
+    }
+
+    public function testFlagToastsAbsentForAnotherTrainer(): void
+    {
+        $client = self::createClient();
+
+        $user = GetUserToken::getFakeUserToken('13', 'TestProvider');
+        $user->addTrainerRole();
+        $client->loginUser($user, 'web');
+
+        $crawler = $client->request('GET', '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
+
+        $this->assertCountFilter($crawler, 0, '#successToast-demo');
+        $this->assertCountFilter($crawler, 0, '#errorToast-demo');
+    }
+
     private function assertFiltersPrimaryType(Crawler $crawler, string $lang): void
     {
         $this->assertCount(1, $crawler->filter('select#primary_type'));

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -141,6 +141,8 @@ album:
   offcanvas:
     informations:
       title: Informations
+    parameters:
+      title: Parameters
     filters:
       title: Filters
       open_distinguish_types: More

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -379,30 +379,37 @@ admin:
         title: "Update games' availabilities"
         item: "Games' availabilities"
         cta: "Update!"
+        description: "Recomputes which Pokémon are available in each game."
       games_shinies_availabilities:
         title: "Update games' shinies' availabilities"
         item: "Games' shinies' availabilities"
         cta: "Update!"
+        description: "Recomputes which shiny Pokémon are available in each game."
       collections_availabilities:
         title: "Update collections"
         item: "Collections' availabilities"
         cta: "Update!"
+        description: "Recomputes which Pokémon are available in each collection."
     update_data:
       title: "Update data"
       labels:
         title: "Update labels"
         cta: "Update!"
+        description: "Resyncs labels (translations, categories, tags) from the Google Sheets source."
       games_collections_and_dex:
         title: "Update games, collections and dex"
         cta: "Update!"
+        description: "Resyncs games, collections and dex definitions from the Google Sheets source."
       pokemons:
         title: "Update pokémons"
         item: "Pokémons"
         cta: "Update!"
+        description: "Resyncs Pokémon data (species, forms, stats) from the Google Sheets source."
       regional_dex_numbers:
         title: "Update regional dex numbers"
         item: "Regional Dex numbers"
         cta: "Update!"
+        description: "Resyncs each Pokémon's regional dex numbers from the Google Sheets source."
       game_generations:
         item: "Game's generations"
       game_bundles:
@@ -434,17 +441,21 @@ admin:
         title: "Calculate game bundles' availabilities"
         item: "Bundles' availabilities"
         cta: "Calculate!"
+        description: "Aggregates game availabilities into game bundle availabilities."
       game_bundles_shinies_availabilities:
         title: "Calculate game bundles' shinies' availabilities"
         item: "Bundles' shinies' availabilities"
         cta: "Calculate!"
+        description: "Aggregates shiny game availabilities into game bundle shiny availabilities."
       dex_availabilities:
         title: "Calculate dex availabilities"
         item: "Dex' availabilities"
         cta: "Calculate!"
+        description: "Aggregates game and collection availabilities into dex-level availabilities."
       pokemon_availabilities:
         title: "Calculate pokemons availabilities"
         cta: "Calculate!"
+        description: "Aggregates all availability data into a per-Pokémon summary used across the app."
       pokemon_availabilities_game_bundle:
         item: "Pokemons' availabilities for Game bundles"
       pokemon_availabilities_game_bundle_shiny:
@@ -460,12 +471,15 @@ admin:
       labels:
         title: "Invalidate labels cache"
         cta: "Invalidate!"
+        description: "Clears the cached labels so the next request reloads them fresh."
       dex:
         title: "Invalidate dex cache"
         cta: "Invalidate!"
+        description: "Clears the cached dex pages so the next request reloads them fresh."
       albums:
         title: "Invalidate album cache"
         cta: "Invalidate!"
+        description: "Clears the cached album pages so the next request reloads them fresh."
       actions:
         title: "Invalidate actions cache"
         cta: "Invalidate!"
@@ -475,10 +489,12 @@ admin:
       update_images:
         title: "Update Pokémon images"
         cta: "Trigger!"
+        description: "Regenerates the Pokémon image set from the latest data."
     reports_data:
       reports:
         title: "Invalidate reports cache"
         cta: "Invalidate!"
+        description: "Clears the cached admin reports so the next visit reloads up-to-date figures."
 
 election:
   candidates:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -383,30 +383,37 @@ admin:
         title: "Mise à jour des disponibilités des jeux"
         item: "Disponibilités des jeux"
         cta: "Mettre à jour"
+        description: "Recalcule quels Pokémon sont disponibles dans chaque jeu."
       games_shinies_availabilities:
         title: "Mise à jour des disponibilités des jeux des chromatiques"
         item: "Disponibilités des jeux des chromatiques"
         cta: "Mettre à jour"
+        description: "Recalcule quels Pokémon chromatiques sont disponibles dans chaque jeu."
       collections_availabilities:
         title: "Mise à jour des disponibilités des collections"
         item: "Disponibilités des collections"
         cta: "Mettre à jour"
+        description: "Recalcule quels Pokémon sont disponibles dans chaque collection."
     update_data:
       title: "Mises à jour des données"
       labels:
         title: "Mise à jour des labels"
         cta: "Mettre à jour"
+        description: "Recharge les labels (traductions, catégories, tags) depuis la source Google Sheets."
       games_collections_and_dex:
         title: "Mise à jour des jeux, des collections et des dex"
         cta: "Mettre à jour"
+        description: "Recharge les jeux, les collections et les dex depuis la source Google Sheets."
       pokemons:
         title: "Mise à jour des pokémons"
         item: "Pokémons"
         cta: "Mettre à jour"
+        description: "Recharge les données des Pokémon (espèces, formes, statistiques) depuis la source Google Sheets."
       regional_dex_numbers:
         title: "Mise à jour des numéro des dex régionaux"
         item: "Numéros de dex régionaux"
         cta: "Mettre à jour"
+        description: "Recharge les numéros de dex régionaux de chaque Pokémon depuis la source Google Sheets."
       game_generations:
         item: "Générations"
       game_bundles:
@@ -438,17 +445,21 @@ admin:
         title: "Calculs des disponibilités des bundles de jeux"
         item: "Disponibilités des bundles"
         cta: "Calculer"
+        description: "Agrège les disponibilités des jeux au niveau des bundles de jeux."
       game_bundles_shinies_availabilities:
         title: "Calculs des disponibilités des bundles de jeux des chromatiques"
         item: "Disponibilités des bundles des chromatiques"
         cta: "Calculer"
+        description: "Agrège les disponibilités chromatiques des jeux au niveau des bundles de jeux."
       dex_availabilities:
         title: "Calculs des disponibilités des dex"
         item: "Disponibilités des dex"
         cta: "Calculer"
+        description: "Agrège les disponibilités des jeux et des collections au niveau des dex."
       pokemon_availabilities:
         title: "Calculs des disponibilités par pokemons"
         cta: "Calculer"
+        description: "Agrège toutes les disponibilités en un résumé par Pokémon, utilisé dans toute l'application."
       pokemon_availabilities_game_bundle:
         item: "Disponibilités des packs de jeux par pokémons"
       pokemon_availabilities_game_bundle_shiny:
@@ -465,12 +476,15 @@ admin:
       labels:
         title: "Invalidation du cache des labels"
         cta: "Invalider"
+        description: "Vide le cache des labels pour qu'ils soient rechargés au prochain accès."
       dex:
         title: "Invalidation du cache des dex"
         cta: "Invalider"
+        description: "Vide le cache des pages de dex pour qu'elles soient rechargées au prochain accès."
       albums:
         title: "Invalidation du cache des albums"
         cta: "Invalider"
+        description: "Vide le cache des pages d'album pour qu'elles soient rechargées au prochain accès."
       actions:
         title: "Invalidation du cache des actions"
         cta: "Invalider"
@@ -481,11 +495,13 @@ admin:
       update_images:
         title: "Mettre à jour les images des Pokémon"
         cta: "Déclencher"
+        description: "Régénère le jeu d'images des Pokémon à partir des dernières données."
 
     reports_data:
       reports:
         title: "Invalidation du cache des rapports"
         cta: "Invalider"
+        description: "Vide le cache des rapports admin pour recharger des chiffres à jour au prochain accès."
 
 election:
   candidates:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -147,6 +147,8 @@ album:
   offcanvas:
     informations:
       title: Informations
+    parameters:
+      title: Paramètres
     title: Filtres
     open_distinguish_types: Avancées
   share:


### PR DESCRIPTION
## Summary

- Privacy and home visibility toggles on the album offcanvas (owners can flip `is_private`/`is_on_home` directly, with success/error toasts).
- Descriptions added for admin actions.
- New feature: warn before leaving the album page while a catch-state change is still saving. A `pendingChangesCount` counter in `public/js/album-edit.js` is incremented when a catch-state PATCH is sent and decremented once it settles (success or error), and a `beforeunload` listener blocks navigation (native browser dialog) while the counter is above zero.
- Along the way, found and fixed a pre-existing bug: `public/js/album-edit.js` and `public/js/trainer_dex.js` both declared a global `function saveChange(...)`; since both load as classic `<script>` tags sharing one global scope on the album page, the second silently overwrote the first, so catch-state saves were silently calling the wrong function. Renamed to `saveCatchStateChange` in `album-edit.js` only.

## Test plan

- [ ] `make tests-browser-chrome` / `make tests-browser-firefox` — in particular `tests/src/Browser/Album/SelectAndLabelTest.php` (new tests: `testActionCatchStatePendingChangeBlocksUnload`, `testActionCatchStateResolvedChangeAllowsUnload`, `testActionCatchStateFailedChangeAllowsUnload`) and `tests/src/Browser/Album/PrivacyHomeToggleTest.php` — **not run in this session**, needs verification before merge.
- [ ] `make quality` / `make measures`

Design doc: `docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-28-prevent-leave-pending-catch-state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pQaUd52DpeAehc4hUp2CB