### PR TITLE
Liens entre pokédex d'un même trainer (Web)

### DIFF
--- a/public/css/album.css
+++ b/public/css/album.css
@@ -110,3 +110,54 @@ a.album-case-catch-state-edit-action:hover {
     border-top-left-radius: inherit;
     border-left-width: var(--bs-list-group-border-width);
 }
+
+/* Album offcanvas "Liens" section: wider panel to fit the dex banner picker
+    grid, plus the banner-thumbnail treatment from the design mockup
+    (docs/superpowers/specs/mockups/2026-08-03-pokedex-link/offcanvas-links-section.html). */
+#offcanvas {
+    width: 480px;
+    max-width: 100%;
+}
+.dex-link-row img {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+    border-radius: .3rem;
+    background: var(--bs-secondary-bg);
+}
+.dex-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: .5rem;
+}
+.dex-pick-card {
+    border: 1px solid var(--bs-border-color);
+    border-radius: .5rem;
+    padding: .35rem;
+    text-align: center;
+    cursor: pointer;
+    background: none;
+}
+.dex-pick-card:hover {
+    border-color: var(--bs-primary);
+}
+.dex-pick-card img {
+    width: 100%;
+    height: 40px;
+    object-fit: cover;
+    border-radius: .3rem;
+    background: var(--bs-secondary-bg);
+}
+.dex-pick-card small {
+    display: block;
+    margin-top: .2rem;
+    font-size: .68rem;
+}
+.dex-pick-card.selected {
+    border-width: 2px;
+    border-color: var(--bs-primary);
+    background: var(--bs-primary-bg-subtle);
+}
+.dex-pick-card[hidden] {
+    display: none;
+}

--- a/public/css/album.css
+++ b/public/css/album.css
@@ -118,27 +118,23 @@ a.album-case-catch-state-edit-action:hover {
     width: 480px;
     max-width: 100%;
 }
-.dex-link-row img {
-    width: 40px;
-    height: 40px;
-    object-fit: cover;
-    border-radius: .3rem;
-    background: var(--bs-secondary-bg);
-}
 .dex-picker-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: .5rem;
 }
 .dex-pick-card {
+    position: relative;
     border: 1px solid var(--bs-border-color);
     border-radius: .5rem;
     padding: .35rem;
     text-align: center;
-    cursor: pointer;
     background: none;
 }
-.dex-pick-card:hover {
+.dex-pick-card:not(.linked) {
+    cursor: pointer;
+}
+.dex-pick-card:not(.linked):hover {
     border-color: var(--bs-primary);
 }
 .dex-pick-card img {
@@ -149,7 +145,10 @@ a.album-case-catch-state-edit-action:hover {
     background: var(--bs-secondary-bg);
 }
 .dex-pick-card small {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .15rem;
     margin-top: .2rem;
     font-size: .68rem;
 }
@@ -158,6 +157,45 @@ a.album-case-catch-state-edit-action:hover {
     border-color: var(--bs-primary);
     background: var(--bs-primary-bg-subtle);
 }
-.dex-pick-card[hidden] {
-    display: none;
+/* A dex already linked to the one this offcanvas is open on: not
+    selectable again (the API rejects duplicate links), shown instead with
+    a direction chip and a delete control revealed on hover/focus. */
+.dex-pick-card.linked {
+    border-color: var(--bs-primary);
+}
+.dex-pick-card .chip-under {
+    display: inline-flex;
+    align-items: center;
+    gap: .18rem;
+    font-size: .6rem;
+    font-weight: 700;
+    padding: .04rem .32rem .04rem .26rem;
+    border-radius: 999px;
+    background: var(--bs-primary-bg-subtle);
+    color: var(--bs-primary);
+}
+.dex-pick-card .unlink-btn {
+    position: absolute;
+    top: .2rem;
+    left: .2rem;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 50%;
+    border: none;
+    background: var(--bs-danger);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .55rem;
+    opacity: 0;
+    transform: scale(.85);
+    transition: opacity .12s ease, transform .12s ease;
+    box-shadow: 0 0 0 2px var(--bs-body-bg);
+    cursor: pointer;
+}
+.dex-pick-card.linked:hover .unlink-btn,
+.dex-pick-card.linked:focus-within .unlink-btn {
+    opacity: 1;
+    transform: scale(1);
 }

--- a/public/js/album-links.js
+++ b/public/js/album-links.js
@@ -1,0 +1,178 @@
+function watchAlbumLinks() {
+  const section = document.getElementById("album-links-section");
+
+  if (!section) {
+    return;
+  }
+
+  const dexSlug = section.dataset.dexSlug;
+  let selectedTargetDexSlug = null;
+
+  document
+    .getElementById("offcanvas")
+    .addEventListener("shown.bs.offcanvas", function () {
+      loadLinks(dexSlug);
+    });
+
+  document.querySelectorAll(".dex-pick-card").forEach(function (card) {
+    card.addEventListener("click", function () {
+      document.querySelectorAll(".dex-pick-card").forEach(function (c) {
+        c.classList.remove("selected");
+      });
+      card.classList.add("selected");
+      selectedTargetDexSlug = card.dataset.dexSlug;
+      document.getElementById("create-link").disabled = false;
+    });
+  });
+
+  document
+    .getElementById("create-link")
+    .addEventListener("click", function () {
+      createLink(dexSlug, selectedTargetDexSlug);
+    });
+}
+
+function createLink(dexSlug, selectedTargetDexSlug) {
+  if (!selectedTargetDexSlug) {
+    return;
+  }
+
+  const direction = document.querySelector(
+    'input[name="link-direction"]:checked'
+  ).value;
+
+  const request = new Request("/" + locale + "/album_link/" + dexSlug, {
+    method: "POST",
+    body: JSON.stringify({
+      targetDexSlug: selectedTargetDexSlug,
+      bidirectional: direction === "both",
+    }),
+  });
+
+  fetch(request)
+    .then(function (response) {
+      if (response.status !== 201) {
+        throw new Error("Something went wrong on api server!");
+      }
+
+      loadLinks(dexSlug);
+      new bootstrap.Toast(document.getElementById("linksToastSuccess")).show();
+    })
+    .catch(function (error) {
+      console.error(error);
+      new bootstrap.Toast(document.getElementById("linksToastError")).show();
+    });
+}
+
+function loadLinks(dexSlug) {
+  fetch("/" + locale + "/album_link/" + dexSlug)
+    .then(function (response) {
+      if (response.status !== 200) {
+        throw new Error("Something went wrong on api server!");
+      }
+
+      return response.json();
+    })
+    .then(function (links) {
+      renderLinks(dexSlug, links);
+      filterPickerGrid(links);
+    })
+    .catch(function (error) {
+      console.error(error);
+      new bootstrap.Toast(document.getElementById("linksToastError")).show();
+    });
+}
+
+function renderLinks(dexSlug, links) {
+  const container = document.getElementById("active-links");
+  container.innerHTML = "";
+
+  const badge = document.getElementById("album-links-count");
+  badge.textContent = links.length;
+  badge.hidden = links.length === 0;
+
+  const directionIcons = {
+    to: "bi-arrow-right",
+    from: "bi-arrow-left",
+    both: "bi-arrow-left-right",
+  };
+  const directionLabels = {
+    to: linksLabels.directionTo,
+    from: linksLabels.directionFrom,
+    both: linksLabels.directionBoth,
+  };
+
+  links.forEach(function (link) {
+    container.appendChild(
+      buildLinkRow(dexSlug, link, directionIcons, directionLabels)
+    );
+  });
+}
+
+function buildLinkRow(dexSlug, link, directionIcons, directionLabels) {
+  const row = document.createElement("div");
+  row.className = "list-group-item d-flex align-items-center gap-2 dex-link-row";
+
+  const img = document.createElement("img");
+  img.src = dexBannerUrlTemplate.replace("%s", link.target_dex_slug);
+  img.alt = "";
+  row.appendChild(img);
+
+  const info = document.createElement("div");
+  info.className = "flex-fill";
+
+  const name = document.createElement("div");
+  name.className = "fw-bold small";
+  name.textContent = locale === "fr" ? link.target_french_name : link.target_name;
+  info.appendChild(name);
+
+  const direction = document.createElement("div");
+  direction.className = "form-text";
+  direction.innerHTML = '<i class="bi ' + directionIcons[link.direction] + '"></i> ';
+  direction.append(directionLabels[link.direction]);
+  info.appendChild(direction);
+
+  row.appendChild(info);
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "btn btn-sm btn-outline-danger";
+  deleteButton.title = linksLabels.deleteTitle;
+  deleteButton.innerHTML = '<i class="bi bi-trash"></i>';
+  deleteButton.addEventListener("click", function () {
+    deleteLink(dexSlug, link.id);
+  });
+  row.appendChild(deleteButton);
+
+  return row;
+}
+
+function filterPickerGrid(links) {
+  const linkedSlugs = links.map(function (link) {
+    return link.target_dex_slug;
+  });
+
+  document.querySelectorAll(".dex-pick-card").forEach(function (card) {
+    card.hidden = linkedSlugs.indexOf(card.dataset.dexSlug) !== -1;
+  });
+}
+
+function deleteLink(dexSlug, linkId) {
+  const request = new Request("/" + locale + "/album_link/" + linkId, {
+    method: "DELETE",
+  });
+
+  fetch(request)
+    .then(function (response) {
+      if (response.status !== 200) {
+        throw new Error("Something went wrong on api server!");
+      }
+
+      loadLinks(dexSlug);
+      new bootstrap.Toast(document.getElementById("linksToastSuccess")).show();
+    })
+    .catch(function (error) {
+      console.error(error);
+      new bootstrap.Toast(document.getElementById("linksToastError")).show();
+    });
+}

--- a/public/js/album-links.js
+++ b/public/js/album-links.js
@@ -91,6 +91,15 @@ function renderLinks(dexSlug, links) {
   badge.textContent = links.length;
   badge.hidden = links.length === 0;
 
+  if (links.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "form-text";
+    empty.textContent = linksLabels.empty;
+    container.appendChild(empty);
+
+    return;
+  }
+
   const directionIcons = {
     to: "bi-arrow-right",
     from: "bi-arrow-left",

--- a/public/js/album-links.js
+++ b/public/js/album-links.js
@@ -14,14 +14,28 @@ function watchAlbumLinks() {
       loadLinks(dexSlug);
     });
 
+  function selectCard(card) {
+    if (card.classList.contains("linked")) {
+      return;
+    }
+
+    document.querySelectorAll(".dex-pick-card").forEach(function (c) {
+      c.classList.remove("selected");
+    });
+    card.classList.add("selected");
+    selectedTargetDexSlug = card.dataset.dexSlug;
+    document.getElementById("create-link").disabled = false;
+  }
+
   document.querySelectorAll(".dex-pick-card").forEach(function (card) {
     card.addEventListener("click", function () {
-      document.querySelectorAll(".dex-pick-card").forEach(function (c) {
-        c.classList.remove("selected");
-      });
-      card.classList.add("selected");
-      selectedTargetDexSlug = card.dataset.dexSlug;
-      document.getElementById("create-link").disabled = false;
+      selectCard(card);
+    });
+    card.addEventListener("keydown", function (event) {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        selectCard(card);
+      }
     });
   });
 
@@ -74,8 +88,7 @@ function loadLinks(dexSlug) {
       return response.json();
     })
     .then(function (links) {
-      renderLinks(dexSlug, links);
-      filterPickerGrid(links);
+      renderPickerGrid(dexSlug, links);
     })
     .catch(function (error) {
       console.error(error);
@@ -83,22 +96,15 @@ function loadLinks(dexSlug) {
     });
 }
 
-function renderLinks(dexSlug, links) {
-  const container = document.getElementById("active-links");
-  container.innerHTML = "";
-
+function renderPickerGrid(dexSlug, links) {
   const badge = document.getElementById("album-links-count");
   badge.textContent = links.length;
   badge.hidden = links.length === 0;
 
-  if (links.length === 0) {
-    const empty = document.createElement("p");
-    empty.className = "form-text";
-    empty.textContent = linksLabels.empty;
-    container.appendChild(empty);
-
-    return;
-  }
+  const linkedBySlug = {};
+  links.forEach(function (link) {
+    linkedBySlug[link.target_dex_slug] = link;
+  });
 
   const directionIcons = {
     to: "bi-arrow-right",
@@ -111,58 +117,50 @@ function renderLinks(dexSlug, links) {
     both: linksLabels.directionBoth,
   };
 
-  links.forEach(function (link) {
-    container.appendChild(
-      buildLinkRow(dexSlug, link, directionIcons, directionLabels)
-    );
-  });
-}
-
-function buildLinkRow(dexSlug, link, directionIcons, directionLabels) {
-  const row = document.createElement("div");
-  row.className = "list-group-item d-flex align-items-center gap-2 dex-link-row";
-
-  const img = document.createElement("img");
-  img.src = dexBannerUrlTemplate.replace("%s", link.target_dex_slug);
-  img.alt = "";
-  row.appendChild(img);
-
-  const info = document.createElement("div");
-  info.className = "flex-fill";
-
-  const name = document.createElement("div");
-  name.className = "fw-bold small";
-  name.textContent = locale === "fr" ? link.target_french_name : link.target_name;
-  info.appendChild(name);
-
-  const direction = document.createElement("div");
-  direction.className = "form-text";
-  direction.innerHTML = '<i class="bi ' + directionIcons[link.direction] + '"></i> ';
-  direction.append(directionLabels[link.direction]);
-  info.appendChild(direction);
-
-  row.appendChild(info);
-
-  const deleteButton = document.createElement("button");
-  deleteButton.type = "button";
-  deleteButton.className = "btn btn-sm btn-outline-danger";
-  deleteButton.title = linksLabels.deleteTitle;
-  deleteButton.innerHTML = '<i class="bi bi-trash"></i>';
-  deleteButton.addEventListener("click", function () {
-    deleteLink(dexSlug, link.id);
-  });
-  row.appendChild(deleteButton);
-
-  return row;
-}
-
-function filterPickerGrid(links) {
-  const linkedSlugs = links.map(function (link) {
-    return link.target_dex_slug;
-  });
-
   document.querySelectorAll(".dex-pick-card").forEach(function (card) {
-    card.hidden = linkedSlugs.indexOf(card.dataset.dexSlug) !== -1;
+    card.classList.remove("selected");
+
+    const previousUnlinkButton = card.querySelector(".unlink-btn");
+    if (previousUnlinkButton) {
+      previousUnlinkButton.remove();
+    }
+
+    const previousChip = card.querySelector(".chip-under");
+    if (previousChip) {
+      previousChip.remove();
+    }
+
+    const link = linkedBySlug[card.dataset.dexSlug];
+
+    if (!link) {
+      card.classList.remove("linked");
+      delete card.dataset.linkId;
+
+      return;
+    }
+
+    card.classList.add("linked");
+    card.dataset.linkId = link.id;
+
+    const unlinkButton = document.createElement("button");
+    unlinkButton.type = "button";
+    unlinkButton.className = "unlink-btn";
+    unlinkButton.title = linksLabels.deleteTitle;
+    unlinkButton.innerHTML = '<i class="bi bi-x-lg"></i>';
+    unlinkButton.addEventListener("click", function (event) {
+      event.stopPropagation();
+      deleteLink(dexSlug, link.id);
+    });
+    card.appendChild(unlinkButton);
+
+    const chip = document.createElement("span");
+    chip.className = "chip-under";
+    chip.innerHTML =
+      '<i class="bi ' +
+      directionIcons[link.direction] +
+      '"></i> ' +
+      directionLabels[link.direction];
+    card.querySelector("small").appendChild(chip);
   });
 }
 

--- a/src/Controller/AlbumIndexController.php
+++ b/src/Controller/AlbumIndexController.php
@@ -69,11 +69,15 @@ final class AlbumIndexController extends AbstractController
             $loggedTrainerId = null;
         }
 
+        $allowedToEdit = $this->editDexIsGranted($dex, $requestedTrainerId);
+
         /** @var DexListItem[] $trainerDexList */
-        $trainerDexList = array_values(array_filter(
-            $this->getTrainerDexListService->get(),
-            static fn (DexListItem $item): bool => $item->getSettings()->getSlug() !== $dexSlug,
-        ));
+        $trainerDexList = $allowedToEdit
+            ? array_values(array_filter(
+                $this->getTrainerDexListService->get(),
+                static fn (DexListItem $item): bool => $item->getSettings()->getSlug() !== $dexSlug,
+            ))
+            : [];
 
         return $this->render('Album/index.html.twig', [
             'currentDexSlug' => $dexSlug,
@@ -91,7 +95,7 @@ final class AlbumIndexController extends AbstractController
             'trainerId' => !empty($requestedTrainerId) ? $requestedTrainerId : $loggedTrainerId,
             'loggedTrainerId' => $loggedTrainerId,
             'requestedTrainerId' => $requestedTrainerId,
-            'allowedToEdit' => $this->editDexIsGranted($dex, $requestedTrainerId),
+            'allowedToEdit' => $allowedToEdit,
             'trainerDexList' => $trainerDexList,
         ]);
     }

--- a/src/Controller/AlbumIndexController.php
+++ b/src/Controller/AlbumIndexController.php
@@ -7,8 +7,10 @@ namespace App\Controller;
 use App\AlbumFilters\FromRequest;
 use App\Exception\NoLoggedUserException;
 use App\ResponseObject\Album\Dex;
+use App\ResponseObject\Album\DexListItem;
 use App\Security\User;
 use App\Security\UserTokenServiceInterface;
+use App\Service\Back\GetTrainerDexListService;
 use App\Service\GetLabelsService;
 use App\Service\GetTrainerPokedexService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -22,6 +24,7 @@ final class AlbumIndexController extends AbstractController
     public function __construct(
         private readonly GetTrainerPokedexService $getTrainerPokedexService,
         private readonly GetLabelsService $getLabelsService,
+        private readonly GetTrainerDexListService $getTrainerDexListService,
         private readonly UserTokenServiceInterface $userTokenService,
     ) {}
 
@@ -66,6 +69,12 @@ final class AlbumIndexController extends AbstractController
             $loggedTrainerId = null;
         }
 
+        /** @var DexListItem[] $trainerDexList */
+        $trainerDexList = array_values(array_filter(
+            $this->getTrainerDexListService->get(),
+            static fn (DexListItem $item): bool => $item->getSettings()->getSlug() !== $dexSlug,
+        ));
+
         return $this->render('Album/index.html.twig', [
             'currentDexSlug' => $dexSlug,
             'dex' => $dex,
@@ -83,6 +92,7 @@ final class AlbumIndexController extends AbstractController
             'loggedTrainerId' => $loggedTrainerId,
             'requestedTrainerId' => $requestedTrainerId,
             'allowedToEdit' => $this->editDexIsGranted($dex, $requestedTrainerId),
+            'trainerDexList' => $trainerDexList,
         ]);
     }
 

--- a/src/Controller/TrainerDexLinkController.php
+++ b/src/Controller/TrainerDexLinkController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\Back\TrainerDexLinkService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+
+#[Route('/album_link')]
+final class TrainerDexLinkController extends AbstractController
+{
+    public function __construct(
+        private readonly TrainerDexLinkService $service,
+    ) {}
+
+    #[Route('/{dexSlug}', methods: ['GET'])]
+    #[IsGranted('ROLE_TRAINER')]
+    public function list(string $dexSlug): Response
+    {
+        try {
+            $links = $this->service->list($dexSlug);
+        } catch (HttpExceptionInterface $e) {
+            return new JsonResponse([], $e->getResponse()->getStatusCode());
+        }
+
+        return $this->json($links);
+    }
+
+    #[Route('/{dexSlug}', methods: ['POST'])]
+    #[IsGranted('ROLE_TRAINER')]
+    public function create(string $dexSlug, Request $request): Response
+    {
+        $content = $request->getContent();
+
+        if (!$content) {
+            return new JsonResponse([], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $this->service->create($dexSlug, $content);
+        } catch (HttpExceptionInterface $e) {
+            return new JsonResponse([], $e->getResponse()->getStatusCode());
+        }
+
+        return new Response('', Response::HTTP_CREATED);
+    }
+
+    #[Route('/{linkId}', methods: ['DELETE'])]
+    #[IsGranted('ROLE_TRAINER')]
+    public function delete(string $linkId): Response
+    {
+        try {
+            $this->service->delete($linkId);
+        } catch (HttpExceptionInterface $e) {
+            return new JsonResponse([], $e->getResponse()->getStatusCode());
+        }
+
+        return new Response();
+    }
+}

--- a/src/Controller/TrainerDexLinkController.php
+++ b/src/Controller/TrainerDexLinkController.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 #[Route('/album_link')]
@@ -19,7 +18,6 @@ final class TrainerDexLinkController extends AbstractController
 {
     public function __construct(
         private readonly TrainerDexLinkService $service,
-        private readonly SerializerInterface $serializer,
     ) {}
 
     #[Route('/{dexSlug}', methods: ['GET'])]
@@ -27,12 +25,10 @@ final class TrainerDexLinkController extends AbstractController
     public function list(string $dexSlug): Response
     {
         try {
-            $links = $this->service->list($dexSlug);
+            $json = $this->service->listAsJson($dexSlug);
         } catch (HttpExceptionInterface $e) {
             return new JsonResponse([], $e->getResponse()->getStatusCode());
         }
-
-        $json = $this->serializer->serialize($links, 'json');
 
         return new JsonResponse($json, Response::HTTP_OK, [], true);
     }

--- a/src/Controller/TrainerDexLinkController.php
+++ b/src/Controller/TrainerDexLinkController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 #[Route('/album_link')]
@@ -18,6 +19,7 @@ final class TrainerDexLinkController extends AbstractController
 {
     public function __construct(
         private readonly TrainerDexLinkService $service,
+        private readonly SerializerInterface $serializer,
     ) {}
 
     #[Route('/{dexSlug}', methods: ['GET'])]
@@ -30,7 +32,9 @@ final class TrainerDexLinkController extends AbstractController
             return new JsonResponse([], $e->getResponse()->getStatusCode());
         }
 
-        return $this->json($links);
+        $json = $this->serializer->serialize($links, 'json');
+
+        return new JsonResponse($json, Response::HTTP_OK, [], true);
     }
 
     #[Route('/{dexSlug}', methods: ['POST'])]

--- a/src/ResponseObject/Album/TrainerDexLink.php
+++ b/src/ResponseObject/Album/TrainerDexLink.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ResponseObject\Album;
+
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
+final class TrainerDexLink
+{
+    public function __construct(
+        #[SerializedName('id')]
+        private readonly string $id,
+        #[SerializedName('direction')]
+        private readonly string $direction,
+        #[SerializedName('target_dex_slug')]
+        private readonly string $targetDexSlug,
+        #[SerializedName('target_name')]
+        private readonly string $targetName,
+        #[SerializedName('target_french_name')]
+        private readonly string $targetFrenchName,
+    ) {}
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getDirection(): string
+    {
+        return $this->direction;
+    }
+
+    public function getTargetDexSlug(): string
+    {
+        return $this->targetDexSlug;
+    }
+
+    public function getTargetName(): string
+    {
+        return $this->targetName;
+    }
+
+    public function getTargetFrenchName(): string
+    {
+        return $this->targetFrenchName;
+    }
+}

--- a/src/Service/Back/TrainerDexLinkService.php
+++ b/src/Service/Back/TrainerDexLinkService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Back;
+
+use App\ResponseObject\Album\TrainerDexLink;
+
+class TrainerDexLinkService extends AbstractBackService
+{
+    /**
+     * @return TrainerDexLink[]
+     */
+    public function list(string $dexSlug): array
+    {
+        $json = $this->requestContent('GET', "/album_link/{$dexSlug}");
+
+        /** @var TrainerDexLink[] */
+        return $this->serializer->deserialize($json, TrainerDexLink::class.'[]', 'json');
+    }
+
+    public function create(string $dexSlug, string $body): void
+    {
+        $this->request('POST', "/album_link/{$dexSlug}", ['body' => $body]);
+    }
+
+    public function delete(string $linkId): void
+    {
+        $this->request('DELETE', "/album_link/{$linkId}");
+    }
+}

--- a/src/Service/Back/TrainerDexLinkService.php
+++ b/src/Service/Back/TrainerDexLinkService.php
@@ -19,6 +19,11 @@ class TrainerDexLinkService extends AbstractBackService
         return $this->serializer->deserialize($json, TrainerDexLink::class.'[]', 'json');
     }
 
+    public function listAsJson(string $dexSlug): string
+    {
+        return $this->serializer->serialize($this->list($dexSlug), 'json');
+    }
+
     public function create(string $dexSlug, string $body): void
     {
         $this->request('POST', "/album_link/{$dexSlug}", ['body' => $body]);

--- a/templates/Album/_album_macros.html.twig
+++ b/templates/Album/_album_macros.html.twig
@@ -263,7 +263,9 @@
       <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
     </div>
   </div>
+{% endmacro %}
 
+{% macro linksToasts() %}
   <div id="linksToastSuccess" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="d-flex">
       <div class="toast-body">{{ 'album.offcanvas.links.toast.success'|trans }}</div>

--- a/templates/Album/_album_macros.html.twig
+++ b/templates/Album/_album_macros.html.twig
@@ -263,6 +263,20 @@
       <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
     </div>
   </div>
+
+  <div id="linksToastSuccess" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.offcanvas.links.toast.success'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+
+  <div id="linksToastError" class="toast text-bg-danger" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ 'album.offcanvas.links.toast.error'|trans }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
 {% endmacro %}
 
 {% macro boxTitle(boxNumber) %}

--- a/templates/Album/_offcanvas.html.twig
+++ b/templates/Album/_offcanvas.html.twig
@@ -113,16 +113,14 @@
         {{ 'album.offcanvas.links.description'|trans }}
       </p>
 
-      <div class="list-group mb-3" id="active-links"></div>
-
       <p class="form-text mb-1">{{ 'album.offcanvas.links.add.label'|trans }}</p>
       <div class="dex-picker-grid mb-2" id="dex-picker-grid">
         {% for item in trainerDexList %}
           {% set bannerUrl = dexBannerUrl|format(item.dex.slug) %}
-          <button type="button" class="dex-pick-card" data-dex-slug="{{ item.settings.slug }}">
+          <div class="dex-pick-card" data-dex-slug="{{ item.settings.slug }}" role="button" tabindex="0">
             <img src="{{ bannerUrl }}" alt="" loading="lazy">
-            <small>{{ locale is same as('fr') ? item.settings.frenchName : item.settings.name }}</small>
-          </button>
+            <small><span class="pick-name">{{ locale is same as('fr') ? item.settings.frenchName : item.settings.name }}</span></small>
+          </div>
         {% endfor %}
       </div>
 

--- a/templates/Album/_offcanvas.html.twig
+++ b/templates/Album/_offcanvas.html.twig
@@ -102,6 +102,47 @@
       {% endif %}
     </div>
 
+    {% if allowedToEdit %}
+    <div id="album-links-section" data-dex-slug="{{ currentDexSlug }}">
+      <h2 class="h5">
+        <i class="bi bi-link-45deg"></i>
+        {{ 'album.offcanvas.links.title'|trans }}
+        <span class="badge text-bg-info" id="album-links-count" hidden>0</span>
+      </h2>
+      <p class="form-text">
+        {{ 'album.offcanvas.links.description'|trans }}
+      </p>
+
+      <div class="list-group mb-3" id="active-links"></div>
+
+      <p class="form-text mb-1">{{ 'album.offcanvas.links.add.label'|trans }}</p>
+      <div class="dex-picker-grid mb-2" id="dex-picker-grid">
+        {% for item in trainerDexList %}
+          {% set bannerUrl = dexBannerUrl|format(item.dex.slug) %}
+          <button type="button" class="dex-pick-card" data-dex-slug="{{ item.settings.slug }}">
+            <img src="{{ bannerUrl }}" alt="" loading="lazy">
+            <small>{{ locale is same as('fr') ? item.settings.frenchName : item.settings.name }}</small>
+          </button>
+        {% endfor %}
+      </div>
+
+      <div class="btn-group w-100 mb-2" role="group" aria-label="{{ 'album.offcanvas.links.title'|trans }}">
+        <input type="radio" class="btn-check" name="link-direction" id="link-direction-to" value="to" autocomplete="off" checked>
+        <label class="btn btn-outline-secondary btn-sm" for="link-direction-to"><i class="bi bi-arrow-right"></i> {{ 'album.offcanvas.links.direction.to'|trans }}</label>
+
+        <input type="radio" class="btn-check" name="link-direction" id="link-direction-from" value="from" autocomplete="off">
+        <label class="btn btn-outline-secondary btn-sm" for="link-direction-from"><i class="bi bi-arrow-left"></i> {{ 'album.offcanvas.links.direction.from'|trans }}</label>
+
+        <input type="radio" class="btn-check" name="link-direction" id="link-direction-both" value="both" autocomplete="off">
+        <label class="btn btn-outline-secondary btn-sm" for="link-direction-both"><i class="bi bi-arrow-left-right"></i> {{ 'album.offcanvas.links.direction.both'|trans }}</label>
+      </div>
+
+      <button type="button" class="btn btn-primary w-100 mb-3" id="create-link" disabled>
+        <i class="bi bi-plus-lg"></i> {{ 'album.offcanvas.links.create'|trans }}
+      </button>
+    </div>
+    {% endif %}
+
     <div>
       <h2>
         {{ 'album.offcanvas.informations.title'|trans }}

--- a/templates/Album/_toasts.html.twig
+++ b/templates/Album/_toasts.html.twig
@@ -29,6 +29,8 @@
                 <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
               </div>
             </div>
+
+            {{ macro.linksToasts() }}
         {% endif %}
 
         {% if not dex.isPrivate %}

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -92,7 +92,6 @@
         directionFrom: '{{ 'album.offcanvas.links.direction.from'|trans }}',
         directionBoth: '{{ 'album.offcanvas.links.direction.both'|trans }}',
         deleteTitle: '{{ 'album.offcanvas.links.delete_title'|trans }}',
-        empty: '{{ 'album.offcanvas.links.empty'|trans|e('js') }}',
     };
     </script>
 

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -80,11 +80,19 @@
     {% if allowedToEdit %}
     <script src="{{ asset('js/album-edit.js') }}"></script>
     <script src="{{ asset('js/trainer_dex.js') }}"></script>
+    <script src="{{ asset('js/album-links.js') }}"></script>
 
     <script>
     const catchStates = JSON.parse('{{ catchStates | map(cs => {name: cs.name, frenchName: cs.frenchName, slug: cs.slug, color: cs.color}) | json_encode | raw }}');
     const locale = '{{ locale }}';
     const dex = '{{ currentDexSlug }}';
+    const dexBannerUrlTemplate = '{{ dexBannerUrl }}';
+    const linksLabels = {
+        directionTo: '{{ 'album.offcanvas.links.direction.to'|trans }}',
+        directionFrom: '{{ 'album.offcanvas.links.direction.from'|trans }}',
+        directionBoth: '{{ 'album.offcanvas.links.direction.both'|trans }}',
+        deleteTitle: '{{ 'album.offcanvas.links.delete_title'|trans }}',
+    };
     </script>
 
     <script>
@@ -94,6 +102,7 @@
         watchToggleShinyMode();
         watchToAdjustSelectSizes();
         watchAttributes();
+        watchAlbumLinks();
     })();
     </script>
     {% endif %}

--- a/templates/Album/index.html.twig
+++ b/templates/Album/index.html.twig
@@ -92,6 +92,7 @@
         directionFrom: '{{ 'album.offcanvas.links.direction.from'|trans }}',
         directionBoth: '{{ 'album.offcanvas.links.direction.both'|trans }}',
         deleteTitle: '{{ 'album.offcanvas.links.delete_title'|trans }}',
+        empty: '{{ 'album.offcanvas.links.empty'|trans|e('js') }}',
     };
     </script>
 

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -2493,7 +2493,22 @@
     },
     "response": {
       "status": "200",
-      "json": []
+      "json": [
+        {
+          "id": "demo-link-1",
+          "direction": "both",
+          "target_dex_slug": "goldsilvercrystal",
+          "target_name": "Gold, Silver, Crystal",
+          "target_french_name": "Or, Argent, Cristal"
+        },
+        {
+          "id": "demo-link-2",
+          "direction": "to",
+          "target_dex_slug": "rubysapphireemerald",
+          "target_name": "Ruby, Sapphire, Emerald",
+          "target_french_name": "Rubis, Saphir, Émeraude"
+        }
+      ]
     }
   },
   {

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -2475,5 +2475,63 @@
     "response": {
       "file": "/var/moco/responses/dex/trainer.json"
     }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album_link/[\\w-]*"
+      },
+      "headers": {
+        "accept": "application/json",
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "200",
+      "json": []
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album_link/[\\w-]*"
+      },
+      "method": "post",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "201"
+    }
+  },
+  {
+    "request": {
+      "uri": {
+        "match": "/album_link/[\\w-]*"
+      },
+      "method": "delete",
+      "headers": {
+        "X-Provider": {
+          "match": ".*"
+        },
+        "authorization": {
+          "match": "Bearer .*"
+        }
+      }
+    },
+    "response": {
+      "status": "200"
+    }
   }
 ]

--- a/tests/src/Integration/Controller/Album/Display/CommonTest.php
+++ b/tests/src/Integration/Controller/Album/Display/CommonTest.php
@@ -175,10 +175,10 @@ final class CommonTest extends WebTestCase
         $this->assertCountFilter($crawler, 41, '.album-case .album-case-catch-state a.album-case-catch-state-label');
         $this->assertCountFilter($crawler, 0, '.album-case .album-case-catch-state span.album-case-catch-state-label');
 
-        $this->assertCountFilter($crawler, 86, '.toast');
-        $this->assertCountFilter($crawler, 42, '.toast.text-bg-success');
+        $this->assertCountFilter($crawler, 88, '.toast');
+        $this->assertCountFilter($crawler, 43, '.toast.text-bg-success');
         $this->assertCountFilter($crawler, 1, '.toast.text-bg-light');
-        $this->assertCountFilter($crawler, 43, '.toast.text-bg-danger');
+        $this->assertCountFilter($crawler, 44, '.toast.text-bg-danger');
 
         $this->assertCountFilter($crawler, 1, 'script[src="/js/album.js"]');
 

--- a/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Controller;
 
 use App\Controller\TrainerDexLinkController;
-use App\ResponseObject\Album\TrainerDexLink;
 use App\Service\Back\TrainerDexLinkService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -22,23 +20,14 @@ final class TrainerDexLinkControllerTest extends TestCase
 {
     public function testList(): void
     {
-        $link = new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique');
-
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())
-            ->method('list')
+            ->method('listAsJson')
             ->with('national')
-            ->willReturn([$link])
-        ;
-
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->once())
-            ->method('serialize')
-            ->with([$link], 'json')
             ->willReturn('[{"id":"link-1"}]')
         ;
 
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->list('national');
 
@@ -56,15 +45,12 @@ final class TrainerDexLinkControllerTest extends TestCase
 
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())
-            ->method('list')
+            ->method('listAsJson')
             ->with('national')
             ->willThrowException($exception)
         ;
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->list('national');
 
@@ -76,10 +62,7 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->never())->method('create');
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: ''));
 
@@ -94,10 +77,7 @@ final class TrainerDexLinkControllerTest extends TestCase
             ->with('national', '{"targetDexSlug":"shiny"}')
         ;
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
 
@@ -119,10 +99,7 @@ final class TrainerDexLinkControllerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
 
@@ -134,10 +111,7 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())->method('delete')->with('link-1');
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->delete('link-1');
 
@@ -159,10 +133,7 @@ final class TrainerDexLinkControllerTest extends TestCase
             ->willThrowException($exception)
         ;
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->expects($this->never())->method('serialize');
-
-        $controller = new TrainerDexLinkController($service, $serializer);
+        $controller = new TrainerDexLinkController($service);
 
         $response = $controller->delete('link-1');
 

--- a/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
@@ -48,14 +48,18 @@ final class TrainerDexLinkControllerTest extends TestCase
 
     public function testListForwardsApiFailureStatusCode(): void
     {
-        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(404);
 
-        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception = $this->createStub(HttpExceptionInterface::class);
         $exception->method('getResponse')->willReturn($apiResponse);
 
         $service = $this->createMock(TrainerDexLinkService::class);
-        $service->method('list')->willThrowException($exception);
+        $service->expects($this->once())
+            ->method('list')
+            ->with('national')
+            ->willThrowException($exception)
+        ;
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->never())->method('serialize');
@@ -102,14 +106,18 @@ final class TrainerDexLinkControllerTest extends TestCase
 
     public function testCreateForwardsApiFailureStatusCode(): void
     {
-        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(409);
 
-        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception = $this->createStub(HttpExceptionInterface::class);
         $exception->method('getResponse')->willReturn($apiResponse);
 
         $service = $this->createMock(TrainerDexLinkService::class);
-        $service->method('create')->willThrowException($exception);
+        $service->expects($this->once())
+            ->method('create')
+            ->with('national', '{"targetDexSlug":"shiny"}')
+            ->willThrowException($exception)
+        ;
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->never())->method('serialize');
@@ -138,14 +146,18 @@ final class TrainerDexLinkControllerTest extends TestCase
 
     public function testDeleteForwardsApiFailureStatusCode(): void
     {
-        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(404);
 
-        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception = $this->createStub(HttpExceptionInterface::class);
         $exception->method('getResponse')->willReturn($apiResponse);
 
         $service = $this->createMock(TrainerDexLinkService::class);
-        $service->method('delete')->willThrowException($exception);
+        $service->expects($this->once())
+            ->method('delete')
+            ->with('link-1')
+            ->willThrowException($exception)
+        ;
 
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->expects($this->never())->method('serialize');

--- a/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
@@ -10,6 +10,7 @@ use App\Service\Back\TrainerDexLinkService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -30,11 +31,19 @@ final class TrainerDexLinkControllerTest extends TestCase
             ->willReturn([$link])
         ;
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('serialize')
+            ->with([$link], 'json')
+            ->willReturn('[{"id":"link-1"}]')
+        ;
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->list('national');
 
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('[{"id":"link-1"}]', $response->getContent());
     }
 
     public function testListForwardsApiFailureStatusCode(): void
@@ -48,7 +57,10 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->method('list')->willThrowException($exception);
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->list('national');
 
@@ -60,7 +72,10 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->never())->method('create');
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: ''));
 
@@ -75,7 +90,10 @@ final class TrainerDexLinkControllerTest extends TestCase
             ->with('national', '{"targetDexSlug":"shiny"}')
         ;
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
 
@@ -93,7 +111,10 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->method('create')->willThrowException($exception);
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
 
@@ -105,7 +126,10 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())->method('delete')->with('link-1');
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->delete('link-1');
 
@@ -123,7 +147,10 @@ final class TrainerDexLinkControllerTest extends TestCase
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->method('delete')->willThrowException($exception);
 
-        $controller = new TrainerDexLinkController($service);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $controller = new TrainerDexLinkController($service, $serializer);
 
         $response = $controller->delete('link-1');
 

--- a/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Controller;
+
+use App\Controller\TrainerDexLinkController;
+use App\ResponseObject\Album\TrainerDexLink;
+use App\Service\Back\TrainerDexLinkService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(TrainerDexLinkController::class)]
+final class TrainerDexLinkControllerTest extends TestCase
+{
+    public function testList(): void
+    {
+        $link = new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique');
+
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->expects($this->once())
+            ->method('list')
+            ->with('national')
+            ->willReturn([$link])
+        ;
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->list('national');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testListForwardsApiFailureStatusCode(): void
+    {
+        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse->method('getStatusCode')->willReturn(404);
+
+        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception->method('getResponse')->willReturn($apiResponse);
+
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->method('list')->willThrowException($exception);
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->list('national');
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testCreateRejectsEmptyBody(): void
+    {
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->expects($this->never())->method('create');
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->create('national', Request::create('test.local', 'POST', content: ''));
+
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
+    public function testCreateSucceeds(): void
+    {
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->expects($this->once())
+            ->method('create')
+            ->with('national', '{"targetDexSlug":"shiny"}')
+        ;
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    public function testCreateForwardsApiFailureStatusCode(): void
+    {
+        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse->method('getStatusCode')->willReturn(409);
+
+        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception->method('getResponse')->willReturn($apiResponse);
+
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->method('create')->willThrowException($exception);
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->create('national', Request::create('test.local', 'POST', content: '{"targetDexSlug":"shiny"}'));
+
+        $this->assertSame(409, $response->getStatusCode());
+    }
+
+    public function testDelete(): void
+    {
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->expects($this->once())->method('delete')->with('link-1');
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->delete('link-1');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testDeleteForwardsApiFailureStatusCode(): void
+    {
+        $apiResponse = $this->createMock(ResponseInterface::class);
+        $apiResponse->method('getStatusCode')->willReturn(404);
+
+        $exception = $this->createMock(HttpExceptionInterface::class);
+        $exception->method('getResponse')->willReturn($apiResponse);
+
+        $service = $this->createMock(TrainerDexLinkService::class);
+        $service->method('delete')->willThrowException($exception);
+
+        $controller = new TrainerDexLinkController($service);
+
+        $response = $controller->delete('link-1');
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+}

--- a/tests/src/Unit/ResponseObject/Album/TrainerDexLinkTest.php
+++ b/tests/src/Unit/ResponseObject/Album/TrainerDexLinkTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\ResponseObject\Album;
+
+use App\ResponseObject\Album\TrainerDexLink;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(TrainerDexLink::class)]
+final class TrainerDexLinkTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $link = new TrainerDexLink(
+            id: 'link-1',
+            direction: 'both',
+            targetDexSlug: 'shiny',
+            targetName: 'Shiny Living',
+            targetFrenchName: 'Vivarium Chromatique',
+        );
+
+        $this->assertSame('link-1', $link->getId());
+        $this->assertSame('both', $link->getDirection());
+        $this->assertSame('shiny', $link->getTargetDexSlug());
+        $this->assertSame('Shiny Living', $link->getTargetName());
+        $this->assertSame('Vivarium Chromatique', $link->getTargetFrenchName());
+    }
+}

--- a/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
+++ b/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
@@ -37,6 +37,29 @@ final class TrainerDexLinkServiceTest extends AbstractTestBackService
         $this->assertSame($links, $service->list('national'));
     }
 
+    public function testListAsJson(): void
+    {
+        $json = '[{"id":"link-1"}]';
+        $links = [new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique')];
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('deserialize')
+            ->with($json, TrainerDexLink::class.'[]', 'json')
+            ->willReturn($links)
+        ;
+        $serializer->expects($this->once())
+            ->method('serialize')
+            ->with($links, 'json')
+            ->willReturn($json)
+        ;
+
+        /** @var TrainerDexLinkService $service */
+        $service = $this->getServiceWithLoggedUser('GET', $json, 'album_link/national', [], $serializer);
+
+        $this->assertSame($json, $service->listAsJson('national'));
+    }
+
     public function testCreate(): void
     {
         /** @var TrainerDexLinkService $service */

--- a/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
+++ b/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Back;
+
+use App\ResponseObject\Album\TrainerDexLink;
+use App\Security\UserTokenServiceInterface;
+use App\Service\Back\AbstractBackService;
+use App\Service\Back\TrainerDexLinkService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(TrainerDexLinkService::class)]
+final class TrainerDexLinkServiceTest extends AbstractTestBackService
+{
+    public function testList(): void
+    {
+        $json = '[{"id":"link-1"}]';
+        $links = [new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique')];
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('deserialize')
+            ->with($json, TrainerDexLink::class.'[]', 'json')
+            ->willReturn($links)
+        ;
+
+        /** @var TrainerDexLinkService $service */
+        $service = $this->getServiceWithLoggedUser('GET', $json, 'album_link/national', [], $serializer);
+
+        $this->assertSame($links, $service->list('national'));
+    }
+
+    public function testCreate(): void
+    {
+        /** @var TrainerDexLinkService $service */
+        $service = $this->getServiceWithLoggedUser(
+            'POST',
+            '',
+            'album_link/national',
+            ['body' => '{"targetDexSlug":"shiny","bidirectional":true}'],
+        );
+
+        $service->create('national', '{"targetDexSlug":"shiny","bidirectional":true}');
+    }
+
+    public function testDelete(): void
+    {
+        /** @var TrainerDexLinkService $service */
+        $service = $this->getServiceWithLoggedUser('DELETE', '', 'album_link/link-1');
+
+        $service->delete('link-1');
+    }
+
+    #[\Override]
+    protected function instanciateService(
+        LoggerInterface $logger,
+        HttpClientInterface $client,
+        string $url,
+        string $cafilePath,
+        UserTokenServiceInterface $userTokenService,
+        SerializerInterface $serializer,
+    ): AbstractBackService {
+        return new TrainerDexLinkService(
+            $logger,
+            $client,
+            $url,
+            $cafilePath,
+            $userTokenService,
+            $serializer,
+        );
+    }
+}

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -146,9 +146,8 @@ album:
     links:
       title: Links
       description: A link synchronizes the catch state between this dex and another of your dexes.
-      empty: No links yet.
       add:
-        label: "Add a link — pick one of your other dexes:"
+        label: "Your other dexes — pick one to create or manage a link:"
       direction:
         to: To it
         from: From it

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -143,6 +143,20 @@ album:
       title: Informations
     parameters:
       title: Parameters
+    links:
+      title: Links
+      description: A link synchronizes the catch state between this dex and another of your dexes.
+      add:
+        label: "Add a link — pick one of your other dexes:"
+      direction:
+        to: To it
+        from: From it
+        both: Both
+      create: Create the link
+      delete_title: Delete this link
+      toast:
+        success: Link updated successfully.
+        error: Something went wrong while updating the link.
     filters:
       title: Filters
       open_distinguish_types: More

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -146,6 +146,7 @@ album:
     links:
       title: Links
       description: A link synchronizes the catch state between this dex and another of your dexes.
+      empty: No links yet.
       add:
         label: "Add a link — pick one of your other dexes:"
       direction:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -149,6 +149,20 @@ album:
       title: Informations
     parameters:
       title: Paramètres
+    links:
+      title: Liens
+      description: Un lien synchronise le statut de capture entre ce dex et un autre de tes dex.
+      add:
+        label: "Ajouter un lien — choisis un de tes autres dex :"
+      direction:
+        to: Vers lui
+        from: Depuis lui
+        both: Les deux
+      create: Créer le lien
+      delete_title: Supprimer ce lien
+      toast:
+        success: "Lien mis à jour avec succès."
+        error: "Une erreur est survenue lors de la mise à jour du lien."
     title: Filtres
     open_distinguish_types: Avancées
   share:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -152,9 +152,8 @@ album:
     links:
       title: Liens
       description: Un lien synchronise le statut de capture entre ce dex et un autre de tes dex.
-      empty: Aucun lien pour l'instant.
       add:
-        label: "Ajouter un lien — choisis un de tes autres dex :"
+        label: "Tes autres dex — choisis-en un pour créer ou gérer un lien :"
       direction:
         to: Vers lui
         from: Depuis lui

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -152,6 +152,7 @@ album:
     links:
       title: Liens
       description: Un lien synchronise le statut de capture entre ce dex et un autre de tes dex.
+      empty: Aucun lien pour l'instant.
       add:
         label: "Ajouter un lien — choisis un de tes autres dex :"
       direction:


### PR DESCRIPTION
## Summary
- Thin proxy `TrainerDexLinkController` + `TrainerDexLinkService` forwarding the dex-link CRUD surface to pokenini-back.
- New "Liens" section in the album offcanvas: server-rendered picker grid of the trainer's other dexes, driven by `album-links.js` (fetch/create/delete, direction toggle, toast feedback).

Part of a 3-repo feature — companion PRs in pokenini-api and pokenini-back.

## Test plan
- [x] `make tests-unit` / `make tests-integration` — green
- [x] `make measures` (coverage 100% + infection 100% MSI) — green
- [x] `make quality` — green
- [ ] Manual cross-repo E2E (create a link, flip a catch state on one dex, confirm the cascade on the other with all three stacks live) — not yet done, left for a follow-up manual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)