### PR TITLE
Fix pipeline refresh link cache-busting

### DIFF
--- a/templates/Admin/_pipeline_status.html.twig
+++ b/templates/Admin/_pipeline_status.html.twig
@@ -32,7 +32,7 @@
           </dd>
         {% endfor %}
       </dl>
-      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 1, '_fragment': 'trigger_update_images'})) }}" class="btn btn-outline-info btn-sm">
+      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 'now'|date('U'), '_fragment': 'trigger_update_images'})) }}" class="btn btn-outline-info btn-sm">
         {{ 'admin.pipeline_status.refresh'|trans }}
       </a>
     </div>

--- a/templates/Admin/_pipeline_status.html.twig
+++ b/templates/Admin/_pipeline_status.html.twig
@@ -32,7 +32,7 @@
           </dd>
         {% endfor %}
       </dl>
-      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 1})) }}" class="btn btn-outline-info btn-sm">
+      <a href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'refresh': 1, '_fragment': 'trigger_update_images'})) }}" class="btn btn-outline-info btn-sm">
         {{ 'admin.pipeline_status.refresh'|trans }}
       </a>
     </div>

--- a/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
+++ b/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
@@ -32,6 +32,8 @@ final class PipelineStatusTest extends WebTestCase
         $this->assertStringContainsString('Mergée', $crawler->outerHtml());
 
         $refreshLink = $crawler->filter('.admin-pipeline-status')->siblings()->filter('a.btn-outline-info')->first();
-        $this->assertStringContainsString('refresh=1', (string) $refreshLink->attr('href'));
+        $href = (string) $refreshLink->attr('href');
+        $this->assertStringContainsString('refresh=1', $href);
+        $this->assertStringContainsString('#trigger_update_images', $href);
     }
 }

--- a/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
+++ b/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
@@ -33,7 +33,7 @@ final class PipelineStatusTest extends WebTestCase
 
         $refreshLink = $crawler->filter('.admin-pipeline-status')->siblings()->filter('a.btn-outline-info')->first();
         $href = (string) $refreshLink->attr('href');
-        $this->assertStringContainsString('refresh=1', $href);
+        $this->assertMatchesRegularExpression('/refresh=\d+/', $href);
         $this->assertStringContainsString('#trigger_update_images', $href);
     }
 }


### PR DESCRIPTION
## Summary
- The admin "refresh pipeline status" link kept a fixed `refresh=1` query param, so a second click produced the same URL and could be served from the browser cache instead of reloading.
- Use `'now'|date('U')` (a Unix timestamp) instead, matching the existing cache-busting pattern in `_macros.html.twig`.
- Also fixes the link losing the `trigger_pipeline` tab anchor after a refresh.

## Test plan
- [x] `make code-quality` green (CS Fixer, PHPStan, Psalm, PHPMD, Deptrac, w3c)
- [x] `PipelineStatusTest::testPipelineStatusRenders` passes, updated to assert `refresh=\d+` instead of the fixed `refresh=1`
- [x] `lint:twig` on the modified template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WegEZoLYoUgbFn88ZjLfMi