### PR TITLE
fix: use pokenini-back's internal session token instead of the raw OAuth token

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -176,6 +176,7 @@ parameters:
       - AppResponseObject
       - SymfonyHttpFoundation
       - SymfonyOptionsResolver
+      - SymfonySerializer
     AppException:
     AppHelper:
     AppResponseObject:

--- a/src/DTO/UserInfo.php
+++ b/src/DTO/UserInfo.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\DTO;
 
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
 final class UserInfo
 {
     /**
@@ -14,6 +16,8 @@ final class UserInfo
         private readonly string $provider,
         private readonly string $profile,
         private readonly array $roles,
+        #[SerializedName('session_token')]
+        private readonly string $sessionToken,
     ) {}
 
     public function getId(): string
@@ -37,5 +41,10 @@ final class UserInfo
     public function getRoles(): array
     {
         return $this->roles;
+    }
+
+    public function getSessionToken(): string
+    {
+        return $this->sessionToken;
     }
 }

--- a/src/Security/AbstractAuthenticator.php
+++ b/src/Security/AbstractAuthenticator.php
@@ -54,7 +54,7 @@ abstract class AbstractAuthenticator extends OAuth2Authenticator
     {
         $userInfo = $this->getUserInfoService->get($accessToken, $providerName);
 
-        $user = new User($userInfo->getId(), $providerName, $accessToken);
+        $user = new User($userInfo->getId(), $providerName, $accessToken, $userInfo->getSessionToken());
 
         $roles = $userInfo->getRoles();
 

--- a/src/Security/FakeAuthenticator.php
+++ b/src/Security/FakeAuthenticator.php
@@ -53,7 +53,11 @@ final class FakeAuthenticator extends OAuth2Authenticator
 
     private function buildUser(AccessToken $accessToken, string $identifier): User
     {
-        $user = new User($identifier, 'fake', $accessToken);
+        // Dev-only shortcut: no call to pokenini-back's /user exchange endpoint here, so the
+        // session token is simply the identifier itself — pokenini-back's AccessTokenHandler
+        // falls back to its own "fake" provider handling for any bearer token that isn't a
+        // valid internal JWT, exactly like it does for the raw provider token today.
+        $user = new User($identifier, 'fake', $accessToken, $identifier);
 
         if ('admin' === $identifier) {
             $user->addAdminRole();

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -16,6 +16,7 @@ final class User implements UserInterface
         private readonly string $identifier,
         private readonly string $providerName,
         private readonly AccessToken $accessToken,
+        private readonly string $sessionToken,
     ) {}
 
     #[\Override]
@@ -75,6 +76,11 @@ final class User implements UserInterface
     public function getAccessToken(): AccessToken
     {
         return $this->accessToken;
+    }
+
+    public function getSessionToken(): string
+    {
+        return $this->sessionToken;
     }
 
     public function isATrainer(): bool

--- a/src/Security/UserRefresher.php
+++ b/src/Security/UserRefresher.php
@@ -66,10 +66,13 @@ class UserRefresher
             ]);
         }
 
+        // The session token has its own SESSION_TTL-based expiry, independent from the raw
+        // provider access token's lifetime, so it carries over unchanged here.
         $newUser = new User(
             $user->getUserIdentifier(),
             $user->getProviderName(),
             $newAccessToken,
+            $user->getSessionToken(),
         );
 
         foreach ($user->getRoles() as $role) {

--- a/src/Service/Back/AbstractBackService.php
+++ b/src/Service/Back/AbstractBackService.php
@@ -39,7 +39,7 @@ abstract class AbstractBackService
 
         try {
             $user = $this->userTokenService->getLoggedUser();
-            $token = $user->getAccessToken()->getToken();
+            $token = $user->getSessionToken();
             $provider = $user->getProviderName();
         } catch (NoLoggedUserException) {
             $token = $accessToken?->getToken() ?? null;

--- a/tests/Utils/GetUserToken.php
+++ b/tests/Utils/GetUserToken.php
@@ -23,7 +23,8 @@ final class GetUserToken
                     'expires_in' => 999999,
                     'refresh_token' => md5($identifier),
                 ]
-            )
+            ),
+            'test-session-token',
         );
     }
 }

--- a/tests/Utils/GetUserToken.php
+++ b/tests/Utils/GetUserToken.php
@@ -14,6 +14,10 @@ final class GetUserToken
         string $providerName = 'TestProvider',
     ): User {
         // Fake tokens derived from the identifier — not real OAuth credentials.
+        // The session token must stay derived from the identifier (not a fixed
+        // value): AbstractBackService::request() sends it as bearer, and the Moco
+        // fixtures under tests/resources/moco/Back/ select per-user responses by
+        // matching this exact bearer value.
         return new User(
             $identifier,
             $providerName,
@@ -24,7 +28,7 @@ final class GetUserToken
                     'refresh_token' => md5($identifier),
                 ]
             ),
-            'test-session-token',
+            sha1($identifier),
         );
     }
 }

--- a/tests/resources/moco/Back/moco.json
+++ b/tests/resources/moco/Back/moco.json
@@ -143,7 +143,8 @@
           "ROLE_TRAINER",
           "ROLE_COLLECTOR",
           "ROLE_ADMIN"
-        ]
+        ],
+        "session_token": "moco-session-token-admin"
       }
     }
   },
@@ -169,7 +170,8 @@
         "roles" : [
           "ROLE_TRAINER",
           "ROLE_COLLECTOR"
-        ]
+        ],
+        "session_token": "moco-session-token-collector"
       }
     }
   },
@@ -194,7 +196,8 @@
         "profile": "trainer",
         "roles" : [
           "ROLE_TRAINER"
-        ]
+        ],
+        "session_token": "moco-session-token-trainer"
       }
     }
   },
@@ -219,7 +222,8 @@
         "profile": "uninvited",
         "roles" : [
           "ROLE_TRAINER"
-        ]
+        ],
+        "session_token": "moco-session-token-uninvited"
       }
     }
   },

--- a/tests/src/Unit/DTO/UserInfoTest.php
+++ b/tests/src/Unit/DTO/UserInfoTest.php
@@ -26,6 +26,7 @@ final class UserInfoTest extends TestCase
                 'ROLE_TRAINER',
                 'ROLE_COLLECTOR',
             ],
+            'session-jwt-from-back',
         );
 
         $this->assertSame(
@@ -46,6 +47,10 @@ final class UserInfoTest extends TestCase
                 'ROLE_COLLECTOR',
             ],
             $userInfo->getRoles(),
+        );
+        $this->assertSame(
+            'session-jwt-from-back',
+            $userInfo->getSessionToken(),
         );
     }
 }

--- a/tests/src/Unit/Security/AuthenticatorAuthenticateClosedTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorAuthenticateClosedTestTrait.php
@@ -41,6 +41,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -62,6 +63,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -83,6 +85,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -104,6 +107,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -125,6 +129,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     /**
@@ -168,6 +173,7 @@ trait AuthenticatorAuthenticateClosedTestTrait
                     'mock',
                     'trainer',
                     $roles,
+                    'session-jwt-from-back',
                 )
             )
         ;

--- a/tests/src/Unit/Security/AuthenticatorAuthenticateOpenedTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorAuthenticateOpenedTestTrait.php
@@ -40,6 +40,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -61,6 +62,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -82,6 +84,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -103,6 +106,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     #[Test]
@@ -124,6 +128,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals('1212121212000000000000012', $user->getId());
         $this->assertEquals('1212121212000000000000012', $user->getUserIdentifier());
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
+        $this->assertEquals('session-jwt-from-back', $user->getSessionToken());
     }
 
     /**
@@ -167,6 +172,7 @@ trait AuthenticatorAuthenticateOpenedTestTrait
                     'mock',
                     'trainer',
                     $roles,
+                    'session-jwt-from-back',
                 )
             )
         ;

--- a/tests/src/Unit/Security/AuthenticatorOnAuthentificationTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorOnAuthentificationTestTrait.php
@@ -30,7 +30,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'zdazdzad-token-dazga'])
+            new AccessToken(['access_token' => 'zdazdzad-token-dazga']),
+            'test-session-token',
         );
 
         $token = $this->createMock(TokenInterface::class);
@@ -61,7 +62,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'zdazdzad-token-dazga'])
+            new AccessToken(['access_token' => 'zdazdzad-token-dazga']),
+            'test-session-token',
         );
         $user->addTrainerRole();
 
@@ -94,7 +96,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'zdazdzad-token-dazga'])
+            new AccessToken(['access_token' => 'zdazdzad-token-dazga']),
+            'test-session-token',
         );
 
         $token = $this->createMock(TokenInterface::class);

--- a/tests/src/Unit/Security/FakeAuthenticatorAuthenticateTest.php
+++ b/tests/src/Unit/Security/FakeAuthenticatorAuthenticateTest.php
@@ -37,6 +37,7 @@ final class FakeAuthenticatorAuthenticateTest extends TestCase
         $this->assertFalse($user->isACollector());
         $this->assertEquals('uninvited', $user->getId());
         $this->assertEquals('uninvited', $user->getUserIdentifier());
+        $this->assertEquals('uninvited', $user->getSessionToken());
     }
 
     #[Test]

--- a/tests/src/Unit/Security/FakeAuthenticatorOnAuthentificationTest.php
+++ b/tests/src/Unit/Security/FakeAuthenticatorOnAuthentificationTest.php
@@ -31,7 +31,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzad6a4d'])
+            new AccessToken(['access_token' => 'dzad6a4d']),
+            'test-session-token',
         );
 
         $token = $this->createMock(TokenInterface::class);
@@ -60,7 +61,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzad6a4d'])
+            new AccessToken(['access_token' => 'dzad6a4d']),
+            'test-session-token',
         );
         $user->addTrainerRole();
 
@@ -93,7 +95,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $user = new User(
             '1',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzad6a4d'])
+            new AccessToken(['access_token' => 'dzad6a4d']),
+            'test-session-token',
         );
 
         $token = $this->createMock(TokenInterface::class);

--- a/tests/src/Unit/Security/UserGetProfileTest.php
+++ b/tests/src/Unit/Security/UserGetProfileTest.php
@@ -22,7 +22,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
 
         $this->assertEquals('user', $user->getProfile());
@@ -34,7 +35,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addTrainerRole();
 
@@ -47,7 +49,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addCollectorRole();
 
@@ -60,7 +63,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addAdminRole();
 
@@ -73,7 +77,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addTrainerRole();
         $user->addAdminRole();
@@ -87,7 +92,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addCollectorRole();
         $user->addAdminRole();
@@ -101,7 +107,8 @@ final class UserGetProfileTest extends TestCase
         $user = new User(
             '12',
             'TestProvider',
-            new AccessToken(['access_token' => 'dzzad'])
+            new AccessToken(['access_token' => 'dzzad']),
+            'test-session-token',
         );
         $user->addTrainerRole();
         $user->addCollectorRole();

--- a/tests/src/Unit/Security/UserProviderTest.php
+++ b/tests/src/Unit/Security/UserProviderTest.php
@@ -47,7 +47,8 @@ final class UserProviderTest extends TestCase
             new AccessToken([
                 'access_token' => 'dzadzz',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $refresher = $this->createMock(UserRefresher::class);

--- a/tests/src/Unit/Security/UserRefresherTest.php
+++ b/tests/src/Unit/Security/UserRefresherTest.php
@@ -62,7 +62,8 @@ final class UserRefresherTest extends TestCase
                 'access_token' => 'dzadzz',
                 'refresh_token' => 'ipoadnaz',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
         $user->addAdminRole();
         $user->addCollectorRole();
@@ -76,6 +77,7 @@ final class UserRefresherTest extends TestCase
         $this->assertSame('yoiup', $newUser->getAccessToken()->getToken());
         $this->assertSame('ipoadnaz', $newUser->getAccessToken()->getRefreshToken());
         $this->assertSame($expectedExpiry, $newUser->getAccessToken()->getExpires());
+        $this->assertSame('test-session-token', $newUser->getSessionToken());
     }
 
     #[Test]
@@ -104,7 +106,8 @@ final class UserRefresherTest extends TestCase
                 'access_token' => 'old-access',
                 'refresh_token' => 'old-refresh',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $newUser = $refresher->refresh($user);
@@ -130,7 +133,8 @@ final class UserRefresherTest extends TestCase
             new AccessToken([
                 'access_token' => 'dzadzz',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $this->expectException(AuthenticationExpiredException::class);
@@ -181,7 +185,8 @@ final class UserRefresherTest extends TestCase
                 'access_token' => 'old-access',
                 'refresh_token' => 'old-refresh',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $this->expectException(AuthenticationExpiredException::class);
@@ -228,7 +233,8 @@ final class UserRefresherTest extends TestCase
                 'access_token' => 'old-access',
                 'refresh_token' => 'old-refresh',
                 'expires_in' => -1,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $this->expectException(AuthenticationExpiredException::class);
@@ -254,7 +260,8 @@ final class UserRefresherTest extends TestCase
             new AccessToken([
                 'access_token' => 'dzadzz',
                 'expires_in' => 1000000000000000000,
-            ])
+            ]),
+            'test-session-token',
         );
 
         $freshUser = $provider->refresh($user);

--- a/tests/src/Unit/Security/UserRolesTest.php
+++ b/tests/src/Unit/Security/UserRolesTest.php
@@ -23,6 +23,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -38,6 +39,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -53,6 +55,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -68,6 +71,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -84,6 +88,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -100,6 +105,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -116,6 +122,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -132,6 +139,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
 
@@ -148,6 +156,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertFalse($user->isATrainer());
@@ -164,6 +173,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertFalse($user->isACollector());
@@ -180,6 +190,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertFalse($user->isAnAdmin());
@@ -196,6 +207,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertFalse($user->isATrainer());
@@ -217,6 +229,7 @@ final class UserRolesTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertFalse($user->isATrainer());

--- a/tests/src/Unit/Security/UserTest.php
+++ b/tests/src/Unit/Security/UserTest.php
@@ -23,6 +23,7 @@ final class UserTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertEquals('12', $user->getUserIdentifier());
@@ -38,8 +39,21 @@ final class UserTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
         );
 
         $this->assertSame('zdazdazd564', $user->getAccessToken()->getToken());
+    }
+
+    public function testGetSessionToken(): void
+    {
+        $user = new User(
+            '12',
+            'TestProvider',
+            new AccessToken(['access_token' => 'zdazdazd564']),
+            'test-session-token',
+        );
+
+        $this->assertSame('test-session-token', $user->getSessionToken());
     }
 }

--- a/tests/src/Unit/Security/UserTokenServiceTest.php
+++ b/tests/src/Unit/Security/UserTokenServiceTest.php
@@ -31,6 +31,7 @@ final class UserTokenServiceTest extends TestCase
                     '12',
                     'TestProvider',
                     new AccessToken(['access_token' => 'd546354']),
+                    'test-session-token',
                 ),
             )
         ;
@@ -71,6 +72,7 @@ final class UserTokenServiceTest extends TestCase
                     '12',
                     'TestProvider',
                     new AccessToken(['access_token' => 'd546354']),
+                    'test-session-token',
                 ),
             )
         ;
@@ -100,6 +102,7 @@ final class UserTokenServiceTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'd546354']),
+            'test-session-token',
         );
 
         $security = $this->createMock(Security::class);

--- a/tests/src/Unit/Service/AppVersionServiceFilemtimeStub.php
+++ b/tests/src/Unit/Service/AppVersionServiceFilemtimeStub.php
@@ -14,7 +14,7 @@ use App\Tests\Unit\Service\AppVersionServiceTest;
  * can prove the missing-file guard clause returns early instead of falling through to
  * filemtime() (whose failure on a missing path would otherwise mask the removed guard).
  */
-function filemtime(string $filename): int|false
+function filemtime(string $filename): false|int
 {
     ++AppVersionServiceTest::$filemtimeCallCount;
 

--- a/tests/src/Unit/Service/AppVersionServiceFilemtimeStub.php
+++ b/tests/src/Unit/Service/AppVersionServiceFilemtimeStub.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Tests\Unit\Service\AppVersionServiceTest;
+
+/**
+ * Shadows the global filemtime() inside App\Service (PHP falls back to the global
+ * function for unqualified calls, so this only intercepts calls from that namespace).
+ * Lets tests force the TOCTOU race in AppVersionService::getUpdatedAt() — file exists,
+ * then filemtime() fails — without an actual race condition. Also counts calls so tests
+ * can prove the missing-file guard clause returns early instead of falling through to
+ * filemtime() (whose failure on a missing path would otherwise mask the removed guard).
+ */
+function filemtime(string $filename): int|false
+{
+    ++AppVersionServiceTest::$filemtimeCallCount;
+
+    return AppVersionServiceTest::$forceFilemtimeFailure ? false : \filemtime($filename);
+}

--- a/tests/src/Unit/Service/AppVersionServiceTest.php
+++ b/tests/src/Unit/Service/AppVersionServiceTest.php
@@ -13,12 +13,23 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
+require_once __DIR__.'/AppVersionServiceFilemtimeStub.php';
+
 /**
  * @internal
  */
 #[CoversClass(AppVersionService::class)]
 final class AppVersionServiceTest extends TestCase
 {
+    public static bool $forceFilemtimeFailure = false;
+    public static int $filemtimeCallCount = 0;
+
+    protected function tearDown(): void
+    {
+        self::$forceFilemtimeFailure = false;
+        self::$filemtimeCallCount = 0;
+    }
+
     #[Test]
     public function getVersionReturnsFileContent(): void
     {
@@ -201,6 +212,19 @@ final class AppVersionServiceTest extends TestCase
         $service = new AppVersionService(self::getDir(), new ArrayAdapter(), new Filesystem());
 
         $this->assertNull($service->getUpdatedAt('non_existent_file'));
+        $this->assertSame(0, self::$filemtimeCallCount, 'getUpdatedAt() must return early on a missing file, without calling filemtime().');
+    }
+
+    #[Test]
+    public function getUpdatedAtReturnsNullWhenFilemtimeFails(): void
+    {
+        file_put_contents(self::getDir().'/resources/metadata/version', '1.2.12');
+
+        self::$forceFilemtimeFailure = true;
+
+        $service = new AppVersionService(self::getDir(), new ArrayAdapter(), new Filesystem());
+
+        $this->assertNull($service->getUpdatedAt());
     }
 
     private static function getDir(): string

--- a/tests/src/Unit/Service/AppVersionServiceTest.php
+++ b/tests/src/Unit/Service/AppVersionServiceTest.php
@@ -24,6 +24,7 @@ final class AppVersionServiceTest extends TestCase
     public static bool $forceFilemtimeFailure = false;
     public static int $filemtimeCallCount = 0;
 
+    #[\Override]
     protected function tearDown(): void
     {
         self::$forceFilemtimeFailure = false;

--- a/tests/src/Unit/Service/Back/AbstractTestBackService.php
+++ b/tests/src/Unit/Service/Back/AbstractTestBackService.php
@@ -194,7 +194,9 @@ abstract class AbstractTestBackService extends TestCase
         ];
 
         if (null !== $token) {
-            $headers['Authorization'] = 'Bearer '.$token;
+            // The logged-in path now sends the internal session token as bearer, not the raw
+            // provider access token — see AbstractBackService::request() and User::getSessionToken().
+            $headers['Authorization'] = 'Bearer test-session-token';
             $headers['X-Provider'] = 'testprovider';
         }
 
@@ -236,6 +238,7 @@ abstract class AbstractTestBackService extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => $token]),
+            'test-session-token',
         );
 
         $userTokenService

--- a/tests/src/Unit/Service/Back/AdminActionServiceTest.php
+++ b/tests/src/Unit/Service/Back/AdminActionServiceTest.php
@@ -74,7 +74,7 @@ final class AdminActionServiceTest extends TestCase
                 [
                     'headers' => [
                         'accept' => 'application/json',
-                        'Authorization' => 'Bearer dzdz-access-token-dzdz',
+                        'Authorization' => 'Bearer test-session-token',
                         'X-Provider' => 'testprovider',
                     ],
                     'cafile' => '/some/where/cafile.pem',
@@ -87,6 +87,7 @@ final class AdminActionServiceTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'dzdz-access-token-dzdz']),
+            'test-session-token',
         );
 
         $userTokenService = $this->createMock(UserTokenServiceInterface::class);
@@ -166,7 +167,7 @@ final class AdminActionServiceTest extends TestCase
                 [
                     'headers' => [
                         'accept' => 'application/json',
-                        'Authorization' => 'Bearer dzdz-access-token-dzdz',
+                        'Authorization' => 'Bearer test-session-token',
                         'X-Provider' => 'testprovider',
                     ],
                     'cafile' => '/some/where/cafile.pem',
@@ -179,6 +180,7 @@ final class AdminActionServiceTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'dzdz-access-token-dzdz']),
+            'test-session-token',
         );
 
         $userTokenService = $this->createMock(UserTokenServiceInterface::class);

--- a/tests/src/Unit/Service/Back/GetElectionIndexServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetElectionIndexServiceTest.php
@@ -154,7 +154,9 @@ final class GetElectionIndexServiceTest extends AbstractTestBackService
         ];
 
         if (null !== $token) {
-            $headers['Authorization'] = 'Bearer '.$token;
+            // The logged-in path sends the internal session token as bearer, not the raw
+            // provider access token — see AbstractBackService::request() and User::getSessionToken().
+            $headers['Authorization'] = 'Bearer test-session-token';
             $headers['X-Provider'] = 'testprovider';
         }
 

--- a/tests/src/Unit/Service/Back/GetUserInfoServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetUserInfoServiceTest.php
@@ -57,7 +57,7 @@ final class GetUserInfoServiceTest extends TestCase
                 [
                     'headers' => [
                         'accept' => 'application/json',
-                        'Authorization' => 'Bearer abcde-access-token-abcde',
+                        'Authorization' => 'Bearer test-session-token',
                         'X-Provider' => 'testprovider',
                     ],
                     'cafile' => './resources/certificates/cacert.pem',
@@ -70,6 +70,7 @@ final class GetUserInfoServiceTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'abcde-access-token-abcde']),
+            'test-session-token',
         );
 
         $userTokenService = $this->createMock(UserTokenServiceInterface::class);
@@ -84,6 +85,7 @@ final class GetUserInfoServiceTest extends TestCase
             'mock',
             'collector',
             ['ROLE_TRAINER', 'ROLE_COLLECTOR'],
+            'session-jwt-from-back',
         );
 
         $serializer = $this->createMock(SerializerInterface::class);
@@ -111,6 +113,7 @@ final class GetUserInfoServiceTest extends TestCase
         $this->assertSame('mock', $userInfo->getProvider());
         $this->assertSame('collector', $userInfo->getProfile());
         $this->assertSame(['ROLE_TRAINER', 'ROLE_COLLECTOR'], $userInfo->getRoles());
+        $this->assertSame('session-jwt-from-back', $userInfo->getSessionToken());
     }
 
     #[Test]
@@ -163,6 +166,7 @@ final class GetUserInfoServiceTest extends TestCase
             'mock',
             'collector',
             ['ROLE_TRAINER', 'ROLE_COLLECTOR'],
+            'session-jwt-from-back',
         );
 
         $serializer = $this->createMock(SerializerInterface::class);
@@ -190,5 +194,6 @@ final class GetUserInfoServiceTest extends TestCase
         $this->assertSame('mock', $userInfo->getProvider());
         $this->assertSame('collector', $userInfo->getProfile());
         $this->assertSame(['ROLE_TRAINER', 'ROLE_COLLECTOR'], $userInfo->getRoles());
+        $this->assertSame('session-jwt-from-back', $userInfo->getSessionToken());
     }
 }

--- a/tests/src/Unit/Service/Back/GetVersionsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetVersionsServiceTest.php
@@ -174,6 +174,7 @@ final class GetVersionsServiceTest extends TestCase
             '12',
             'TestProvider',
             new AccessToken(['access_token' => 'dzdz-access-token-dzdz']),
+            'test-session-token',
         );
 
         $userTokenService = $this->createMock(UserTokenServiceInterface::class);


### PR DESCRIPTION
## Summary
- Companion to pokenini-back's `fix/persistent-session-token` PR — needs to land together with it.
- `User`/`UserInfo` now carry a `sessionToken` (from pokenini-back's `session_token` field, obtained at login).
- `AbstractBackService` sends this internal token as the Bearer credential instead of the raw Google/Discord OAuth access token, which expired after ~1h and caused forced logouts well before the 7-day session cookie expired.
- `UserRefresher`/`FakeAuthenticator` updated to carry/produce the session token consistently.

## Test plan
- [ ] `make tests` passes
- [ ] Manually verify a session survives past 1h against a pokenini-back deployed with its matching fix
- [ ] `make quality` / `make measures` still green