### PR TITLE
Fix: add missing translation and badge color for pipeline PR "closed" state

### DIFF
--- a/templates/Admin/_pipeline_status.html.twig
+++ b/templates/Admin/_pipeline_status.html.twig
@@ -7,6 +7,7 @@
         'open': 'info',
         'done': 'success',
         'merged': 'success',
+        'closed': 'danger',
         'failed': 'danger',
       } %}
       {% set stages = [

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -728,7 +728,7 @@
         "workflow_a": {"state": "done", "url": "https://github.com/douzeEnsemble/pokenini-icon/actions/runs/1"},
         "icon_pr": {"state": "merged", "url": "https://github.com/douzeEnsemble/pokenini-icon/pull/2"},
         "workflow_b": {"state": "done", "url": "https://github.com/douzeEnsemble/pokenini-icon/actions/runs/3"},
-        "resources_pr": {"state": "open", "url": "https://github.com/douzeEnsemble/pokenini-resources/pull/4"}
+        "resources_pr": {"state": "closed", "url": "https://github.com/douzeEnsemble/pokenini-resources/pull/4"}
       }
     }
   },

--- a/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
+++ b/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
@@ -29,7 +29,10 @@ final class PipelineStatusTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
 
-        $this->assertStringContainsString('Mergée', $crawler->outerHtml());
+        $html = $crawler->outerHtml();
+        $this->assertStringContainsString('Mergée', $html);
+        $this->assertStringContainsString('Fermée', $html);
+        $this->assertStringNotContainsString('admin.pipeline_status.state.closed', $html);
 
         $refreshLink = $crawler->filter('.admin-pipeline-status')->siblings()->filter('a.btn-outline-info')->first();
         $href = (string) $refreshLink->attr('href');

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -376,6 +376,7 @@ admin:
       open: "Open"
       done: "Done"
       merged: "Merged"
+      closed: "Closed"
       failed: "Failed"
 
   actions:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -381,6 +381,7 @@ admin:
       open: "Ouverte"
       done: "Terminé"
       merged: "Mergée"
+      closed: "Fermée"
       failed: "Échoué"
   actions:
     update_availabilities:


### PR DESCRIPTION
## Summary
- A PR closed without merging surfaces as `state: "closed"` from `pokenini-back`, but that state had no entry in either translation catalog nor in the Twig badge color map.
- It rendered as the raw untranslated key `admin.pipeline_status.state.closed` with a pale default badge instead of a proper label.
- Added `closed` translations (fr: "Fermée", en: "Closed") and mapped it to the `danger` badge color, matching GitHub's own closed-PR styling.

## Test plan
- [x] `PipelineStatusTest` moco fixture updated to exercise the `closed` state; asserts the translated label appears and the raw key does not (confirmed the test fails without the fix, passes with it)
- [x] Full unit suite (371 tests) and full `api-mocked-testing` integration suite (240 tests) green
- [x] PHP CS Fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tqe8PZUVNyFffF8qDY553u