### PR TITLE
Show a fixed column count in the album box and list-N grids

### DIFF
--- a/public/css/album.css
+++ b/public/css/album.css
@@ -32,26 +32,6 @@
     padding-bottom: .125rem;
 }
 
-/* Below md, .album-box shows fewer columns (row-cols-3/row-cols-sm-4), so
-    cells are wider than at the 6-column desktop density: scale text up
-    accordingly instead of keeping the desktop-tuned sizes illegibly small. */
-@media (max-width: 767.98px) {
-    .album-case-dex-number {
-        font-size: .65rem;
-    }
-    .album-case-name {
-        font-size: .75rem;
-    }
-    .album-case-catch-state {
-        font-size: .8rem;
-    }
-    .album-case-forms {
-        font-size: .7rem;
-    }
-    .album-case-action {
-        font-size: .7rem;
-    }
-}
 .album-case-action select {
     width: 100%;
 }
@@ -98,17 +78,13 @@ a.album-case-catch-state-edit-action:hover {
     background-color: white;
 }
 
-/* Bootstrap only ships row-cols-*-1 through -6; a list-7 dex needs a 7-column
-    tier of its own once it reaches the row-cols-md-7 breakpoint (see
-    Album/view/_list.html.twig) - below md it falls back to the real Bootstrap
-    row-cols-3/row-cols-sm-4 utilities, so no override is needed there. */
-@media (min-width: 768px) {
-    .album-line.row-cols-md-7 > * {
-        flex: 0 0 auto;
-        width: 14.285714285714286%;
-    }
+/* Bootstrap only ships row-cols-1 through -6; a list-7 dex needs a 7-column
+    class of its own, fixed at every viewport (see Album/view/_list.html.twig). */
+.album-line.row-cols-7 > * {
+    flex: 0 0 auto;
+    width: 14.285714285714286%;
 }
-.album-line.row-cols-md-7 .modal {
+.album-line.row-cols-7 .modal {
     width: 100%;
 }
 

--- a/templates/Album/view/_box.html.twig
+++ b/templates/Album/view/_box.html.twig
@@ -5,7 +5,7 @@
 <div class="album-container album-box">
 {% if filters is not empty %}
     <h2 class="sticky-top">{{ 'title.empty'|trans }}</h2>
-    <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
+    <div class="row row-cols-6 album-line">
         {% for item in list %}
             {{ macro.albumCase(item, dex, allowedToEdit, catchStates, sharedTrainerId, list, loop) }}
         {% endfor %}
@@ -13,7 +13,7 @@
 {% else %}
     <div id="box-1" class="box row">
         {{ macro.boxTitle(1) }}
-        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
+        <div class="row row-cols-6 album-line">
             {% for item in list %}
             {% set boxNumber = (loop.index0 / (6*5)) + 1 %}
 
@@ -23,7 +23,7 @@
     <hr>
     <div id="box-{{ boxNumber }}" class="box row">
         {{ macro.boxTitle(boxNumber) }}
-        <div class="row row-cols-3 row-cols-sm-4 row-cols-md-6 album-line">
+        <div class="row row-cols-6 album-line">
             {% endif %}
 
             {{ macro.albumCase(item, dex, allowedToEdit, catchStates, sharedTrainerId, list, loop) }}

--- a/templates/Album/view/_list.html.twig
+++ b/templates/Album/view/_list.html.twig
@@ -1,33 +1,20 @@
 {% import "Album/_album_macros.html.twig" as macro %}
 {% set sharedTrainerId = app.request.attributes.get('t') %}
 
-{# Responsive column tiers capped at nbCaseByLine, so mobile never shows *more*
-  columns than desktop - mirrors the box template's row-cols-3/sm-4/md-6 pattern
-  (Album/view/_box.html.twig) instead of a single fixed row-cols-N that stayed
-  just as cramped on a phone as on desktop. A list-3 dex is already narrow
-  enough to need no change; list-5/list-7 pick up the same tiering.
+{# Fixed at nbCaseByLine columns on every viewport (a list-N dex must always
+  show exactly N columns, mirroring the box template's fixed row-cols-6 -
+  see Album/view/_box.html.twig).
 
   All items share a single .row: letting Bootstrap's flex-wrap break lines on
   its own (like _box.html.twig's "filters is not empty" branch) means every
-  line but the very last is always full, at every breakpoint. Manually
-  chunking the list into fixed-size groups of nbCaseByLine first (the
-  previous approach) produced a sparse, orphaned line at every chunk boundary
-  whenever nbCaseByLine wasn't a multiple of the column count actually active
-  at that breakpoint - e.g. a list-5 dex still chunks 5-by-5 at the sm/md
-  768px breakpoint, which only displays 4 columns. #}
-{% set mobileCols = nbCaseByLine < 3 ? nbCaseByLine : 3 %}
-{% set smCols = nbCaseByLine < 4 ? nbCaseByLine : 4 %}
-{% set rowColsClasses = 'row-cols-' ~ mobileCols %}
-{% if smCols != mobileCols %}
-    {% set rowColsClasses = rowColsClasses ~ ' row-cols-sm-' ~ smCols %}
-{% endif %}
-{% if nbCaseByLine != smCols %}
-    {% set rowColsClasses = rowColsClasses ~ ' row-cols-md-' ~ nbCaseByLine %}
-{% endif %}
+  line but the very last is always full. Manually chunking the list into
+  fixed-size groups of nbCaseByLine first (an earlier approach) produced a
+  sparse, orphaned line at every chunk boundary whenever the last chunk
+  wasn't a full group. #}
 
 <div class="album-container album-list-{{ nbCaseByLine }}">
     <h2>{{ 'title.empty'|trans }}</h2>
-    <div class="row {{ rowColsClasses }} album-line" id="top-of-the-list">
+    <div class="row row-cols-{{ nbCaseByLine }} album-line" id="top-of-the-list">
         {% for item in list %}
         {{ macro.albumCase(item, dex, allowedToEdit, catchStates, sharedTrainerId, list, loop) }}
         {% endfor %}


### PR DESCRIPTION
## Summary
- The box template (row-cols-3/sm-4/md-6) and list-N templates picked up a responsive column tiering that showed *fewer* columns on mobile than desktop. Requirement is the opposite: the box grid must always show 6 columns and a list-N dex must always show exactly N columns, on every viewport.
- Reverts the responsive tiering back to a single fixed `row-cols-N` class, drops the now-unneeded mobile text-scaling media query (its premise - wider cells on mobile - no longer holds), and fixes the list-7 CSS override to apply the fixed `row-cols-7` class at every breakpoint instead of only above the md breakpoint.

## Test plan
- [ ] Visually check the album box grid and list-3/5/7 dex pages at mobile and desktop widths - column count should stay constant across viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u