### PR TITLE
Expose catch_states/types cache invalidation, force-trigger pending actions, and group Admin Actions into tabs

### DIFF
--- a/docs/superpowers/plans/2026-07-30-admin-actions-tabs.md
+++ b/docs/superpowers/plans/2026-07-30-admin-actions-tabs.md
@@ -1,0 +1,591 @@
+# Admin Actions Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the five stacked sections of the Admin Actions page
+(`Admin/_actions.html.twig`, route `app_admin_actions`) into Bootstrap 5
+tabs, one section visible at a time, while preserving the existing
+"jump to and highlight the triggered item after a POST" redirect behavior.
+
+**Architecture:** Replace the five sequential `row px-4 py-5` blocks with a
+Bootstrap `nav-pills` + `tab-content`/`tab-pane` structure (native
+Bootstrap 5 JS component, already loaded globally — no new dependency).
+Move `Admin/_pipeline_status.html.twig` inside the `trigger_pipeline` pane.
+Add one small JS function to `public/js/admin.js` that, on page load,
+reads `window.location.hash`, finds which pane contains that element, and
+activates that pane's tab via `bootstrap.Tab` before the browser's native
+anchor scroll would otherwise land on a hidden element.
+
+**Tech Stack:** Symfony 8 / Twig, Bootstrap 5.3.8 (CSS + `bootstrap.bundle.min.js`,
+already loaded in `templates/base.html.twig`), vanilla JS (`public/js/admin.js`),
+PHPUnit `WebTestCase` (integration), Panther/Selenium (browser tests).
+
+## Global Constraints
+
+- Design doc: `docs/superpowers/specs/2026-07-30-admin-actions-tabs-design.md`.
+- Scope is the Actions page only (`Admin/_actions.html.twig`,
+  `templates/Admin/actions.html.twig`). The Reports page
+  (`Admin/_reports.html.twig`) is untouched.
+- No changes to `AdminActionController`, `Admin/_macros.html.twig`, or
+  `public/css/admin.css` — tab labels reuse existing translation keys
+  (`admin.actions.<section>.title`), item ids/classes from the `action`
+  macro are unchanged, tabs use Bootstrap's default styling.
+- No new JS dependency — `bootstrap.Tab` is already available globally via
+  `bootstrap.bundle.min.js` (see `templates/base.html.twig:34` and its
+  existing `new bootstrap.Tooltip(...)` usage for precedent).
+- Per standing user preference: **do not create git commits** while
+  executing this plan. Leave changes staged/unstaged for the user to
+  review and commit themselves. Each task below ends with a verification
+  step instead of a commit step.
+- Test commands run inside the `php` container per this repo's `CLAUDE.md`,
+  e.g. `docker compose exec php php vendor/bin/phpunit --filter <name> <path>`
+  for integration tests, `make tests-browser-chrome` for browser tests.
+
+---
+
+## Task 1: Restructure `_actions.html.twig` into Bootstrap tabs
+
+**Files:**
+- Modify: `templates/Admin/_actions.html.twig`
+- Test: `tests/src/Integration/Controller/Admin/AdminPageTest.php`
+
+**Interfaces:**
+- Consumes: `Admin/_macros.html.twig`'s `admin.action(...)` macro (unchanged
+  signature), `Admin/_pipeline_status.html.twig` (unchanged, only its
+  include location moves).
+- Produces: pane ids `tab-pane-update_data`, `tab-pane-update_availabilities`,
+  `tab-pane-calculate_data`, `tab-pane-invalidate_data`,
+  `tab-pane-trigger_pipeline`; nav button ids `tab-update_data-tab`,
+  `tab-update_availabilities-tab`, `tab-calculate_data-tab`,
+  `tab-invalidate_data-tab`, `tab-trigger_pipeline-tab`, each with
+  `data-bs-target="#tab-pane-<section>"`. Task 2 depends on these exact
+  id patterns for its hash-lookup JS and its browser-test tab activation
+  helper.
+
+- [ ] **Step 1: Write the failing test**
+
+  In `tests/src/Integration/Controller/Admin/AdminPageTest.php`, inside
+  `testAdminHome()`, add these assertions right after the existing
+  `assertCountFilter($crawler, 6, 'h2')` line (line 81):
+
+  ```php
+        $this->assertCountFilter($crawler, 5, '#admin-actions-tab > .nav-item > .nav-link');
+        $this->assertCountFilter($crawler, 1, '#admin-actions-tab .nav-link.active');
+        $this->assertCountFilter($crawler, 5, '.tab-content > .tab-pane');
+        $this->assertCountFilter($crawler, 1, '.tab-content > .tab-pane.show.active');
+
+        foreach ([
+            'update_data',
+            'update_availabilities',
+            'calculate_data',
+            'invalidate_data',
+            'trigger_pipeline',
+        ] as $section) {
+            $this->assertCountFilter($crawler, 1, "#tab-{$section}-tab[data-bs-target=\"#tab-pane-{$section}\"]");
+            $this->assertCountFilter($crawler, 1, "#tab-pane-{$section}");
+        }
+
+        $this->assertCountFilter($crawler, 1, '#tab-pane-update_data.show.active');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-update_data #update_labels');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-invalidate_data #invalidate_labels');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-trigger_pipeline .admin-pipeline-status');
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  Run: `docker compose exec php php vendor/bin/phpunit --filter testAdminHome tests/src/Integration/Controller/Admin/AdminPageTest.php`
+  Expected: FAIL — none of `#admin-actions-tab`, `.tab-pane`,
+  `#tab-pane-update_data`, etc. exist yet in the current markup.
+
+- [ ] **Step 3: Rewrite the template**
+
+  Replace the entire contents of `templates/Admin/_actions.html.twig`
+  with:
+
+  ```twig
+  {% set locale = app.request.locale %}
+
+  {% import "Admin/_macros.html.twig" as admin %}
+
+  <h2>{{ 'title.admin_actions'|trans }}</h2>
+
+  <ul class="nav nav-pills mb-4" id="admin-actions-tab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link active"
+        id="tab-update_data-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#tab-pane-update_data"
+        type="button"
+        role="tab"
+        aria-controls="tab-pane-update_data"
+        aria-selected="true"
+      >
+        {{ 'admin.actions.update_data.title'|trans }}
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="tab-update_availabilities-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#tab-pane-update_availabilities"
+        type="button"
+        role="tab"
+        aria-controls="tab-pane-update_availabilities"
+        aria-selected="false"
+      >
+        {{ 'admin.actions.update_availabilities.title'|trans }}
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="tab-calculate_data-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#tab-pane-calculate_data"
+        type="button"
+        role="tab"
+        aria-controls="tab-pane-calculate_data"
+        aria-selected="false"
+      >
+        {{ 'admin.actions.calculate_data.title'|trans }}
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="tab-invalidate_data-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#tab-pane-invalidate_data"
+        type="button"
+        role="tab"
+        aria-controls="tab-pane-invalidate_data"
+        aria-selected="false"
+      >
+        {{ 'admin.actions.invalidate_data.title'|trans }}
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="tab-trigger_pipeline-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#tab-pane-trigger_pipeline"
+        type="button"
+        role="tab"
+        aria-controls="tab-pane-trigger_pipeline"
+        aria-selected="false"
+      >
+        {{ 'admin.actions.trigger_pipeline.title'|trans }}
+      </button>
+    </li>
+  </ul>
+
+  <div class="tab-content" id="admin-actions-tab-content">
+    <div class="tab-pane fade show active" id="tab-pane-update_data" role="tabpanel" aria-labelledby="tab-update_data-tab" tabindex="0">
+      <div class="row px-4 py-5">
+        <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.update_data.title'|trans }}</h2>
+        {% set updateDataItems = {
+          'labels': 'tags-fill',
+          'games_collections_and_dex': 'joystick',
+          'pokemons': 'bug-fill',
+          'regional_dex_numbers': 'globe-asia-australia',
+        } %}
+        {% for item, icon in updateDataItems %}
+          {{ admin.action('update_data', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="tab-pane-update_availabilities" role="tabpanel" aria-labelledby="tab-update_availabilities-tab" tabindex="0">
+      <div class="row px-4 py-5">
+        <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.update_availabilities.title'|trans }}</h2>
+        {% set updateAvailabilitiesItems = {
+          'games_availabilities': 'box2',
+          'games_shinies_availabilities': 'box2-fill',
+          'collections_availabilities': 'collection-fill',
+        } %}
+        {% for item, icon in updateAvailabilitiesItems %}
+          {{ admin.action('update_availabilities', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="tab-pane-calculate_data" role="tabpanel" aria-labelledby="tab-calculate_data-tab" tabindex="0">
+      <div class="row px-4 py-5">
+        <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.calculate_data.title'|trans }}</h2>
+        {% set calculateDataItems = {
+          'game_bundles_availabilities': 'box-seam',
+          'game_bundles_shinies_availabilities': 'box-seam-fill',
+          'dex_availabilities': 'list-check',
+          'pokemon_availabilities': 'calculator',
+        } %}
+        {% for item, icon in calculateDataItems %}
+          {{ admin.action('calculate_data', 'calculate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="tab-pane-invalidate_data" role="tabpanel" aria-labelledby="tab-invalidate_data-tab" tabindex="0">
+      <div class="row px-4 py-5">
+        <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.invalidate_data.title'|trans }}</h2>
+        {% set invalidateDataItems = {
+          'labels': 'tags-fill',
+          'catch_states': 'check2-square',
+          'types': 'shapes',
+          'dex': 'journals',
+          'albums': 'journal-album',
+        } %}
+        {% for item, icon in invalidateDataItems %}
+          {{ admin.action('invalidate_data', 'invalidate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="tab-pane-trigger_pipeline" role="tabpanel" aria-labelledby="tab-trigger_pipeline-tab" tabindex="0">
+      <div class="row px-4 py-5">
+        <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
+        <p class="text-body-secondary small">{{ 'admin.actions.trigger_pipeline.help'|trans }}</p>
+        {% set triggerPipelineItems = {
+          'update_images': 'images',
+        } %}
+        {% for item, icon in triggerPipelineItems %}
+          {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+        {% endfor %}
+      </div>
+
+      {% include 'Admin/_pipeline_status.html.twig' %}
+    </div>
+  </div>
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  Run: `docker compose exec php php vendor/bin/phpunit --filter testAdminHome tests/src/Integration/Controller/Admin/AdminPageTest.php`
+  Expected: PASS.
+
+  Also run the full `AdminPageTest` and `PipelineStatusTest` files (neither
+  needs code changes, but both read markup produced by this template and
+  must stay green):
+
+  Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin/AdminPageTest.php tests/src/Integration/Controller/Admin/PipelineStatusTest.php`
+  Expected: PASS (`PipelineStatusTest` uses `Crawler::filter()`, which is
+  DOM-based and ignores CSS `display: none`, so moving the pipeline-status
+  include inside a hidden tab pane doesn't affect it).
+
+**Note:** After this task, the browser tests `RedirectActionsTest` will
+fail for every item outside the default-active `update_data` pane, because
+those items are now hidden (`display: none`) until their tab is opened —
+Task 2 fixes this. Do not run `make tests-browser` yet.
+
+---
+
+## Task 2: Deep-link tab activation + fix browser tests
+
+**Files:**
+- Modify: `public/js/admin.js`
+- Modify: `templates/Admin/actions.html.twig`
+- Modify: `tests/src/Browser/Admin/RedirectActionsTest.php`
+
+**Interfaces:**
+- Consumes: pane/button id patterns produced by Task 1
+  (`tab-pane-<section>`, `tab-<section>-tab`, `data-bs-target`).
+- Produces: `activateTabForHash()` global function in `admin.js`, called
+  once on page load from `actions.html.twig`'s `foot_javascript` block.
+
+- [ ] **Step 1: Write the failing test**
+
+  Replace the entire contents of
+  `tests/src/Browser/Admin/RedirectActionsTest.php` with:
+
+  ```php
+  <?php
+
+  declare(strict_types=1);
+
+  namespace App\Tests\Browser\Admin;
+
+  use App\Tests\Browser\AbstractBrowserTestCase;
+  use App\Tests\Utils\GetUserToken;
+  use Facebook\WebDriver\WebDriverBy;
+  use PHPUnit\Framework\Attributes\CoversNothing;
+  use PHPUnit\Framework\Attributes\DataProvider;
+  use Symfony\Component\Panther\Client;
+
+  /**
+   * @internal
+   */
+  #[CoversNothing]
+  final class RedirectActionsTest extends AbstractBrowserTestCase
+  {
+      /**
+       * Action/item combinations whose fixture (tests/resources/moco/Back/responses/action-logs.json)
+       * reports the current run as still "pending" (created_at set, done_at null). Task 1/3 of the
+       * force-pending-admin-action feature made their button always carry a `data-confirm-message`
+       * attribute and pop a native `confirm()` on submit, so they can't use Panther's `submit()`
+       * helper (it calls `createCrawler()` right after clicking, which throws
+       * `UnexpectedAlertOpenException` while the alert is still open) — see ForceActionTest.
+       *
+       * @var list<string>
+       */
+      private const array PENDING_ACTION_ITEMS = [
+          'update_games_collections_and_dex',
+          'calculate_game_bundles_availabilities',
+          'calculate_dex_availabilities',
+      ];
+
+      #[DataProvider('providerActionItems')]
+      public function testActionItems(string $action, string $item, string $section): void
+      {
+          $client = $this->getNewClient();
+
+          $user = GetUserToken::getFakeUserToken('109903422692691643666', 'TestProvider');
+          $user->addAdminRole();
+          $this->loginUser($client, $user);
+
+          $client->request('GET', '/fr/istration/actions');
+
+          $this->activateTab($client, $section);
+
+          match (\in_array("{$action}_{$item}", self::PENDING_ACTION_ITEMS, true)) {
+              true => $this->clickPendingActionAndAcceptConfirm($client, $action, $item),
+              false => $this->submitActionForm($client, $action, $item),
+          };
+
+          $rawUri = getenv('PANTHER_EXTERNAL_BASE_URI');
+          $baseUri = rtrim(false !== $rawUri ? $rawUri : 'http://127.0.0.1:9080', '/');
+          $expectedUrl = "{$baseUri}/fr/istration/actions#{$action}_{$item}";
+
+          $client->wait()->until(static fn (): bool => $expectedUrl === $client->getCurrentURL());
+
+          $this->assertSame(
+              $expectedUrl,
+              $client->getCurrentURL()
+          );
+
+          // The redirect landed back on the default-active tab; the item lives in a
+          // different pane until admin.js's activateTabForHash() reads the URL hash
+          // and activates the right one — this is what this assertion proves.
+          $this->assertSelectorWillBeVisible("#{$action}_{$item}");
+      }
+
+      /**
+       * @return array<string, array<string, string>>
+       */
+      public static function providerActionItems(): array
+      {
+          return [
+              'update_labels' => [
+                  'action' => 'update',
+                  'item' => 'labels',
+                  'section' => 'update_data',
+              ],
+              'update_games_collections_and_dex' => [
+                  'action' => 'update',
+                  'item' => 'games_collections_and_dex',
+                  'section' => 'update_data',
+              ],
+              'update_pokemons' => [
+                  'action' => 'update',
+                  'item' => 'pokemons',
+                  'section' => 'update_data',
+              ],
+              'update_regional_dex_numbers' => [
+                  'action' => 'update',
+                  'item' => 'regional_dex_numbers',
+                  'section' => 'update_data',
+              ],
+              'update_games_availabilities' => [
+                  'action' => 'update',
+                  'item' => 'games_availabilities',
+                  'section' => 'update_availabilities',
+              ],
+              'update_games_shinies_availabilities' => [
+                  'action' => 'update',
+                  'item' => 'games_shinies_availabilities',
+                  'section' => 'update_availabilities',
+              ],
+              'update_collections_availabilities' => [
+                  'action' => 'update',
+                  'item' => 'collections_availabilities',
+                  'section' => 'update_availabilities',
+              ],
+              'calculate_game_bundles_availabilities' => [
+                  'action' => 'calculate',
+                  'item' => 'game_bundles_availabilities',
+                  'section' => 'calculate_data',
+              ],
+              'calculate_game_bundles_shinies_availabilities' => [
+                  'action' => 'calculate',
+                  'item' => 'game_bundles_shinies_availabilities',
+                  'section' => 'calculate_data',
+              ],
+              'calculate_dex_availabilities' => [
+                  'action' => 'calculate',
+                  'item' => 'dex_availabilities',
+                  'section' => 'calculate_data',
+              ],
+              'calculate_pokemon_availabilities' => [
+                  'action' => 'calculate',
+                  'item' => 'pokemon_availabilities',
+                  'section' => 'calculate_data',
+              ],
+              'invalidate_labels' => [
+                  'action' => 'invalidate',
+                  'item' => 'labels',
+                  'section' => 'invalidate_data',
+              ],
+              'invalidate_catch_states' => [
+                  'action' => 'invalidate',
+                  'item' => 'catch_states',
+                  'section' => 'invalidate_data',
+              ],
+              'invalidate_types' => [
+                  'action' => 'invalidate',
+                  'item' => 'types',
+                  'section' => 'invalidate_data',
+              ],
+              'invalidate_dex' => [
+                  'action' => 'invalidate',
+                  'item' => 'dex',
+                  'section' => 'invalidate_data',
+              ],
+              'invalidate_albums' => [
+                  'action' => 'invalidate',
+                  'item' => 'albums',
+                  'section' => 'invalidate_data',
+              ],
+          ];
+      }
+
+      /**
+       * Pending action items always show a `data-confirm-message` button (Task 1/3 of the
+       * force-pending-admin-action feature) that pops a native `confirm()` on submit — Panther's
+       * `submit()` helper can't be used here since it calls `createCrawler()` right after clicking,
+       * which throws `UnexpectedAlertOpenException` while the alert is still open (see
+       * ForceActionTest for the same pattern).
+       */
+      private function clickPendingActionAndAcceptConfirm(Client $client, string $action, string $item): void
+      {
+          $button = $client->findElement(WebDriverBy::cssSelector("#{$action}_{$item} button.admin-item-cta"));
+
+          // The page nav (templates/_nav.html.twig) is `fixed-bottom`; a plain click() only scrolls
+          // the element minimally into view, which can leave it directly behind that fixed bar and
+          // throw ElementClickInterceptedException. Center it first so the click always lands on
+          // the button itself.
+          $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$button]);
+          $button->click();
+          $client->switchTo()->alert()->accept();
+      }
+
+      private function submitActionForm(Client $client, string $action, string $item): void
+      {
+          $form = $client->getCrawler()->filter("#{$action}_{$item} form")->form();
+          $client->submit($form);
+      }
+
+      /**
+       * Opens the nav-pill tab for the given section (templates/Admin/_actions.html.twig) so its
+       * items become visible/interactable — items outside the default-active `update_data` tab
+       * start hidden (`display: none`) on a fresh page load.
+       */
+      private function activateTab(Client $client, string $section): void
+      {
+          $tab = $client->findElement(WebDriverBy::cssSelector("#tab-{$section}-tab"));
+          $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$tab]);
+          $tab->click();
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  Run: `make tests-browser-chrome` filtered to this file (or run PHPUnit
+  directly against the running Panther/Selenium stack):
+  `docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/RedirectActionsTest.php`
+  Expected: FAIL on `assertSelectorWillBeVisible("#{$action}_{$item}")` for
+  every case where `section !== 'update_data'` (7 of 16 cases: the
+  `update_availabilities`, `calculate_data`, and `invalidate_data` items) —
+  the redirect lands back on the default `update_data` pane and nothing
+  yet re-activates the right tab from the URL hash.
+
+- [ ] **Step 3: Add the deep-link activation function**
+
+  Append to `public/js/admin.js`:
+
+  ```js
+  function activateTabForHash() {
+    const hash = window.location.hash;
+    if (!hash) {
+      return;
+    }
+    const target = document.querySelector(hash);
+    if (!target) {
+      return;
+    }
+    const pane = target.closest('.tab-pane');
+    if (!pane || pane.classList.contains('active')) {
+      return;
+    }
+    const trigger = document.querySelector(`[data-bs-target="#${pane.id}"]`);
+    if (!trigger) {
+      return;
+    }
+    new bootstrap.Tab(trigger).show();
+    target.scrollIntoView();
+  }
+  ```
+
+- [ ] **Step 4: Wire the call into the Actions page**
+
+  In `templates/Admin/actions.html.twig`, update the `foot_javascript`
+  block (currently lines 39-48) to:
+
+  ```twig
+  {% block foot_javascript %}
+    {{ parent() }}
+
+    <script>
+      (function () {
+        watchActionLogToggles();
+        watchForceConfirm();
+        activateTabForHash();
+      })();
+    </script>
+  {% endblock %}
+  ```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+  Run: `docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/RedirectActionsTest.php`
+  Expected: PASS for all 16 cases.
+
+  Then run the other two admin browser tests that share this page to
+  confirm no regression (`ToggleActionsTest` only touches
+  `update_labels`, inside the default-active pane, so it needs no code
+  changes but must still pass; `ForceActionTest` only touches
+  `update_games_collections_and_dex`, also default-active):
+
+  Run: `docker compose exec php php vendor/bin/phpunit tests/src/Browser/Admin/ToggleActionsTest.php tests/src/Browser/Admin/ForceActionTest.php`
+  Expected: PASS, unchanged.
+
+**Verification for this task:** no commit — leave the three modified files
+(`public/js/admin.js`, `templates/Admin/actions.html.twig`,
+`tests/src/Browser/Admin/RedirectActionsTest.php`) and Task 1's
+`templates/Admin/_actions.html.twig` /
+`tests/src/Integration/Controller/Admin/AdminPageTest.php` for the user to
+review.
+
+---
+
+## Final check
+
+- [ ] Run the full admin test surface one more time end to end:
+  `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin tests/src/Browser/Admin tests/src/Unit/Controller/AdminControllerTest.php`
+  Expected: PASS.
+- [ ] Manually load `http://localhost/fr/connect/f/c?t=admin` then
+  `/fr/istration/actions` in a browser: confirm the five tabs render, only
+  `update_data` shows by default, clicking a pill switches panes, and
+  triggering an action in a non-default pane (e.g. an "Invalidation"
+  button) lands back on that same pane with the item scrolled into view.

--- a/docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md
+++ b/docs/superpowers/specs/2026-07-28-prevent-leave-pending-catch-state-design.md
@@ -21,9 +21,9 @@ No debouncing, no request queue, no "unsaved changes" concept beyond in-flight r
 2. `onChangeCatchState` increments `pendingChangesCount` before calling `saveChange`.
 3. `saveChange`'s `fetch(...)` chain gets a `.finally()` that decrements `pendingChangesCount` exactly once per request. (Decrementing in both `.then` and `.catch` would double-count: on a non-200 response, the existing code `throw`s *inside* `.then`, which then also falls through to `.catch` — so a single `.finally()` is required, not one decrement per branch.)
 4. `watchCatchStates()` (already only invoked when `allowedToEdit` is true, `templates/Album/index.html.twig:93`) additionally registers:
-   ```js
-   window.addEventListener("beforeunload", onBeforeUnload);
-   ```
+  ```js
+  window.addEventListener("beforeunload", onBeforeUnload);
+  ```
 5. `onBeforeUnload(event)`: if `pendingChangesCount > 0`, calls `event.preventDefault()` and sets `event.returnValue = ""` to trigger the browser's native confirmation dialog. Modern browsers ignore any custom message text and show their own generic wording — this is expected and not worked around.
 
 No Twig changes needed: the listener piggybacks on the existing `watchCatchStates()` call, which is already gated correctly.

--- a/docs/superpowers/specs/2026-07-30-admin-actions-tabs-design.md
+++ b/docs/superpowers/specs/2026-07-30-admin-actions-tabs-design.md
@@ -1,0 +1,149 @@
+# Tabbed sections on the Admin Actions page
+
+## Context
+
+`Admin/_actions.html.twig` (included from `actions.html.twig`, route
+`app_admin_actions`) currently stacks five sections vertically, one after
+another, each a `<div class="row px-4 py-5">` with its own `<h2>` and a set
+of action items rendered via the `admin.action()` macro:
+
+1. `update_data` — Mise à jour des données (labels, games_collections_and_dex,
+   pokemons, regional_dex_numbers)
+2. `update_availabilities` — Disponibilités (games_availabilities,
+   games_shinies_availabilities, collections_availabilities)
+3. `calculate_data` — Calculs (game_bundles_availabilities,
+   game_bundles_shinies_availabilities, dex_availabilities,
+   pokemon_availabilities)
+4. `invalidate_data` — Invalidation (labels, catch_states, types, dex, albums)
+5. `trigger_pipeline` — Déclenchement pipeline (update_images), followed by
+   `Admin/_pipeline_status.html.twig` (image pipeline stage tracker)
+
+The page is already the single-purpose Actions page (Reports lives on its
+own route, `app_admin_reports`, with its own top-level tab bar rendered by
+`Admin/_tabs.html.twig`). The five sections above make the page long; the
+goal is to turn them into in-page tabs so only one section is visible at a
+time.
+
+Each action button submits a form to `AdminActionController` (update /
+calculate / invalidate / trigger), which redirects back to
+`app_admin_actions` with `_fragment => "{action}_{name}"` (e.g.
+`#update_labels`), the `id` of the corresponding `.admin-item` div rendered
+by the `action` macro (`_macros.html.twig:77`). This is how the page
+scrolls back to the item that was just triggered after a POST, and how the
+"refresh" link (`_macros.html.twig:142`) works for pending actions. This
+behavior must keep working once items live inside hidden tab panes.
+
+## Goal
+
+Replace the five stacked sections in `_actions.html.twig` with Bootstrap 5
+tabs (one tab per section), without breaking the existing "jump to and
+highlight the triggered item" redirect behavior, and without touching the
+Reports page.
+
+## Design
+
+### Markup: Bootstrap nav + tab-content
+
+Bootstrap 5.3.8's JS bundle is already loaded globally in `base.html.twig`
+(`bootstrap.bundle.min.js`), so the native tab component
+(`data-bs-toggle="tab"`) can be used with no custom JS needed for switching
+panes.
+
+`_actions.html.twig` changes from five sequential `row px-4 py-5` blocks to:
+
+- A `<ul class="nav nav-pills mb-4" role="tablist">` with one `<li>` per
+  section, `nav-link` buttons carrying `data-bs-toggle="tab"`,
+  `data-bs-target="#tab-pane-{section}"`, `role="tab"`. `nav-pills` is used
+  (rather than `nav-tabs`) so these sub-tabs are visually distinct from the
+  page-level `nav-tabs` already rendered by `Admin/_tabs.html.twig` above
+  them (Actions vs Reports).
+- Labels reuse the existing translation keys already used for each
+  section's `<h2>` (`admin.actions.<section>.title`) — no new translation
+  strings needed.
+- A `<div class="tab-content">` with one `<div class="tab-pane fade" id="tab-pane-{section}" role="tabpanel">`
+  per section, containing exactly what that section's `row px-4 py-5` div
+  contains today (unchanged macro calls).
+- The first pane (`update_data`) and its nav button get `show active` by
+  default; this is overridden client-side when the URL hash points into a
+  different section (see below).
+- `Admin/_pipeline_status.html.twig` moves inside the `trigger_pipeline`
+  pane, right after the `update_images` action item (unchanged include,
+  just relocated).
+
+No changes to `_macros.html.twig` — the `action` macro's markup and ids are
+untouched.
+
+### Deep-link on load: activate the right tab, then scroll
+
+Bootstrap hides inactive `tab-pane`s via CSS (`display: none` unless
+`show`), so a `#update_labels` URL fragment landing on an inactive pane
+won't scroll into view or even be reachable by the browser's native anchor
+scroll. A small function is added to `public/js/admin.js`:
+
+```js
+function activateTabForHash() {
+  const hash = window.location.hash;
+  if (!hash) return;
+  const target = document.querySelector(hash);
+  if (!target) return;
+  const pane = target.closest('.tab-pane');
+  if (!pane || pane.classList.contains('active')) return;
+  const trigger = document.querySelector(`[data-bs-target="#${pane.id}"]`);
+  if (!trigger) return;
+  new bootstrap.Tab(trigger).show();
+  target.scrollIntoView();
+}
+```
+
+Called once from `actions.html.twig`'s `foot_javascript` block alongside
+the existing `watchActionLogToggles()` / `watchForceConfirm()` calls, after
+DOM is ready (same IIFE). This covers both cases that set the fragment:
+
+- The controller redirect after a POST (`AdminActionController::execute()`,
+  `_fragment => "{action}_{name}"`).
+- The "refresh" link for a pending action (`_macros.html.twig:142`, same
+  fragment pattern), which reloads the page with the hash already in the
+  URL — Bootstrap's `Tab.show()` call still runs on that fresh load since
+  it's driven by JS reading `location.hash`, not by relying on native
+  anchor jump.
+
+`bootstrap.Tab` firing `show()` on an already-active tab is a no-op guarded
+by the `pane.classList.contains('active')` check above, so no flicker on
+normal (non-fragment) loads.
+
+### No changes to
+
+- `AdminActionController` (fragment format `{action}_{name}` is already
+  correct — no server-side awareness of tabs needed).
+- `_macros.html.twig` (item ids, toggle/refresh links unchanged).
+- `admin.css` (tabs use Bootstrap's default styling; no new custom classes
+  beyond what `nav-pills`/`tab-content`/`tab-pane` already provide).
+- The Reports page / `Admin/_tabs.html.twig` (page-level Actions/Reports
+  tabs stay as plain links, unrelated to this change).
+
+## Tests
+
+- `AdminPageTest` (integration, WebTestCase against Moco fixtures): assert
+  the five section headers are still present in the response body (now as
+  tab button labels + pane headings instead of plain `<h2>`s) and that all
+  five `tab-pane` ids / nav targets exist. No behavioral change to what
+  data is fetched or which actions are available, so existing action
+  button/CSRF assertions stay as-is.
+- Browser tests (`tests/src/Browser/`): existing `RedirectActionsTest`
+  (redirect-and-scroll-to-item behavior) and `ToggleActionsTest` need to
+  keep passing — they exercise the exact redirect-fragment flow this
+  design must preserve. Add a browser-test assertion that after triggering
+  an action in a non-default section (e.g. `invalidate_labels`, section 4),
+  the corresponding tab becomes visibly active (not just present in DOM)
+  and the item is scrolled into view.
+- No test commands are run as part of this design; the user runs `make
+  tests` / `make tests-browser` themselves.
+
+## Out of scope
+
+- Reports page (`app_admin_reports`) — stays as one continuous page, no
+  sub-tabs.
+- No change to which sections/actions exist, their icons, or their order.
+- No change to `AdminActionController` routing or the CSRF/POST flow.
+- No persistence of "last active tab" across page loads beyond what the
+  redirect fragment already provides (e.g. no `localStorage`).

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -70,6 +70,27 @@ function onToggleLast(event) {
   });
 }
 
+function activateTabForHash() {
+  const hash = window.location.hash;
+  if (!hash) {
+    return;
+  }
+  const target = document.querySelector(hash);
+  if (!target) {
+    return;
+  }
+  const pane = target.closest('.tab-pane');
+  if (!pane || pane.classList.contains('active')) {
+    return;
+  }
+  const trigger = document.querySelector(`[data-bs-target="#${pane.id}"]`);
+  if (!trigger) {
+    return;
+  }
+  new bootstrap.Tab(trigger).show();
+  target.scrollIntoView();
+}
+
 function watchForceConfirm() {
     document.querySelectorAll(".admin-item-cta[data-confirm-message]").forEach(function (button) {
       const form = button.closest('form');

--- a/src/Controller/AdminActionController.php
+++ b/src/Controller/AdminActionController.php
@@ -83,6 +83,8 @@ final class AdminActionController extends AbstractController
         condition: "params['name']
             in [
                 'labels',
+                'catch_states',
+                'types',
                 'dex',
                 'albums',
                 'reports',

--- a/templates/Admin/_actions.html.twig
+++ b/templates/Admin/_actions.html.twig
@@ -46,6 +46,8 @@
   <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.invalidate_data.title'|trans }}</h2>
   {% set invalidateDataItems = {
     'labels': 'tags-fill',
+    'catch_states': 'check2-square',
+    'types': 'shapes',
     'dex': 'journals',
     'albums': 'journal-album',
   } %}

--- a/templates/Admin/_actions.html.twig
+++ b/templates/Admin/_actions.html.twig
@@ -2,69 +2,76 @@
 
 {% import "Admin/_macros.html.twig" as admin %}
 
-<h2>{{ 'title.admin_actions'|trans }}</h2>
+{% include 'Admin/_tabs.html.twig' with {'page': 'actions', 'active': 'update_data'} %}
 
-<div class="row px-4 py-5">
-  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.update_data.title'|trans }}</h2>
-  {% set updateDataItems = {
-    'labels': 'tags-fill',
-    'games_collections_and_dex': 'joystick',
-    'pokemons': 'bug-fill',
-    'regional_dex_numbers': 'globe-asia-australia',
-  } %}
-  {% for item, icon in updateDataItems %}
-    {{ admin.action('update_data', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
-  {% endfor %}
+<div class="tab-content" id="admin-actions-tab-content">
+  <div class="tab-pane fade show active" id="tab-pane-update_data" role="tabpanel" aria-labelledby="tab-update_data-tab" tabindex="0">
+    <div class="row px-4 py-5">
+      {% set updateDataItems = {
+        'labels': 'tags-fill',
+        'games_collections_and_dex': 'joystick',
+        'pokemons': 'bug-fill',
+        'regional_dex_numbers': 'globe-asia-australia',
+      } %}
+      {% for item, icon in updateDataItems %}
+        {{ admin.action('update_data', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="tab-pane-update_availabilities" role="tabpanel" aria-labelledby="tab-update_availabilities-tab" tabindex="0">
+    <div class="row px-4 py-5">
+      {% set updateAvailabilitiesItems = {
+        'games_availabilities': 'box2',
+        'games_shinies_availabilities': 'box2-fill',
+        'collections_availabilities': 'collection-fill',
+      } %}
+      {% for item, icon in updateAvailabilitiesItems %}
+        {{ admin.action('update_availabilities', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="tab-pane-calculate_data" role="tabpanel" aria-labelledby="tab-calculate_data-tab" tabindex="0">
+    <div class="row px-4 py-5">
+      {% set calculateDataItems = {
+        'game_bundles_availabilities': 'box-seam',
+        'game_bundles_shinies_availabilities': 'box-seam-fill',
+        'dex_availabilities': 'list-check',
+        'pokemon_availabilities': 'calculator',
+      } %}
+      {% for item, icon in calculateDataItems %}
+        {{ admin.action('calculate_data', 'calculate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="tab-pane-invalidate_data" role="tabpanel" aria-labelledby="tab-invalidate_data-tab" tabindex="0">
+    <div class="row px-4 py-5">
+      {% set invalidateDataItems = {
+        'labels': 'tags-fill',
+        'catch_states': 'check2-square',
+        'types': 'shapes',
+        'dex': 'journals',
+        'albums': 'journal-album',
+      } %}
+      {% for item, icon in invalidateDataItems %}
+        {{ admin.action('invalidate_data', 'invalidate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="tab-pane-trigger_pipeline" role="tabpanel" aria-labelledby="tab-trigger_pipeline-tab" tabindex="0">
+    <div class="row px-4 py-5">
+      <p class="text-body-secondary small">{{ 'admin.actions.trigger_pipeline.help'|trans }}</p>
+      {% set triggerPipelineItems = {
+        'update_images': 'images',
+      } %}
+      {% for item, icon in triggerPipelineItems %}
+        {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
+      {% endfor %}
+    </div>
+
+    {% include 'Admin/_pipeline_status.html.twig' %}
+  </div>
 </div>
-
-<div class="row px-4 py-5">
-  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.update_availabilities.title'|trans }}</h2>
-  {% set updateAvailabilitiesItems = {
-    'games_availabilities': 'box2',
-    'games_shinies_availabilities': 'box2-fill',
-    'collections_availabilities': 'collection-fill',
-  } %}
-  {% for item, icon in updateAvailabilitiesItems %}
-    {{ admin.action('update_availabilities', 'update', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
-  {% endfor %}
-</div>
-
-<div class="row px-4 py-5">
-  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.calculate_data.title'|trans }}</h2>
-  {% set calculateDataItems = {
-    'game_bundles_availabilities': 'box-seam',
-    'game_bundles_shinies_availabilities': 'box-seam-fill',
-    'dex_availabilities': 'list-check',
-    'pokemon_availabilities': 'calculator',
-  } %}
-  {% for item, icon in calculateDataItems %}
-    {{ admin.action('calculate_data', 'calculate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
-  {% endfor %}
-</div>
-
-<div class="row px-4 py-5">
-  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.invalidate_data.title'|trans }}</h2>
-  {% set invalidateDataItems = {
-    'labels': 'tags-fill',
-    'catch_states': 'check2-square',
-    'types': 'shapes',
-    'dex': 'journals',
-    'albums': 'journal-album',
-  } %}
-  {% for item, icon in invalidateDataItems %}
-    {{ admin.action('invalidate_data', 'invalidate', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
-  {% endfor %}
-</div>
-
-<div class="row px-4 py-5">
-  <h2 class="mb-3 pb-2 border-bottom">{{ 'admin.actions.trigger_pipeline.title'|trans }}</h2>
-  <p class="text-body-secondary small">{{ 'admin.actions.trigger_pipeline.help'|trans }}</p>
-  {% set triggerPipelineItems = {
-    'update_images': 'images',
-  } %}
-  {% for item, icon in triggerPipelineItems %}
-    {{ admin.action('trigger_pipeline', 'trigger', item, icon, updatedItem, updatedAction, updatedState, actionLogsData) }}
-  {% endfor %}
-</div>
-
-{% include 'Admin/_pipeline_status.html.twig' %}

--- a/templates/Admin/_reports.html.twig
+++ b/templates/Admin/_reports.html.twig
@@ -2,8 +2,6 @@
 
 {% import "Admin/_macros.html.twig" as admin %}
 
-<h2 class="mt-5">{{ 'title.admin_reports'|trans }}</h2>
-
 <h3 class="mt-3">{{ 'admin.reports.catch_state_counts_defined_by_trainer.title'|trans }}</h3>
 <div class="row align-items-center justify-content-center">
   <div class="col-md-3">

--- a/templates/Admin/_tabs.html.twig
+++ b/templates/Admin/_tabs.html.twig
@@ -1,23 +1,37 @@
-{% set adminTabs = {
-  'actions': {
-    'route': 'app_admin_actions',
-    'label': 'title.admin_actions',
-  },
-  'reports': {
-    'route': 'app_admin_reports',
-    'label': 'title.admin_reports',
-  },
-} %}
+{% set adminActionSections = [
+  {'key': 'update_data', 'label': 'admin.actions.update_data.title'},
+  {'key': 'update_availabilities', 'label': 'admin.actions.update_availabilities.title'},
+  {'key': 'calculate_data', 'label': 'admin.actions.calculate_data.title'},
+  {'key': 'invalidate_data', 'label': 'admin.actions.invalidate_data.title'},
+  {'key': 'trigger_pipeline', 'label': 'admin.actions.trigger_pipeline.title'},
+] %}
 
-<ul class="nav nav-tabs mb-4">
-  {% for key, tab in adminTabs %}
-    <li class="nav-item">
-      <a
-        class="nav-link{{ key == active ? ' active' : '' }}"
-        href="{{ path(tab.route) }}"
-      >
-        {{ tab.label|trans }}
-      </a>
+<ul class="nav nav-tabs mb-4" id="admin-actions-tab" role="tablist">
+  {% for section in adminActionSections %}
+    <li class="nav-item" role="presentation">
+      {% if 'actions' == page %}
+        <button
+          class="nav-link{{ section.key == active ? ' active' : '' }}"
+          id="tab-{{ section.key }}-tab"
+          data-bs-toggle="tab"
+          data-bs-target="#tab-pane-{{ section.key }}"
+          type="button"
+          role="tab"
+          aria-controls="tab-pane-{{ section.key }}"
+          aria-selected="{{ section.key == active ? 'true' : 'false' }}"
+        >
+          {{ section.label|trans }}
+        </button>
+      {% else %}
+        <a class="nav-link" href="{{ path('app_admin_actions', {'_fragment': 'tab-pane-'~section.key}) }}">
+          {{ section.label|trans }}
+        </a>
+      {% endif %}
     </li>
   {% endfor %}
+  <li class="nav-item" role="presentation">
+    <a class="nav-link{{ 'reports' == active ? ' active' : '' }}" href="{{ path('app_admin_reports') }}">
+      {{ 'title.admin_reports'|trans }}
+    </a>
+  </li>
 </ul>

--- a/templates/Admin/actions.html.twig
+++ b/templates/Admin/actions.html.twig
@@ -25,7 +25,6 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
-    {% include 'Admin/_tabs.html.twig' with {'active': 'actions'} %}
     {% include 'Admin/_actions.html.twig' %}
   </div>
 </div>
@@ -43,6 +42,7 @@
     (function () {
       watchActionLogToggles();
       watchForceConfirm();
+      activateTabForHash();
     })();
   </script>
 {% endblock %}

--- a/templates/Admin/reports.html.twig
+++ b/templates/Admin/reports.html.twig
@@ -25,7 +25,7 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
-    {% include 'Admin/_tabs.html.twig' with {'active': 'reports'} %}
+    {% include 'Admin/_tabs.html.twig' with {'page': 'reports', 'active': 'reports'} %}
     {% include 'Admin/_reports.html.twig' %}
   </div>
 </div>

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -553,6 +553,58 @@
   {
     "request": {
       "uri": {
+        "match": "/istration/action/invalidate/catch_states"
+      },
+      "method": "delete",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "202",
+      "json": {
+        "action": "invalidate",
+        "item": "catch_states",
+        "state": "ok",
+        "content": "",
+        "error": ""
+      }
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/istration/action/invalidate/types"
+      },
+      "method": "delete",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "202",
+      "json": {
+        "action": "invalidate",
+        "item": "types",
+        "state": "ok",
+        "content": "",
+        "error": ""
+      }
+    }
+  },
+  {
+    "request": {
+      "uri": {
         "match": "/istration/action/invalidate/dex"
       },
       "method": "delete",

--- a/tests/src/Browser/Admin/RedirectActionsTest.php
+++ b/tests/src/Browser/Admin/RedirectActionsTest.php
@@ -34,7 +34,7 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
     ];
 
     #[DataProvider('providerActionItems')]
-    public function testActionItems(string $action, string $item): void
+    public function testActionItems(string $action, string $item, string $section): void
     {
         $client = $this->getNewClient();
 
@@ -43,6 +43,8 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
         $this->loginUser($client, $user);
 
         $client->request('GET', '/fr/istration/actions');
+
+        $this->activateTab($client, $section);
 
         match (\in_array("{$action}_{$item}", self::PENDING_ACTION_ITEMS, true)) {
             true => $this->clickPendingActionAndAcceptConfirm($client, $action, $item),
@@ -59,6 +61,11 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
             $expectedUrl,
             $client->getCurrentURL()
         );
+
+        // The redirect landed back on the default-active tab; the item lives in a
+        // different pane until admin.js's activateTabForHash() reads the URL hash
+        // and activates the right one — this is what this assertion proves.
+        $this->assertSelectorWillBeVisible("#{$action}_{$item}");
     }
 
     /**
@@ -70,66 +77,82 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
             'update_labels' => [
                 'action' => 'update',
                 'item' => 'labels',
+                'section' => 'update_data',
             ],
             'update_games_collections_and_dex' => [
                 'action' => 'update',
                 'item' => 'games_collections_and_dex',
+                'section' => 'update_data',
             ],
             'update_pokemons' => [
                 'action' => 'update',
                 'item' => 'pokemons',
+                'section' => 'update_data',
             ],
             'update_regional_dex_numbers' => [
                 'action' => 'update',
                 'item' => 'regional_dex_numbers',
+                'section' => 'update_data',
             ],
             'update_games_availabilities' => [
                 'action' => 'update',
                 'item' => 'games_availabilities',
+                'section' => 'update_availabilities',
             ],
             'update_games_shinies_availabilities' => [
                 'action' => 'update',
                 'item' => 'games_shinies_availabilities',
+                'section' => 'update_availabilities',
             ],
             'update_collections_availabilities' => [
                 'action' => 'update',
                 'item' => 'collections_availabilities',
+                'section' => 'update_availabilities',
             ],
             'calculate_game_bundles_availabilities' => [
                 'action' => 'calculate',
                 'item' => 'game_bundles_availabilities',
+                'section' => 'calculate_data',
             ],
             'calculate_game_bundles_shinies_availabilities' => [
                 'action' => 'calculate',
                 'item' => 'game_bundles_shinies_availabilities',
+                'section' => 'calculate_data',
             ],
             'calculate_dex_availabilities' => [
                 'action' => 'calculate',
                 'item' => 'dex_availabilities',
+                'section' => 'calculate_data',
             ],
             'calculate_pokemon_availabilities' => [
                 'action' => 'calculate',
                 'item' => 'pokemon_availabilities',
+                'section' => 'calculate_data',
             ],
             'invalidate_labels' => [
                 'action' => 'invalidate',
                 'item' => 'labels',
+                'section' => 'invalidate_data',
             ],
             'invalidate_catch_states' => [
                 'action' => 'invalidate',
                 'item' => 'catch_states',
+                'section' => 'invalidate_data',
             ],
             'invalidate_types' => [
                 'action' => 'invalidate',
                 'item' => 'types',
+                'section' => 'invalidate_data',
             ],
             'invalidate_dex' => [
                 'action' => 'invalidate',
                 'item' => 'dex',
+                'section' => 'invalidate_data',
             ],
             'invalidate_albums' => [
                 'action' => 'invalidate',
                 'item' => 'albums',
+                'section' => 'invalidate_data',
             ],
         ];
     }
@@ -158,5 +181,17 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
     {
         $form = $client->getCrawler()->filter("#{$action}_{$item} form")->form();
         $client->submit($form);
+    }
+
+    /**
+     * Opens the nav-pill tab for the given section (templates/Admin/_actions.html.twig) so its
+     * items become visible/interactable — items outside the default-active `update_data` tab
+     * start hidden (`display: none`) on a fresh page load.
+     */
+    private function activateTab(Client $client, string $section): void
+    {
+        $tab = $client->findElement(WebDriverBy::cssSelector("#tab-{$section}-tab"));
+        $client->executeScript('arguments[0].scrollIntoView({block: "center", inline: "nearest"});', [$tab]);
+        $tab->click();
     }
 }

--- a/tests/src/Browser/Admin/RedirectActionsTest.php
+++ b/tests/src/Browser/Admin/RedirectActionsTest.php
@@ -115,6 +115,14 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
                 'action' => 'invalidate',
                 'item' => 'labels',
             ],
+            'invalidate_catch_states' => [
+                'action' => 'invalidate',
+                'item' => 'catch_states',
+            ],
+            'invalidate_types' => [
+                'action' => 'invalidate',
+                'item' => 'types',
+            ],
             'invalidate_dex' => [
                 'action' => 'invalidate',
                 'item' => 'dex',

--- a/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
@@ -60,6 +60,8 @@ final class ActionInvalidateTest extends WebTestCase
     {
         return [
             ['labels'],
+            ['catch_states'],
+            ['types'],
             ['dex'],
             ['albums'],
             ['reports'],
@@ -88,8 +90,6 @@ final class ActionInvalidateTest extends WebTestCase
     public static function providerInvalidateNotExists(): array
     {
         return [
-            ['catch_states'],
-            ['types'],
             ['games_collections_and_dex'],
             ['pokemons'],
             ['regional_dex_numbers'],

--- a/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @internal
@@ -113,8 +114,8 @@ final class ActionInvalidateTest extends WebTestCase
 
         $client->catchExceptions(false);
 
-        $this->expectException(NotFoundHttpException::class);
+        $this->expectException(AccessDeniedException::class);
 
-        $client->request('GET', '/fr/istration/action/invalidate/catch_states');
+        $client->request('POST', '/fr/istration/action/invalidate/labels');
     }
 }

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -74,12 +74,39 @@ final class AdminPageTest extends WebTestCase
         $this->getAdminHomeConnected();
     }
 
+    /**
+     * @SuppressWarnings("PHPMD.ExcessiveMethodLength")
+     */
     public function testAdminHome(): void
     {
         $crawler = $this->getAdminHomeConnected();
 
-        $this->assertCountFilter($crawler, 6, 'h2');
+        $this->assertCountFilter($crawler, 0, 'h2');
         $this->assertCountFilter($crawler, 17, 'h3');
+
+        $this->assertCountFilter($crawler, 6, '#admin-actions-tab > .nav-item > .nav-link');
+        $this->assertCountFilter($crawler, 1, '#admin-actions-tab .nav-link.active');
+        $this->assertCountFilter($crawler, 5, '.tab-content > .tab-pane');
+        $this->assertCountFilter($crawler, 1, '.tab-content > .tab-pane.show.active');
+
+        $reportsTabHref = $crawler->filter('#admin-actions-tab a.nav-link')->attr('href') ?? '';
+        $this->assertStringContainsString('/fr/istration/reports', $reportsTabHref);
+
+        foreach ([
+            'update_data',
+            'update_availabilities',
+            'calculate_data',
+            'invalidate_data',
+            'trigger_pipeline',
+        ] as $section) {
+            $this->assertCountFilter($crawler, 1, "#tab-{$section}-tab[data-bs-target=\"#tab-pane-{$section}\"]");
+            $this->assertCountFilter($crawler, 1, "#tab-pane-{$section}");
+        }
+
+        $this->assertCountFilter($crawler, 1, '#tab-pane-update_data.show.active');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-update_data #update_labels');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-invalidate_data #invalidate_labels');
+        $this->assertCountFilter($crawler, 1, '#tab-pane-trigger_pipeline .admin-pipeline-status');
         $this->assertCountFilter($crawler, 17, '.admin-item-description');
         $this->assertCountFilter($crawler, 17, '.admin-item button.admin-item-cta');
 

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -172,13 +172,13 @@ final class AdminPageTest extends WebTestCase
     private function getExpectedDescriptions(): array
     {
         return [
-            'update_labels' => 'Recharge les labels (traductions, catégories, tags) depuis la source Google Sheets.',
-            'update_games_collections_and_dex' => 'Recharge les jeux, les collections et les dex depuis la source Google Sheets.',
-            'update_pokemons' => 'Recharge les données des Pokémon (espèces, formes, statistiques) depuis la source Google Sheets.',
-            'update_regional_dex_numbers' => 'Recharge les numéros de dex régionaux de chaque Pokémon depuis la source Google Sheets.',
-            'update_games_availabilities' => 'Recalcule quels Pokémon sont disponibles dans chaque jeu.',
-            'update_games_shinies_availabilities' => 'Recalcule quels Pokémon chromatiques sont disponibles dans chaque jeu.',
-            'update_collections_availabilities' => 'Recalcule quels Pokémon sont disponibles dans chaque collection.',
+            'update_labels' => 'Resynchronise les labels (statuts, types, régions, catégories, formes régionales, formes spéciales, variantes) depuis la source Google Sheets.',
+            'update_games_collections_and_dex' => 'Resynchronise les jeux, les collections et les dex depuis la source Google Sheets.',
+            'update_pokemons' => 'Resynchronise les données des Pokémon depuis la source Google Sheets.',
+            'update_regional_dex_numbers' => 'Resynchronise les numéros de dex régionaux depuis la source Google Sheets.',
+            'update_games_availabilities' => 'Resynchronise depuis Google Sheets quels Pokémon sont disponibles dans chaque jeu.',
+            'update_games_shinies_availabilities' => 'Resynchronise depuis Google Sheets quels Pokémon chromatiques sont disponibles dans chaque jeu.',
+            'update_collections_availabilities' => 'Resynchronise depuis Google Sheets quels Pokémon sont disponibles dans chaque collection.',
             'calculate_game_bundles_availabilities' => 'Agrège les disponibilités des jeux au niveau des bundles de jeux.',
             'calculate_game_bundles_shinies_availabilities' => 'Agrège les disponibilités chromatiques des jeux au niveau des bundles de jeux.',
             'calculate_dex_availabilities' => 'Agrège les disponibilités des jeux et des collections au niveau des dex.',

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -79,9 +79,9 @@ final class AdminPageTest extends WebTestCase
         $crawler = $this->getAdminHomeConnected();
 
         $this->assertCountFilter($crawler, 6, 'h2');
-        $this->assertCountFilter($crawler, 15, 'h3');
-        $this->assertCountFilter($crawler, 15, '.admin-item-description');
-        $this->assertCountFilter($crawler, 15, '.admin-item button.admin-item-cta');
+        $this->assertCountFilter($crawler, 17, 'h3');
+        $this->assertCountFilter($crawler, 17, '.admin-item-description');
+        $this->assertCountFilter($crawler, 17, '.admin-item button.admin-item-cta');
 
         foreach ($this->getExpectedDescriptions() as $itemId => $description) {
             $this->assertSame(
@@ -92,7 +92,7 @@ final class AdminPageTest extends WebTestCase
 
         $this->assertCountFilter($crawler, 7, '.admin-item-update button.admin-item-cta');
         $this->assertCountFilter($crawler, 4, '.admin-item-calculate button.admin-item-cta');
-        $this->assertCountFilter($crawler, 3, '.admin-item-invalidate button.admin-item-cta');
+        $this->assertCountFilter($crawler, 5, '.admin-item-invalidate button.admin-item-cta');
         $this->assertCountFilter($crawler, 1, '.admin-item-trigger button.admin-item-cta');
         $this->assertCountFilter($crawler, 1, '#trigger_update_images button.admin-item-cta');
 
@@ -184,6 +184,8 @@ final class AdminPageTest extends WebTestCase
             'calculate_dex_availabilities' => 'Agrège les disponibilités des jeux et des collections au niveau des dex.',
             'calculate_pokemon_availabilities' => "Agrège toutes les disponibilités en un résumé par Pokémon, utilisé dans toute l'application.",
             'invalidate_labels' => "Vide le cache des labels pour qu'ils soient rechargés au prochain accès.",
+            'invalidate_catch_states' => "Vide le cache des statuts pour qu'ils soient rechargés au prochain accès.",
+            'invalidate_types' => "Vide le cache des types pour qu'ils soient rechargés au prochain accès.",
             'invalidate_dex' => "Vide le cache des pages de dex pour qu'elles soient rechargées au prochain accès.",
             'invalidate_albums' => "Vide le cache des pages d'album pour qu'elles soient rechargées au prochain accès.",
             'trigger_update_images' => "Régénère le jeu d'images des Pokémon à partir des dernières données.",

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -385,23 +385,23 @@ admin:
         title: "Update games' availabilities"
         item: "Games' availabilities"
         cta: "Update!"
-        description: "Recomputes which Pokémon are available in each game."
+        description: "Resyncs which Pokémon are available in each game from the Google Sheets source."
       games_shinies_availabilities:
         title: "Update games' shinies' availabilities"
         item: "Games' shinies' availabilities"
         cta: "Update!"
-        description: "Recomputes which shiny Pokémon are available in each game."
+        description: "Resyncs which shiny Pokémon are available in each game from the Google Sheets source."
       collections_availabilities:
         title: "Update collections"
         item: "Collections' availabilities"
         cta: "Update!"
-        description: "Recomputes which Pokémon are available in each collection."
+        description: "Resyncs which Pokémon are available in each collection from the Google Sheets source."
     update_data:
       title: "Update data"
       labels:
         title: "Update labels"
         cta: "Update!"
-        description: "Resyncs labels (translations, categories, tags) from the Google Sheets source."
+        description: "Resyncs labels (catch states, types, regions, category forms, regional forms, special forms, variant forms) from the Google Sheets source."
       games_collections_and_dex:
         title: "Update games, collections and dex"
         cta: "Update!"
@@ -410,12 +410,12 @@ admin:
         title: "Update pokémons"
         item: "Pokémons"
         cta: "Update!"
-        description: "Resyncs Pokémon data (species, forms, stats) from the Google Sheets source."
+        description: "Resyncs Pokémon data from the Google Sheets source."
       regional_dex_numbers:
         title: "Update regional dex numbers"
         item: "Regional Dex numbers"
         cta: "Update!"
-        description: "Resyncs each Pokémon's regional dex numbers from the Google Sheets source."
+        description: "Resyncs regional dex numbers from the Google Sheets source."
       game_generations:
         item: "Game's generations"
       game_bundles:

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -471,9 +471,11 @@ admin:
       catch_states:
         title: "Invalidate status cache"
         cta: "Invalidate!"
+        description: "Clears the cached catch states so the next request reloads them fresh."
       types:
         title: "Invalidate types cache"
         cta: "Invalidate!"
+        description: "Clears the cached types so the next request reloads them fresh."
       labels:
         title: "Invalidate labels cache"
         cta: "Invalidate!"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -389,37 +389,37 @@ admin:
         title: "Mise à jour des disponibilités des jeux"
         item: "Disponibilités des jeux"
         cta: "Mettre à jour"
-        description: "Recalcule quels Pokémon sont disponibles dans chaque jeu."
+        description: "Resynchronise depuis Google Sheets quels Pokémon sont disponibles dans chaque jeu."
       games_shinies_availabilities:
         title: "Mise à jour des disponibilités des jeux des chromatiques"
         item: "Disponibilités des jeux des chromatiques"
         cta: "Mettre à jour"
-        description: "Recalcule quels Pokémon chromatiques sont disponibles dans chaque jeu."
+        description: "Resynchronise depuis Google Sheets quels Pokémon chromatiques sont disponibles dans chaque jeu."
       collections_availabilities:
         title: "Mise à jour des disponibilités des collections"
         item: "Disponibilités des collections"
         cta: "Mettre à jour"
-        description: "Recalcule quels Pokémon sont disponibles dans chaque collection."
+        description: "Resynchronise depuis Google Sheets quels Pokémon sont disponibles dans chaque collection."
     update_data:
       title: "Mises à jour des données"
       labels:
         title: "Mise à jour des labels"
         cta: "Mettre à jour"
-        description: "Recharge les labels (traductions, catégories, tags) depuis la source Google Sheets."
+        description: "Resynchronise les labels (statuts, types, régions, catégories, formes régionales, formes spéciales, variantes) depuis la source Google Sheets."
       games_collections_and_dex:
         title: "Mise à jour des jeux, des collections et des dex"
         cta: "Mettre à jour"
-        description: "Recharge les jeux, les collections et les dex depuis la source Google Sheets."
+        description: "Resynchronise les jeux, les collections et les dex depuis la source Google Sheets."
       pokemons:
         title: "Mise à jour des pokémons"
         item: "Pokémons"
         cta: "Mettre à jour"
-        description: "Recharge les données des Pokémon (espèces, formes, statistiques) depuis la source Google Sheets."
+        description: "Resynchronise les données des Pokémon depuis la source Google Sheets."
       regional_dex_numbers:
         title: "Mise à jour des numéro des dex régionaux"
         item: "Numéros de dex régionaux"
         cta: "Mettre à jour"
-        description: "Recharge les numéros de dex régionaux de chaque Pokémon depuis la source Google Sheets."
+        description: "Resynchronise les numéros de dex régionaux depuis la source Google Sheets."
       game_generations:
         item: "Générations"
       game_bundles:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -476,9 +476,11 @@ admin:
       catch_states:
         title: "Invalidation du cache des statuts"
         cta: "Invalider"
+        description: "Vide le cache des statuts pour qu'ils soient rechargés au prochain accès."
       types:
         title: "Invalidation du cache des types"
         cta: "Invalider"
+        description: "Vide le cache des types pour qu'ils soient rechargés au prochain accès."
       labels:
         title: "Invalidation du cache des labels"
         cta: "Invalider"


### PR DESCRIPTION
## Summary

- Exposes independent `catch_states` and `types` cache invalidation actions in the admin UI (previously only invalidated together), with descriptions clarified to reflect the Google Sheets resync source.
- Fixes `ActionInvalidateTest::testAdminNonAdmin` to actually exercise access control instead of trivially passing.
- Groups the Admin Actions page's five sections (update data, update availabilities, calculate, invalidate, trigger pipeline) into a single Bootstrap tab bar, merged with the previously separate page-level Actions/Reports links so both admin pages share one consistent nav bar. Redundant `<h2>` titles that duplicated tab labels are removed.
- `admin.js` gains `activateTabForHash()` so the existing "jump to and highlight the triggered item" redirect behavior keeps working when the target item lives inside a non-default tab.

Design spec: `docs/superpowers/specs/2026-07-30-admin-actions-tabs-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-30-admin-actions-tabs.md`

## Test plan

- [x] `tests/src/Integration/Controller/Admin` — 44/44 passing
- [x] `tests/src/Browser/Admin` (Chrome) — 19/19 passing
- [x] Full `make tests` (unit + integration + browser Chrome/Firefox) run twice — each run hit one different, unrelated pre-existing flaky browser test (`ProgressBarPopoverTest`, `CommonTest::testOpenCookieManager`), neither touching admin code; both confirmed to pass in isolation
- [ ] `make quality` / `make measures` — not run in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcSHQW94u4oXjtkDen6tiw