### PR TITLE
Fix credit tooltip not showing on mobile tap

### DIFF
--- a/templates/common/Pokemon/_image_macros.html.twig
+++ b/templates/common/Pokemon/_image_macros.html.twig
@@ -74,15 +74,31 @@
         a real link or carry a tabindex without breaking markup validity
         at those call sites. It stays a non-focusable <span> with an
         accessible name (for assistive tech that inspects it, e.g.
-        screen-reader browse mode) and a click handler (for mouse/touch);
-        it won't appear in sequential Tab order. Visible attribution is
-        also always available via the tooltip on hover. #}
+        screen-reader browse mode); it won't appear in sequential Tab order.
+
+        The credit link itself lives inside the tooltip content (rendered
+        into data-bs-container="body", so the <a> below never ends up
+        nested inside the ancestor <a>), instead of on the badge's own
+        click. Touch devices have no hover, so a tap is the only signal
+        they can give - it used to fire a direct window.open() on the
+        badge, which meant mobile users were sent to the credit link
+        without ever seeing who it was for. Making the tap always open the
+        tooltip first (data-bs-trigger includes "click") guarantees the
+        attribution is seen before anyone follows the link, on every input
+        type. #}
     {% if credit is not null %}
+        {% set creditLabel = ('credit.tooltip'|trans) ~ ': ' ~ credit.name %}
+        {% set tooltipContent = credit.url is not null
+            ? '<a href="%s" target="_blank" rel="noopener">%s</a>'|format(credit.url|e('html_attr'), creditLabel|e('html'))
+            : creditLabel|e('html') %}
         <span
             class="pokemon-image-credit"
             data-bs-toggle="tooltip"
-            data-bs-title="{{ 'credit.tooltip'|trans }}: {{ credit.name }}"
-            {% if credit.url is not null %}onclick="event.preventDefault();event.stopPropagation();window.open('{{ credit.url|e('js') }}', '_blank', 'noopener');"{% endif %}
-        ><i class="bi bi-info-lg" aria-hidden="true"></i><span class="visually-hidden">{{ 'credit.tooltip'|trans }}: {{ credit.name }}</span></span>
+            data-bs-trigger="hover focus click"
+            data-bs-html="true"
+            data-bs-container="body"
+            data-bs-title="{{ tooltipContent }}"
+            onclick="event.stopPropagation();"
+        ><i class="bi bi-info-lg" aria-hidden="true"></i><span class="visually-hidden">{{ creditLabel }}</span></span>
     {% endif %}
 {% endmacro %}

--- a/tests/src/Browser/Album/CreditBadgeTooltipTest.php
+++ b/tests/src/Browser/Album/CreditBadgeTooltipTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser\Album;
+
+use App\Tests\Browser\AbstractBrowserTestCase;
+use App\Tests\Common\Traits\TestNavTrait;
+use App\Tests\Utils\GetUserToken;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Regression guard: on touch devices there is no hover, so a tap on the
+ * credit badge is the only signal it ever gets. It used to fire a direct
+ * window.open() on tap, sending mobile users to the credit link without
+ * ever showing them the tooltip attribution. The badge tap must always
+ * reveal the tooltip first; the credit link only lives inside its content.
+ *
+ * @internal
+ */
+#[CoversNothing]
+#[Group('api-mocked-testing')]
+final class CreditBadgeTooltipTest extends AbstractBrowserTestCase
+{
+    use TestNavTrait;
+
+    public function testTappingCreditBadgeShowsTooltipInsteadOfNavigating(): void
+    {
+        $client = $this->getNewClient();
+
+        $user = GetUserToken::getFakeUserToken('109903422692691643666', 'TestProvider');
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->request('GET', '/fr/album/demolite');
+
+        $client->executeScript(<<<'JS'
+                const modal = new bootstrap.Modal(document.getElementById('modal-bulbasaur'));
+                modal.show();
+            JS);
+        $this->assertSelectorWillBeVisible('#modal-bulbasaur');
+
+        $this->assertSelectorNotExists('.tooltip');
+
+        $urlBeforeClick = $client->getCurrentURL();
+
+        $client->executeScript('document.querySelector(\'#modal-bulbasaur .pokemon-image-credit\').click()');
+
+        $this->assertSame($urlBeforeClick, $client->getCurrentURL());
+
+        $this->assertSelectorWillBeVisible('.tooltip');
+        $this->assertSelectorExists('.tooltip .tooltip-inner a[href*="pokemondb.net"]');
+    }
+}

--- a/tests/src/Integration/Controller/Album/Display/CommonTest.php
+++ b/tests/src/Integration/Controller/Album/Display/CommonTest.php
@@ -102,11 +102,14 @@ final class CommonTest extends WebTestCase
         $badge = $crawler->filter('#modal-bulbasaur a.album-modal-icon-regular .pokemon-image-credit');
         $this->assertCount(1, $badge);
         $this->assertStringContainsString('PokéSprite', $badge->filter('.visually-hidden')->text());
-        $onclick = (string) $badge->first()->attr('onclick');
-        $this->assertStringContainsString('window.open(', $onclick);
-        $this->assertStringContainsString('github.com', $onclick);
-        $this->assertStringContainsString('msikma', $onclick);
-        $this->assertStringContainsString('pokesprite', $onclick);
+        // The credit link lives inside the tooltip content, not on the badge's own click:
+        // touch devices have no hover, so a tap must always reveal the attribution first.
+        $tooltipTitle = (string) $badge->first()->attr('data-bs-title');
+        $this->assertStringContainsString('<a href="', $tooltipTitle);
+        $this->assertStringContainsString('github.com', $tooltipTitle);
+        $this->assertStringContainsString('msikma', $tooltipTitle);
+        $this->assertStringContainsString('pokesprite', $tooltipTitle);
+        $this->assertSame('event.stopPropagation();', (string) $badge->first()->attr('onclick'));
     }
 
     private function assertAlbum(KernelBrowser $client): void

--- a/tests/src/Integration/Controller/Election/ElectionIndexTest.php
+++ b/tests/src/Integration/Controller/Election/ElectionIndexTest.php
@@ -501,11 +501,14 @@ final class ElectionIndexTest extends WebTestCase
         // (the "big" image), never the icon macro, so the badge here reflects the big credit,
         // not the small/icon credit used elsewhere (e.g. Album icons).
         $this->assertStringContainsString('PokemonDB', $badge->filter('.visually-hidden')->text());
-        $onclick = (string) $badge->first()->attr('onclick');
-        $this->assertStringContainsString('window.open(', $onclick);
-        $this->assertStringContainsString('pokemondb.net', $onclick);
-        $this->assertStringContainsString('sprites', $onclick);
-        $this->assertStringContainsString('bulbasaur', $onclick);
+        // The credit link lives inside the tooltip content, not on the badge's own click:
+        // touch devices have no hover, so a tap must always reveal the attribution first.
+        $tooltipTitle = (string) $badge->first()->attr('data-bs-title');
+        $this->assertStringContainsString('<a href="', $tooltipTitle);
+        $this->assertStringContainsString('pokemondb.net', $tooltipTitle);
+        $this->assertStringContainsString('sprites', $tooltipTitle);
+        $this->assertStringContainsString('bulbasaur', $tooltipTitle);
+        $this->assertSame('event.stopPropagation();', (string) $badge->first()->attr('onclick'));
     }
 
     private function assertCardContentDemoLite(Crawler $crawler): void


### PR DESCRIPTION
## Summary
- The credit badge's tooltip only triggered on `hover`, which never fires on touch devices. Its `onclick` fired `window.open(credit.url)` unconditionally, so tapping the badge on mobile navigated straight to the credit link without ever showing the attribution.
- The credit link now lives inside the tooltip content instead of on the badge's own click, rendered into `data-bs-container="body"` so the `<a>` never ends up nested inside the ancestor `<a>` some call sites already wrap the badge in. Tooltip trigger now includes `click`, so a tap always reveals the tooltip first, on every input type - matching desktop's existing hover-then-click behavior.

## Test plan
- [x] Updated `CommonTest::testImageCreditBadgeIsShownWhenCreditExists` and `ElectionIndexTest::testImageCreditBadgeIsShownOnCandidateCard` to assert the link now lives in `data-bs-title`, not `onclick`.
- [x] Added `tests/src/Browser/Album/CreditBadgeTooltipTest.php`: simulates a tap on the badge, asserts no navigation occurs and the tooltip becomes visible with the credit link inside.
- [x] Full integration suite (270 tests), unit suite (368 tests), and Album browser suite (27 tests) pass.
- [x] PHP CS Fixer and PHPStan clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u