### PR TITLE
Fix: preserve trigger_pipeline tab after refreshing pipeline status

### DIFF
--- a/templates/Admin/_pipeline_status.html.twig
+++ b/templates/Admin/_pipeline_status.html.twig
@@ -32,7 +32,7 @@
           </dd>
         {% endfor %}
       </dl>
-      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 1})) }}" class="btn btn-outline-info btn-sm">
+      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 1, '_fragment': 'trigger_update_images'})) }}" class="btn btn-outline-info btn-sm">
         {{ 'admin.pipeline_status.refresh'|trans }}
       </a>
     </div>

--- a/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
+++ b/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
@@ -32,6 +32,8 @@ final class PipelineStatusTest extends WebTestCase
         $this->assertStringContainsString('Mergée', $crawler->outerHtml());
 
         $refreshLink = $crawler->filter('.admin-pipeline-status')->siblings()->filter('a.btn-outline-info')->first();
-        $this->assertStringContainsString('refresh=1', (string) $refreshLink->attr('href'));
+        $href = (string) $refreshLink->attr('href');
+        $this->assertStringContainsString('refresh=1', $href);
+        $this->assertStringContainsString('#trigger_update_images', $href);
     }
 }


### PR DESCRIPTION
## Summary
- The "Rafraichir le statut" link on the pipeline-triggering tab was missing the `_fragment` param that every other tab-preserving link on the admin actions page relies on, so clicking it reset the view back to the default tab instead of staying on "Déclenchement des pipelines".
- Added `_fragment: trigger_update_images`, matching the fragment already used by the item's own refresh link and by the POST-action redirect for this item.
- Strengthened `PipelineStatusTest` to assert the fragment is present (it previously only checked for `refresh=1`, which is why the missing fragment went unnoticed).

## Test plan
- [x] `PipelineStatusTest::testPipelineStatusRenders` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u