### PR TITLE
Ne plus forcer l'écran de consentement Google à chaque connexion

### DIFF
--- a/src/Controller/Connect/AbstractConnectController.php
+++ b/src/Controller/Connect/AbstractConnectController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Connect;
 
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -13,7 +14,7 @@ abstract class AbstractConnectController extends AbstractController implements C
 {
     #[Route('', methods: ['GET'])]
     #[\Override]
-    public function goto(ClientRegistry $clientRegistry): Response
+    public function goto(ClientRegistry $clientRegistry, Request $request): Response
     {
         return $clientRegistry
             ->getClient($this->getProviderName())
@@ -21,7 +22,7 @@ abstract class AbstractConnectController extends AbstractController implements C
                 [
                     $this->getscope(),
                 ],
-                $this->getExtraOptions(),
+                $this->getExtraOptions($request),
             )
         ;
     }
@@ -42,5 +43,5 @@ abstract class AbstractConnectController extends AbstractController implements C
     /**
      * @return array<string, string>
      */
-    abstract protected function getExtraOptions(): array;
+    abstract protected function getExtraOptions(Request $request): array;
 }

--- a/src/Controller/Connect/ConnectControllerInterface.php
+++ b/src/Controller/Connect/ConnectControllerInterface.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Controller\Connect;
 
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 interface ConnectControllerInterface
 {
-    public function goto(ClientRegistry $clientRegistry): Response;
+    public function goto(ClientRegistry $clientRegistry, Request $request): Response;
 
     public function check(): void;
 }

--- a/src/Controller/Connect/DiscordController.php
+++ b/src/Controller/Connect/DiscordController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Connect;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/connect/dd')]
@@ -21,8 +22,11 @@ final class DiscordController extends AbstractConnectController
         return 'openid';
     }
 
+    /**
+     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+     */
     #[\Override]
-    protected function getExtraOptions(): array
+    protected function getExtraOptions(Request $request): array
     {
         return [];
     }

--- a/src/Controller/Connect/GoogleController.php
+++ b/src/Controller/Connect/GoogleController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Connect;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/connect/g')]
@@ -22,9 +23,19 @@ final class GoogleController extends AbstractConnectController
     }
 
     #[\Override]
-    protected function getExtraOptions(): array
+    protected function getExtraOptions(Request $request): array
     {
-        // Forces Google to always resend a refresh_token, not just on first consent.
-        return ['prompt' => 'consent'];
+        // AuthenticationEntryPoint::start() stores '_security_target_path' in the session right
+        // before redirecting here, but only when it's reacting to a missing/expired refresh
+        // token (silent re-auth). AuthenticatorTrait::onAuthenticationSuccess() reads and
+        // removes that key once auth succeeds. So its presence here means this redirect is part
+        // of the silent-reauth flow and we must force Google to resend a refresh_token. Its
+        // absence means a normal user-initiated login, where forcing 'prompt=consent' would
+        // needlessly show the heavy re-consent screen.
+        if ($request->getSession()->has('_security_target_path')) {
+            return ['prompt' => 'consent'];
+        }
+
+        return [];
     }
 }

--- a/tests/src/Integration/Controller/Connect/ConnectTest.php
+++ b/tests/src/Integration/Controller/Connect/ConnectTest.php
@@ -53,13 +53,16 @@ final class ConnectTest extends WebTestCase
     {
         $client = self::createClient();
 
+        // A plain, user-initiated visit to /fr/connect/g has no '_security_target_path' in
+        // session (that key is only set by AuthenticationEntryPoint during silent re-auth), so
+        // Google must not be asked to force the heavy 'prompt=consent' re-consent screen.
         $client->request('GET', '/fr/connect/g');
 
         $this->assertResponseStatusCodeSame(302);
         $crawler = $client->followRedirect();
 
         $this->assertStringStartsWith(
-            'https://accounts.google.com/o/oauth2/v2/auth?prompt=consent&scope=openid%20email%20profile&access_type=offline&state=',
+            'https://accounts.google.com/o/oauth2/v2/auth?scope=openid%20email%20profile&access_type=offline&state=',
             (string) $crawler->getUri()
         );
     }

--- a/tests/src/Unit/Controller/Connect/ConnectControllerTestTrait.php
+++ b/tests/src/Unit/Controller/Connect/ConnectControllerTestTrait.php
@@ -7,7 +7,10 @@ namespace App\Tests\Unit\Controller\Connect;
 use App\Controller\Connect\ConnectControllerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 trait ConnectControllerTestTrait
 {
@@ -18,7 +21,8 @@ trait ConnectControllerTestTrait
         ConnectControllerInterface $controller,
         string $scope,
         string $clientName,
-        array $options = [],
+        array $options,
+        Request $request,
     ): void {
         $client = $this->createMock(OAuth2ClientInterface::class);
         $client
@@ -41,6 +45,20 @@ trait ConnectControllerTestTrait
             ->willReturn($client)
         ;
 
-        $controller->goto($clientRegistry);
+        $controller->goto($clientRegistry, $request);
+    }
+
+    private function createRequestWithSession(bool $withSilentReauthTargetPath): Request
+    {
+        $session = new Session(new MockArraySessionStorage());
+
+        if ($withSilentReauthTargetPath) {
+            $session->set('_security_target_path', '/fr/some/protected/page');
+        }
+
+        $request = new Request();
+        $request->setSession($session);
+
+        return $request;
     }
 }

--- a/tests/src/Unit/Controller/Connect/DiscordControllerTest.php
+++ b/tests/src/Unit/Controller/Connect/DiscordControllerTest.php
@@ -16,14 +16,16 @@ final class DiscordControllerTest extends TestCase
 {
     use ConnectControllerTestTrait;
 
-    public function testGoto(): void
+    public function testGotoIgnoresSessionState(): void
     {
         $controller = new DiscordController();
 
         $this->assertGoto(
             $controller,
             'openid',
-            'discord'
+            'discord',
+            [],
+            $this->createRequestWithSession(true),
         );
     }
 }

--- a/tests/src/Unit/Controller/Connect/GoogleControllerTest.php
+++ b/tests/src/Unit/Controller/Connect/GoogleControllerTest.php
@@ -16,7 +16,7 @@ final class GoogleControllerTest extends TestCase
 {
     use ConnectControllerTestTrait;
 
-    public function testGoto(): void
+    public function testGotoDuringSilentReauthForcesConsent(): void
     {
         $controller = new GoogleController();
 
@@ -25,6 +25,20 @@ final class GoogleControllerTest extends TestCase
             'openid',
             'google',
             ['prompt' => 'consent'],
+            $this->createRequestWithSession(true),
+        );
+    }
+
+    public function testGotoOnNormalLoginDoesNotForceConsent(): void
+    {
+        $controller = new GoogleController();
+
+        $this->assertGoto(
+            $controller,
+            'openid',
+            'google',
+            [],
+            $this->createRequestWithSession(false),
         );
     }
 }


### PR DESCRIPTION
## Summary
- `GoogleController::getExtraOptions()` forçait `prompt=consent` sur **chaque** login, ce qui affiche l'écran "Vous vous reconnectez à pokenini.fr" (+ rappel privacy policy) à chaque connexion, même quand Google a déjà un grant valide.
- On ne force désormais `prompt=consent` que lorsque le redirect provient du mécanisme de reconnexion silencieuse (`AuthenticationEntryPoint`, détecté via la clé de session existante `_security_target_path`) — c'est-à-dire uniquement quand un `refresh_token` frais est réellement nécessaire (issue #287). Une connexion manuelle normale n'affiche plus l'écran de reconsentement.

## Test plan
- [x] TDD : tests écrits et vus rouges avant l'implémentation (`GoogleControllerTest`, `DiscordControllerTest`, `ConnectControllerTestTrait`, `ConnectTest` d'intégration)
- [x] `make measures` : 100% couverture + 100% MSI
- [x] `make quality` (code-quality) : deptrac, phpcsfixer, phpstan, phpmd, psalm, w3c, jsonlint tous verts
- [ ] Vérifier en staging/prod qu'une connexion Google normale ne montre plus l'écran de reconsentement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u