### PR TITLE
Persist sessions in Redis instead of container-local files

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,7 +12,7 @@ framework:
         log: true
 
     session:
-        handler_id: null
+        handler_id: '%env(REDIS_DSN)%'
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native


### PR DESCRIPTION
## Summary
- Sessions used the native PHP file handler (`handler_id: null`), storing session files on the `php` container's ephemeral filesystem.
- Every deploy recreates that container, wiping all active sessions and forcing every logged-in user to reconnect.
- `REDIS_DSN` was already provisioned (Redis container, already used by the cache pools) but never wired to sessions.
- Fix: point `session.handler_id` at `REDIS_DSN` in prod. `dev`/`test` already override `handler_id` and are unaffected.

## Test plan
- [x] `bin/console cache:clear --env=prod` compiles (DI graph valid, `session.handler` resolves via `SessionHandlerFactory` from the DSN)
- [x] Manual round-trip: wrote a session key via `RedisSessionHandler`, confirmed it survives a full `php` container restart (equivalent to a redeploy)
- [x] 270 integration tests pass (`make tests-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u