### PR TITLE
Let admins force-trigger a pending admin action with confirmation

### DIFF
--- a/docs/superpowers/plans/2026-07-29-force-pending-admin-action.md
+++ b/docs/superpowers/plans/2026-07-29-force-pending-admin-action.md
@@ -1,0 +1,437 @@
+# Force a Pending Admin Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin force-trigger a pending admin action from the UI (with a confirmation dialog showing how long it's been pending), instead of the button being permanently disabled.
+
+**Architecture:** Pure front-end change — no backend/API changes. The `admin-item-cta` button is never rendered `disabled`; when the underlying action is `pending`, it carries a `data-confirm-message` attribute (translated string with elapsed duration, computed server-side in Twig using the same `.diff(date('now'))` pattern the codebase already uses for the progress bar). A new vanilla-JS function intercepts the form's `submit` event and shows `window.confirm(...)` only for buttons carrying that attribute; canceling prevents the submit, confirming lets the existing POST flow run unchanged.
+
+**Tech Stack:** Symfony 8 Twig macros, plain JS (no framework — matches existing `public/js/admin.js` style), Symfony Translation (ICU MessageFormat), PHPUnit `WebTestCase` (Moco-backed integration test), Panther browser test.
+
+## Global Constraints
+
+- No server-side check/lock is added anywhere (`AdminActionController` stays untouched) — confirmed the backend already allows duplicate/concurrent triggers, so this feature only replaces a client-side restriction, per the approved spec `docs/superpowers/specs/2026-07-29-force-pending-admin-action-design.md`.
+- `declare(strict_types=1)` in any PHP file touched; test classes are `final`, `@internal`, and carry the appropriate PHPUnit attributes (`#[CoversClass(...)]` or `#[CoversNothing]` for browser tests, matching existing sibling tests).
+- Follow existing code style exactly (no unrelated refactors of `progress` macro or `admin.js`'s existing functions).
+- `make code-quality` (phpcsfixer, phpstan, psalm, phpmd, deptrac) and `make tests-integration` / `make tests-browser` must pass before considering a task done.
+
+---
+
+### Task 1: Twig — always-clickable button with `data-confirm-message`
+
+**Files:**
+- Modify: `templates/Admin/_macros.html.twig:84` (call site) and `templates/Admin/_macros.html.twig:111-142` (macro `actionButton`)
+- Test: `tests/src/Integration/Controller/Admin/AdminPageTest.php:99-102` (existing `testAdminHome` method)
+
+**Interfaces:**
+- Produces: macro `_self.formatElapsed(timeDiff)` (Twig macro, takes a `DateInterval`-like object with `.days`, `.h`, `.i` properties, returns a formatted string like `"3j 12h"`, `"2h 5min"`, or `"1 min"`).
+- Produces: `data-confirm-message` HTML attribute on `button.admin-item-cta`, present only when the action's `currentState == 'pending'`, containing the fully-translated confirmation string.
+- Consumes: existing `admin.action.force_confirm` translation key (added in Task 2) via `|trans({'duration': duration})`.
+
+- [ ] **Step 1: Write the failing integration test assertions**
+
+Open `tests/src/Integration/Controller/Admin/AdminPageTest.php` and replace lines 99-102:
+
+```php
+        $this->assertCountFilter($crawler, 3, '.admin-item-cta.disabled');
+        $this->assertCountFilter($crawler, 1, '#update_games_collections_and_dex .admin-item-cta.disabled');
+        $this->assertCountFilter($crawler, 1, '#calculate_game_bundles_availabilities .admin-item-cta.disabled');
+        $this->assertCountFilter($crawler, 1, '#calculate_dex_availabilities .admin-item-cta.disabled');
+```
+
+with:
+
+```php
+        $this->assertCountFilter($crawler, 0, '.admin-item-cta.disabled');
+
+        $this->assertCountFilter($crawler, 3, '.admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#update_games_collections_and_dex .admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#calculate_game_bundles_availabilities .admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#calculate_dex_availabilities .admin-item-cta[data-confirm-message]');
+
+        $confirmMessage = $crawler->filter('#update_games_collections_and_dex .admin-item-cta')->attr('data-confirm-message') ?? '';
+        $this->assertStringContainsString('Une exécution est en cours depuis', $confirmMessage);
+        $this->assertStringContainsString('j ', $confirmMessage);
+        $this->assertStringContainsString('Voulez-vous quand même relancer cette action', $confirmMessage);
+```
+
+The fixture `tests/resources/moco/Back/responses/action-logs.json` has `update_games_collections_and_dex.current.created_at` = `2023-09-01T08:00:20+00:00` with `done_at: null` — always more than a day in the past relative to any real test run, so asserting `'j '` (the "days" unit in the formatted duration) in the message is deterministic without pinning an exact number.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+docker compose exec php php vendor/bin/phpunit --filter testAdminHome tests/src/Integration/Controller/Admin/AdminPageTest.php
+```
+
+Expected: FAIL — `.admin-item-cta.disabled` still exists (3, not 0) and `[data-confirm-message]` doesn't exist yet (0, not 3).
+
+- [ ] **Step 3: Add the `formatElapsed` macro and update `actionButton`**
+
+In `templates/Admin/_macros.html.twig`, change the call site at line 84 from:
+
+```twig
+        {{ _self.actionButton(action, actionPrefix, item, currentState, currentBgStyle) }}
+```
+
+to:
+
+```twig
+        {{ _self.actionButton(action, actionPrefix, item, currentState, currentBgStyle, currentActionLog) }}
+```
+
+Then replace the `actionButton` macro (lines 111-142) with:
+
+```twig
+{% macro actionButton (
+    action,
+    actionPrefix,
+    item,
+    currentState,
+    bgStyle,
+    currentActionLog
+) %}
+  {% set csrfId = 'admin_' ~ actionPrefix %}
+  {% set confirmMessage = null %}
+  {% if currentState == 'pending' %}
+    {% set timeDiff = currentActionLog.createdAt.diff(date('now')) %}
+    {% set confirmMessage = ('admin.action.force_confirm')|trans({'duration': _self.formatElapsed(timeDiff)}) %}
+  {% endif %}
+  <div class="text-end border-top border-{{ bgStyle }} pt-3">
+    <form method="post" action="{{ path('app_adminaction_'~actionPrefix, {'name': item}) }}">
+      <input type="hidden" name="_token" value="{{ csrf_token(csrfId) }}">
+      <button
+        type="submit"
+        class="btn btn-outline-primary admin-item-cta"
+        {% if confirmMessage is not null %}data-confirm-message="{{ confirmMessage }}"{% endif %}
+      >
+        {{ ('admin.actions.'~action~'.'~item~'.cta')|trans }}
+      </button>
+
+    {% if currentState == 'pending' %}
+      {% set query = app.request.query.all %}
+      {% set query = query|merge({
+    'refresh': 'now'|date('U'),
+    '_fragment': actionPrefix~'_'~item,
+    }) %}
+      <a href="{{ path(app.request.attributes.get('_route'), query) }}" class="btn btn-outline-info btn-sm admin-item-refresh">
+        <i class="bi bi-arrow-clockwise"></i>
+      </a>
+    {% endif %}
+    </form>
+  </div>
+{% endmacro %}
+
+{% macro formatElapsed(timeDiff) %}
+  {%- if timeDiff.days > 0 -%}
+    {{ timeDiff.days }}j {{ timeDiff.h }}h
+  {%- elseif timeDiff.h > 0 -%}
+    {{ timeDiff.h }}h {{ timeDiff.i }}min
+  {%- else -%}
+    {{ timeDiff.i > 0 ? timeDiff.i : 1 }} min
+  {%- endif -%}
+{% endmacro %}
+```
+
+Note: `timeDiff.days` (total whole days elapsed) is the same property already used by the existing `progress` macro at line ~264 (`actionData.createdAt.diff(date('now'))`) — this is not a new pattern, just reused.
+
+This step alone will still fail the test because the translation key doesn't exist yet (Task 2) — that's expected; do not skip to running tests yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/Admin/_macros.html.twig tests/src/Integration/Controller/Admin/AdminPageTest.php
+git commit -m "feat(admin): always render action button clickable with data-confirm-message when pending"
+```
+
+---
+
+### Task 2: Translations for the confirmation message
+
+**Files:**
+- Modify: `translations/messages+intl-icu.fr.yaml` (under the existing `admin: action:` block, currently lines 361-364)
+- Modify: `translations/messages+intl-icu.en.yaml` (under the existing `admin: action:` block, currently lines 356-359)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: translation key `admin.action.force_confirm` with an ICU `{duration}` placeholder, used by Task 1's Twig code (`'admin.action.force_confirm'|trans({'duration': ...})`).
+
+- [ ] **Step 1: Add the French translation**
+
+In `translations/messages+intl-icu.fr.yaml`, the `admin: action:` block currently reads:
+
+```yaml
+  action:
+    created_at: "Démarré le"
+    done_at: "Terminé le"
+    execution_time: "Terminé en"
+```
+
+Change it to:
+
+```yaml
+  action:
+    created_at: "Démarré le"
+    done_at: "Terminé le"
+    execution_time: "Terminé en"
+    force_confirm: "Une exécution est en cours depuis {duration}. Voulez-vous quand même relancer cette action ?"
+```
+
+- [ ] **Step 2: Add the English translation**
+
+In `translations/messages+intl-icu.en.yaml`, the `admin: action:` block currently reads:
+
+```yaml
+  action:
+    created_at: "Start at"
+    done_at: "End at"
+    execution_time: "Execution time"
+```
+
+Change it to:
+
+```yaml
+  action:
+    created_at: "Start at"
+    done_at: "End at"
+    execution_time: "Execution time"
+    force_confirm: "An execution has been running for {duration}. Do you still want to trigger this action?"
+```
+
+- [ ] **Step 3: Run the integration test from Task 1 to verify it now passes**
+
+```bash
+docker compose exec php php vendor/bin/phpunit --filter testAdminHome tests/src/Integration/Controller/Admin/AdminPageTest.php
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run jsonlint/yaml lint for the translation files**
+
+```bash
+docker compose exec php php vendor/bin/console lint:yaml translations/messages+intl-icu.fr.yaml translations/messages+intl-icu.en.yaml
+```
+
+Expected: both files reported valid.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add translations/messages+intl-icu.fr.yaml translations/messages+intl-icu.en.yaml
+git commit -m "feat(admin): add force_confirm translation for pending action override"
+```
+
+---
+
+### Task 3: JS confirmation handler
+
+**Files:**
+- Modify: `public/js/admin.js` (append new function, following the existing plain-function style of `watchActionLogToggles`)
+- Modify: `templates/Admin/actions.html.twig:42-46` (inline `foot_javascript` block)
+- Test: `tests/src/Browser/Admin/ForceActionTest.php` (new)
+
+**Interfaces:**
+- Consumes: `button.admin-item-cta[data-confirm-message]` markup produced by Task 1.
+- Produces: global function `watchForceConfirm()` (no args, no return value), to be called once at page load exactly like `watchActionLogToggles()` already is.
+
+- [ ] **Step 1: Write the failing browser test**
+
+Create `tests/src/Browser/Admin/ForceActionTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Admin;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use Facebook\WebDriver\WebDriverBy;
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class ForceActionTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testDismissingConfirmationKeepsActionPending(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('109903422692691644111', 'TestProvider');
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/istration/actions');
+
+        $client
+            ->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex button.admin-item-cta'))
+            ->click();
+
+        $alert = $client->switchTo()->alert();
+        $this->assertStringContainsString('Une exécution est en cours depuis', $alert->getText());
+        $alert->dismiss();
+
+        $crawler = $client->refreshCrawler();
+        $this->assertSame('', $crawler->filter('#update_games_collections_and_dex')->attr('data-updated-state'));
+    }
+
+    public function testAcceptingConfirmationSubmitsTheForm(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('109903422692691644222', 'TestProvider');
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/istration/actions');
+
+        $client
+            ->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex button.admin-item-cta'))
+            ->click();
+
+        $alert = $client->switchTo()->alert();
+        $alert->accept();
+
+        // The click triggers a real page navigation (POST then 302 redirect back to the GET page).
+        // Panther's own submit() helper has Firefox-specific waiting logic for exactly this reason
+        // (vendor/symfony/panther/src/Client.php:227-246); since we bypass that helper (see note
+        // below), wait explicitly for the post-redirect DOM state instead of assuming the click()
+        // call already blocked until navigation finished.
+        $client->wait()->until(static function () use ($client) {
+            return '' !== $client->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex'))->getAttribute('data-updated-state');
+        });
+
+        $crawler = $client->refreshCrawler();
+        $this->assertNotSame('', $crawler->filter('#update_games_collections_and_dex')->attr('data-updated-state'));
+    }
+}
+```
+
+Note: this uses `$client->findElement(...)->click()` (raw WebDriver) instead of Panther's `Client::click()`/`submit()` helpers, because those helpers call `createCrawler()` right after clicking — which would hit the open native `confirm()` dialog and throw `UnexpectedAlertOpenException` before the test gets a chance to inspect it. `$client->switchTo()->alert()`, `$client->refreshCrawler()`, and `$client->wait()` are all public methods on `Symfony\Component\Panther\Client` (confirmed at `vendor/symfony/panther/src/Client.php:646`, `:257`, and `:625`). The assertion on `data-updated-state` (set in `templates/Admin/_macros.html.twig:77` from the `updatedState` flash) is what actually distinguishes "no POST happened" (dismiss — attribute stays `''`, its value with no flash set) from "POST happened" (accept — `AdminActionController::execute()` always redirects back with an item/action/state flash, confirmed in `src/Controller/AdminActionController.php`, so the attribute becomes non-empty either way, success or failure).
+
+- [ ] **Step 2: Run the browser test to verify it fails**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/ForceActionTest.php
+```
+
+Expected: FAIL — no `data-confirm-message` handling exists yet, so clicking submits the form immediately (no JS alert appears), and `$client->switchTo()->alert()` throws a `NoSuchAlertException`.
+
+- [ ] **Step 3: Implement `watchForceConfirm()` in `public/js/admin.js`**
+
+Append at the end of the file:
+
+```js
+function watchForceConfirm() {
+    document.querySelectorAll(".admin-item-cta[data-confirm-message]").forEach(function (button) {
+        const form = button.closest('form');
+        if (!form) {
+            return;
+        }
+        form.addEventListener('submit', function (event) {
+            if (!window.confirm(button.getAttribute('data-confirm-message'))) {
+                event.preventDefault();
+            }
+        });
+    });
+}
+```
+
+- [ ] **Step 4: Wire it up in `templates/Admin/actions.html.twig`**
+
+Replace the `foot_javascript` block (lines 39-47):
+
+```twig
+{% block foot_javascript %}
+  {{ parent() }}
+
+  <script>
+    (function () {
+      watchActionLogToggles();
+    })();
+  </script>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block foot_javascript %}
+  {{ parent() }}
+
+  <script>
+    (function () {
+      watchActionLogToggles();
+      watchForceConfirm();
+    })();
+  </script>
+{% endblock %}
+```
+
+- [ ] **Step 5: Run the browser test to verify it passes**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/ForceActionTest.php
+```
+
+Expected: PASS for both `testDismissingConfirmationKeepsActionPending` and `testAcceptingConfirmationSubmitsTheForm`.
+
+- [ ] **Step 6: Run the full existing browser suite for the Admin folder to check for regressions**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/
+```
+
+Expected: all tests (including the pre-existing `ToggleActionsTest` and `RedirectActionsTest`) still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add public/js/admin.js templates/Admin/actions.html.twig tests/src/Browser/Admin/ForceActionTest.php
+git commit -m "feat(admin): confirm before submitting a pending admin action"
+```
+
+---
+
+### Task 4: Full regression pass
+
+**Files:** none (verification only)
+
+**Interfaces:** none
+
+- [ ] **Step 1: Run the full integration suite**
+
+```bash
+docker compose exec php php vendor/bin/phpunit --group api-mocked-testing
+```
+
+Expected: PASS, no regressions in other Admin-page assertions (report tables, descriptions, etc. from `testAdminHome`).
+
+- [ ] **Step 2: Run the full browser suite**
+
+```bash
+docker compose exec php php vendor/bin/phpunit tests/src/Browser
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run code-quality checks**
+
+```bash
+docker compose exec php php tools/phpcsfixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+docker compose exec php php tools/phpstan/vendor/bin/phpstan analyse --memory-limit=-1
+docker compose exec php php tools/psalm/vendor/bin/psalm --show-info=false
+```
+
+Expected: all clean (no new baseline entries needed — no PHP class signatures changed, only Twig/JS/YAML).
+
+- [ ] **Step 4: Manual smoke check**
+
+Log in as admin via `http://localhost/fr/connect/f/c?t=admin`, go to `/fr/istration/actions`, find a pending action (or trigger one and reload before it completes), click its button, verify the confirm dialog text shows a plausible elapsed duration, cancel it (page stays put, no request sent), click again and accept (request is sent, page reloads/flashes as a normal trigger would).
+
+- [ ] **Step 5: Commit** (only if any fixups were needed in prior steps; otherwise skip — nothing to commit)

--- a/docs/superpowers/specs/2026-07-29-force-pending-admin-action-design.md
+++ b/docs/superpowers/specs/2026-07-29-force-pending-admin-action-design.md
@@ -1,0 +1,58 @@
+# Force a pending admin action
+
+## Problem
+
+On `/{_locale}/istration/actions`, each admin action button (`update`, `calculate`, `invalidate`, `trigger`) is disabled while the last `ActionLog` for that action is in the `pending` state (has `createdAt` but no `doneAt` and no `errorTrace`). This state is reported by pokenini-back/pokenini-api and pokenini-web has no local knowledge of whether the job is actually still running.
+
+In practice, jobs can get stuck in `pending` forever (crash, timeout on the API side) with no `doneAt` or `errorTrace` ever arriving. The admin then has no way to retrigger the action from the UI — the button stays disabled indefinitely, and the only path today is bypassing the browser entirely (e.g. curling the endpoint directly), since `AdminActionController` performs no server-side check on the action state at all — only CSRF.
+
+## Goal
+
+Let an admin force-trigger a pending action from the UI, with an explicit confirmation, instead of the button being permanently unclickable.
+
+## Non-goals
+
+- No server-side lock/guard is added in pokenini-web or requested from pokenini-back/pokenini-api. The backend already allows concurrent/duplicate triggers (confirmed: `AdminActionController` only checks CSRF), so "forcing" only removes a client-side restriction that never had a matching server-side guarantee.
+- No change to how `pending`/`done`/`ko`/`idle` states are computed or displayed elsewhere (the "last action" panel, the progress bar, the refresh link all stay as-is).
+
+## Design
+
+### 1. Template — `templates/Admin/_macros.html.twig`, macro `actionButton`
+
+- The button `admin-item-cta` is never rendered with the `disabled` attribute/class anymore — it stays clickable in every state.
+- When `currentState == 'pending'`, compute elapsed time the same way the existing `progress` macro already does (`actionData.createdAt.diff(date('now'))` → days/h/i/s), and format it into a short human string (e.g. `3h 12min`, or `12 min` when under an hour, or `2j 4h` when over a day).
+- Render that formatted duration into the translated confirmation string and put the result in a `data-confirm-message` attribute on the button. When not pending, the attribute is simply absent.
+- The existing "refresh" link (`admin-item-refresh`, shown next to the button when pending) is unchanged.
+
+### 2. Translations — `translations/messages+intl-icu.fr.yaml` / `messages+intl-icu.en.yaml`
+
+New key under `admin.action`:
+
+```yaml
+admin:
+  action:
+    force_confirm: "Une exécution est en cours depuis {duration}. Voulez-vous quand même relancer cette action ?"
+```
+
+(English equivalent in the `.en.yaml` file.) `{duration}` is substituted with the string computed in step 1 before being placed in the `data-confirm-message` attribute — the translation itself only needs the ICU placeholder.
+
+### 3. JS — `public/js/admin.js`
+
+New function `watchForceConfirm()`, following the existing plain-function style already used by `watchActionLogToggles()`:
+
+- Selects every `.admin-item-cta` button that has a `data-confirm-message` attribute.
+- Attaches a `submit` listener on the button's parent `<form>`.
+- On submit: reads `data-confirm-message`, calls `window.confirm(message)`. If the user cancels, `event.preventDefault()`. If confirmed, the form submits normally — identical request to a normal (non-pending) action trigger.
+- Buttons without `data-confirm-message` (idle/done/ko states) are untouched and submit immediately, exactly as today.
+
+Wired in `templates/Admin/actions.html.twig`'s existing inline `foot_javascript` block, alongside the current `watchActionLogToggles();` call.
+
+### Error handling / edge cases
+
+- No new error paths: the POST request and its handling in `AdminActionController` / `AdminActionService` are completely unchanged. A forced trigger looks identical to a normal trigger from the server's point of view.
+- If `data-confirm-message` is somehow present but empty (shouldn't happen given the Twig logic above), `window.confirm('')` still opens a dialog — acceptable, not worth guarding against.
+
+## Testing
+
+- `tests/src/Integration/Controller/Admin/AdminPageTest.php`: replace the assertions on `.admin-item-cta.disabled` (currently lines ~99-102) with assertions that the same 3 actions expose `button.admin-item-cta[data-confirm-message]`, and add an assertion that `.admin-item-cta.disabled` no longer exists anywhere on the page.
+- New browser test in `tests/src/Browser/Admin/` (Panther): trigger a pending action, intercept the native `confirm()` dialog (accept and dismiss cases), and assert the POST does/doesn't go through accordingly.

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -69,3 +69,17 @@ function onToggleLast(event) {
     );
   });
 }
+
+function watchForceConfirm() {
+    document.querySelectorAll(".admin-item-cta[data-confirm-message]").forEach(function (button) {
+      const form = button.closest('form');
+      if (!form) {
+        return;
+      }
+      form.addEventListener('submit', function (event) {
+        if (!window.confirm(button.getAttribute('data-confirm-message'))) {
+          event.preventDefault();
+        }
+      });
+    });
+}

--- a/templates/Admin/_macros.html.twig
+++ b/templates/Admin/_macros.html.twig
@@ -81,7 +81,7 @@
         {{ _self.actionTitle(action, item, icon) }}
         {{ _self.actionFlashError(actionPrefix, item, updatedItem, updatedAction, updatedState) }}
         {{ _self.actionContainer(action, item, currentActionLog, lastActionLog) }}
-        {{ _self.actionButton(action, actionPrefix, item, currentState, currentBgStyle) }}
+        {{ _self.actionButton(action, actionPrefix, item, currentState, currentBgStyle, currentActionLog) }}
       </div>
     </div>
   </div>
@@ -113,16 +113,22 @@
     actionPrefix,
     item,
     currentState,
-    bgStyle
+    bgStyle,
+    currentActionLog
 ) %}
   {% set csrfId = 'admin_' ~ actionPrefix %}
+  {% set confirmMessage = null %}
+  {% if currentState == 'pending' %}
+    {% set timeDiff = currentActionLog.createdAt.diff(date('now')) %}
+    {% set confirmMessage = ('admin.action.force_confirm')|trans({'duration': _self.formatElapsed(timeDiff)}) %}
+  {% endif %}
   <div class="text-end border-top border-{{ bgStyle }} pt-3">
     <form method="post" action="{{ path('app_adminaction_'~actionPrefix, {'name': item}) }}">
       <input type="hidden" name="_token" value="{{ csrf_token(csrfId) }}">
       <button
         type="submit"
-        class="btn btn-outline-primary admin-item-cta{{ currentState == 'pending' ? ' disabled' : '' }}"
-        {% if currentState == 'pending' %}disabled{% endif %}
+        class="btn btn-outline-primary admin-item-cta"
+        {% if confirmMessage is not null %}data-confirm-message="{{ confirmMessage }}"{% endif %}
       >
         {{ ('admin.actions.'~action~'.'~item~'.cta')|trans }}
       </button>
@@ -139,6 +145,16 @@
     {% endif %}
     </form>
   </div>
+{% endmacro %}
+
+{% macro formatElapsed(timeDiff) %}
+  {%- if timeDiff.days > 0 -%}
+    {{ timeDiff.days }}{{ ('admin.action.unit_day')|trans }} {{ timeDiff.h }}{{ ('admin.action.unit_hour')|trans }}
+  {%- elseif timeDiff.h > 0 -%}
+    {{ timeDiff.h }}{{ ('admin.action.unit_hour')|trans }} {{ timeDiff.i }}{{ ('admin.action.unit_minute')|trans }}
+  {%- else -%}
+    {{ timeDiff.i > 0 ? timeDiff.i : 1 }} {{ ('admin.action.unit_minute')|trans }}
+  {%- endif -%}
 {% endmacro %}
 
 {% macro actionFlashError(

--- a/templates/Admin/actions.html.twig
+++ b/templates/Admin/actions.html.twig
@@ -42,6 +42,7 @@
   <script>
     (function () {
       watchActionLogToggles();
+      watchForceConfirm();
     })();
   </script>
 {% endblock %}

--- a/tests/src/Browser/Admin/ForceActionTest.php
+++ b/tests/src/Browser/Admin/ForceActionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Admin;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use Facebook\WebDriver\WebDriverBy;
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class ForceActionTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testDismissingConfirmationKeepsActionPending(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('109903422692691644111', 'TestProvider');
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/istration/actions');
+
+        // Sentinel wiped out by any real page load (navigation destroys the JS context), unlike
+        // the `data-updated-state` attribute which can't distinguish "no navigation happened" from
+        // "navigation is still in flight when we happen to check" — this is what actually proves
+        // event.preventDefault() ran and no form submission occurred.
+        $client->executeScript('window.__noNav = true;');
+
+        $button = $client->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex button.admin-item-cta'));
+        $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$button]);
+        $button->click();
+
+        $alert = $client->switchTo()->alert();
+        $this->assertStringContainsString('Une exécution est en cours depuis', $alert->getText());
+        $alert->dismiss();
+
+        $this->assertTrue((bool) $client->executeScript('return window.__noNav === true;'));
+    }
+
+    public function testAcceptingConfirmationSubmitsTheForm(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('109903422692691644222', 'TestProvider');
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/istration/actions');
+
+        $button = $client->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex button.admin-item-cta'));
+        $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$button]);
+        $button->click();
+
+        $alert = $client->switchTo()->alert();
+        $alert->accept();
+
+        // The click triggers a real page navigation (POST then 302 redirect back to the GET page).
+        // Panther's own submit() helper has Firefox-specific waiting logic for exactly this reason
+        // (vendor/symfony/panther/src/Client.php:227-246); since we bypass that helper (see note
+        // below), wait explicitly for the post-redirect DOM state instead of assuming the click()
+        // call already blocked until navigation finished.
+        $client->wait()->until(static function () use ($client) {
+            return '' !== $client->findElement(WebDriverBy::cssSelector('#update_games_collections_and_dex'))->getAttribute('data-updated-state');
+        });
+
+        $crawler = $client->refreshCrawler();
+        $this->assertNotSame('', $crawler->filter('#update_games_collections_and_dex')->attr('data-updated-state'));
+    }
+}

--- a/tests/src/Browser/Admin/RedirectActionsTest.php
+++ b/tests/src/Browser/Admin/RedirectActionsTest.php
@@ -6,8 +6,10 @@ namespace App\Tests\Browser\Admin;
 
 use App\Tests\Browser\AbstractBrowserTestCase;
 use App\Tests\Utils\GetUserToken;
+use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Panther\Client;
 
 /**
  * @internal
@@ -15,6 +17,22 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversNothing]
 final class RedirectActionsTest extends AbstractBrowserTestCase
 {
+    /**
+     * Action/item combinations whose fixture (tests/resources/moco/Back/responses/action-logs.json)
+     * reports the current run as still "pending" (created_at set, done_at null). Task 1/3 of the
+     * force-pending-admin-action feature made their button always carry a `data-confirm-message`
+     * attribute and pop a native `confirm()` on submit, so they can't use Panther's `submit()`
+     * helper (it calls `createCrawler()` right after clicking, which throws
+     * `UnexpectedAlertOpenException` while the alert is still open) — see ForceActionTest.
+     *
+     * @var list<string>
+     */
+    private const array PENDING_ACTION_ITEMS = [
+        'update_games_collections_and_dex',
+        'calculate_game_bundles_availabilities',
+        'calculate_dex_availabilities',
+    ];
+
     #[DataProvider('providerActionItems')]
     public function testActionItems(string $action, string $item): void
     {
@@ -26,14 +44,19 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
 
         $client->request('GET', '/fr/istration/actions');
 
-        $form = $client->getCrawler()->filter("#{$action}_{$item} form")->form();
-        $client->submit($form);
+        match (\in_array("{$action}_{$item}", self::PENDING_ACTION_ITEMS, true)) {
+            true => $this->clickPendingActionAndAcceptConfirm($client, $action, $item),
+            false => $this->submitActionForm($client, $action, $item),
+        };
 
         $rawUri = getenv('PANTHER_EXTERNAL_BASE_URI');
         $baseUri = rtrim(false !== $rawUri ? $rawUri : 'http://127.0.0.1:9080', '/');
+        $expectedUrl = "{$baseUri}/fr/istration/actions#{$action}_{$item}";
+
+        $client->wait()->until(static fn (): bool => $expectedUrl === $client->getCurrentURL());
 
         $this->assertSame(
-            "{$baseUri}/fr/istration/actions#{$action}_{$item}",
+            $expectedUrl,
             $client->getCurrentURL()
         );
     }
@@ -101,5 +124,31 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
                 'item' => 'albums',
             ],
         ];
+    }
+
+    /**
+     * Pending action items always show a `data-confirm-message` button (Task 1/3 of the
+     * force-pending-admin-action feature) that pops a native `confirm()` on submit — Panther's
+     * `submit()` helper can't be used here since it calls `createCrawler()` right after clicking,
+     * which throws `UnexpectedAlertOpenException` while the alert is still open (see
+     * ForceActionTest for the same pattern).
+     */
+    private function clickPendingActionAndAcceptConfirm(Client $client, string $action, string $item): void
+    {
+        $button = $client->findElement(WebDriverBy::cssSelector("#{$action}_{$item} button.admin-item-cta"));
+
+        // The page nav (templates/_nav.html.twig) is `fixed-bottom`; a plain click() only scrolls
+        // the element minimally into view, which can leave it directly behind that fixed bar and
+        // throw ElementClickInterceptedException. Center it first so the click always lands on
+        // the button itself.
+        $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$button]);
+        $button->click();
+        $client->switchTo()->alert()->accept();
+    }
+
+    private function submitActionForm(Client $client, string $action, string $item): void
+    {
+        $form = $client->getCrawler()->filter("#{$action}_{$item} form")->form();
+        $client->submit($form);
     }
 }

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -96,10 +96,17 @@ final class AdminPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.admin-item-trigger button.admin-item-cta');
         $this->assertCountFilter($crawler, 1, '#trigger_update_images button.admin-item-cta');
 
-        $this->assertCountFilter($crawler, 3, '.admin-item-cta.disabled');
-        $this->assertCountFilter($crawler, 1, '#update_games_collections_and_dex .admin-item-cta.disabled');
-        $this->assertCountFilter($crawler, 1, '#calculate_game_bundles_availabilities .admin-item-cta.disabled');
-        $this->assertCountFilter($crawler, 1, '#calculate_dex_availabilities .admin-item-cta.disabled');
+        $this->assertCountFilter($crawler, 0, '.admin-item-cta.disabled');
+
+        $this->assertCountFilter($crawler, 3, '.admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#update_games_collections_and_dex .admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#calculate_game_bundles_availabilities .admin-item-cta[data-confirm-message]');
+        $this->assertCountFilter($crawler, 1, '#calculate_dex_availabilities .admin-item-cta[data-confirm-message]');
+
+        $confirmMessage = $crawler->filter('#update_games_collections_and_dex .admin-item-cta')->attr('data-confirm-message') ?? '';
+        $this->assertStringContainsString('Une exécution est en cours depuis', $confirmMessage);
+        $this->assertStringContainsString('j ', $confirmMessage);
+        $this->assertStringContainsString('Voulez-vous quand même relancer cette action', $confirmMessage);
 
         $this->assertCountFilter($crawler, 3, '.admin-item-refresh');
 

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -357,6 +357,10 @@ admin:
     created_at: "Start at"
     done_at: "End at"
     execution_time: "Execution time"
+    force_confirm: "An execution has been running for {duration}. Do you still want to trigger this action?"
+    unit_day: "d"
+    unit_hour: "h"
+    unit_minute: "min"
   toggle:
     last: "Show last action"
     current: "Show current action"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -362,6 +362,10 @@ admin:
     created_at: "Démarré le"
     done_at: "Terminé le"
     execution_time: "Terminé en"
+    force_confirm: "Une exécution est en cours depuis {duration}. Voulez-vous quand même relancer cette action ?"
+    unit_day: "j"
+    unit_hour: "h"
+    unit_minute: "min"
   toggle:
     last: "Voir l'action précédente"
     current: "Voir la dernière action"


### PR DESCRIPTION
## Summary
- Admin action buttons on `/istration/actions` stayed permanently disabled once a run reported `pending`, with no recovery path if the job crashed/timed out and never got a `doneAt`/`errorTrace`.
- The backend already has no server-side lock against duplicate/concurrent triggers (`AdminActionController` only checks CSRF), so this replaces the client-side block with a JS `confirm()` showing how long the job has been pending — in both FR and EN.
- A pre-existing browser test (`RedirectActionsTest`) needed a fix mid-implementation since the new confirm dialogs broke 3 of its subtests (pending items can no longer use Panther's generic form-submit helper).

Design spec: `docs/superpowers/specs/2026-07-29-force-pending-admin-action-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-29-force-pending-admin-action.md`

## Test plan
- [x] `--filter testAdminHome tests/src/Integration/Controller/Admin/AdminPageTest.php` — pass
- [x] Full integration suite (`--group api-mocked-testing`) — 238/238 pass
- [x] Full browser suite on Chrome and Firefox (`tests/src/Browser`) — 54/54 pass, including new `ForceActionTest.php` (dismiss/accept paths) and the fixed `RedirectActionsTest.php`
- [x] phpcsfixer / phpstan / psalm — clean
- [ ] `make editorconfig-linter` as part of a full `make code-quality` before merge (not run standalone during this branch's verification pass)
- [ ] Manual smoke test in a real browser (skipped — no browser environment available while building this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfPgj5AiwAhqaHmCp7e643