### PR TITLE
feat: richer dex-link picker + links tree section on the Trainer page

### DIFF
--- a/public/css/album.css
+++ b/public/css/album.css
@@ -131,11 +131,26 @@ a.album-case-catch-state-edit-action:hover {
     text-align: center;
     background: none;
 }
-.dex-pick-card:not(.linked) {
+.dex-pick-card:not(.linked):not(.dex-pick-card-current) {
     cursor: pointer;
 }
-.dex-pick-card:not(.linked):hover {
+.dex-pick-card:not(.linked):not(.dex-pick-card-current):hover {
     border-color: var(--bs-primary);
+}
+/* The dex currently displayed in the album: always shown, in the same
+    position as on any other dex's picker, but disabled since linking a
+    dex to itself makes no sense. */
+.dex-pick-card.dex-pick-card-current {
+    opacity: .45;
+    cursor: not-allowed;
+}
+.dex-pick-card .chip-current {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-secondary-color);
+}
+/* Client-side filtering (search + flags) on the picker grid. */
+.dex-pick-card.dex-pick-hidden {
+    display: none;
 }
 .dex-pick-card img {
     max-width: 100%;
@@ -192,6 +207,32 @@ a.album-case-catch-state-edit-action:hover {
     transition: opacity .12s ease, transform .12s ease;
     box-shadow: 0 0 0 2px var(--bs-body-bg);
     cursor: pointer;
+}
+/* Small "view this dex" shortcut, symmetric to the unlink control, always
+    present except on the current dex's own (disabled) card. */
+.dex-pick-card .dex-pick-view {
+    position: absolute;
+    top: .2rem;
+    right: .2rem;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 50%;
+    border: none;
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .55rem;
+    opacity: 0;
+    transform: scale(.85);
+    transition: opacity .12s ease, transform .12s ease;
+    box-shadow: 0 0 0 2px var(--bs-body-bg);
+}
+.dex-pick-card:hover .dex-pick-view,
+.dex-pick-card:focus-within .dex-pick-view {
+    opacity: 1;
+    transform: scale(1);
 }
 .dex-pick-card.linked:hover .unlink-btn,
 .dex-pick-card.linked:focus-within .unlink-btn {

--- a/public/css/trainer.css
+++ b/public/css/trainer.css
@@ -1,0 +1,40 @@
+/* Trainer page: "Links between dexes" tab — a deduplicated edge list acting
+    as a simple visual tree/graph of the trainer's dex links (see
+    src/Service/GetTrainerDexLinksTreeService.php for how edges are built). */
+.dex-links-tree {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.dex-links-edge {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: .5rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: .5rem;
+}
+.dex-links-node {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    flex: 1 1 220px;
+    min-width: 0;
+}
+.dex-links-node img {
+    width: 56px;
+    height: 56px;
+    object-fit: cover;
+    border-radius: .5rem;
+    background: var(--bs-secondary-bg);
+    flex-shrink: 0;
+}
+.dex-links-node span {
+    overflow-wrap: anywhere;
+}
+.dex-links-arrow {
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    color: var(--bs-primary);
+}

--- a/public/js/album-links.js
+++ b/public/js/album-links.js
@@ -28,10 +28,20 @@ function watchAlbumLinks() {
   }
 
   document.querySelectorAll(".dex-pick-card").forEach(function (card) {
-    card.addEventListener("click", function () {
+    if (card.classList.contains("dex-pick-card-current")) {
+      return;
+    }
+
+    card.addEventListener("click", function (event) {
+      if (event.target.closest(".dex-pick-view")) {
+        return;
+      }
       selectCard(card);
     });
     card.addEventListener("keydown", function (event) {
+      if (event.target.closest(".dex-pick-view")) {
+        return;
+      }
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         selectCard(card);
@@ -44,6 +54,49 @@ function watchAlbumLinks() {
     .addEventListener("click", function () {
       createLink(dexSlug, selectedTargetDexSlug);
     });
+
+  watchDexPickerFilters();
+}
+
+function watchDexPickerFilters() {
+  const search = document.getElementById("dex-picker-search");
+  const filters = document.querySelectorAll('[id^="dex-picker-filter-"]');
+
+  if (!search) {
+    return;
+  }
+
+  search.addEventListener("input", applyDexPickerFilters);
+  filters.forEach(function (filter) {
+    filter.addEventListener("change", applyDexPickerFilters);
+  });
+}
+
+function applyDexPickerFilters() {
+  const searchInput = document.getElementById("dex-picker-search");
+  const search = searchInput ? searchInput.value.trim().toLowerCase() : "";
+  const flagFilters = {
+    isShiny: document.getElementById("dex-picker-filter-shiny"),
+    isPremium: document.getElementById("dex-picker-filter-premium"),
+    isCustom: document.getElementById("dex-picker-filter-custom"),
+  };
+
+  document.querySelectorAll(".dex-pick-card").forEach(function (card) {
+    let visible = true;
+
+    if (search && card.dataset.name.indexOf(search) === -1) {
+      visible = false;
+    }
+
+    Object.keys(flagFilters).forEach(function (flag) {
+      const select = flagFilters[flag];
+      if (visible && select && select.value && card.dataset[flag] !== select.value) {
+        visible = false;
+      }
+    });
+
+    card.classList.toggle("dex-pick-hidden", !visible);
+  });
 }
 
 function createLink(dexSlug, selectedTargetDexSlug) {
@@ -120,6 +173,12 @@ function renderPickerGrid(dexSlug, links) {
   document.querySelectorAll(".dex-pick-card").forEach(function (card) {
     card.classList.remove("selected");
 
+    if (card.classList.contains("dex-pick-card-current")) {
+      // The current dex's own card is never selectable and never carries a
+      // link (linking a dex to itself makes no sense) — leave it untouched.
+      return;
+    }
+
     const previousUnlinkButton = card.querySelector(".unlink-btn");
     if (previousUnlinkButton) {
       previousUnlinkButton.remove();
@@ -162,6 +221,8 @@ function renderPickerGrid(dexSlug, links) {
       directionLabels[link.direction];
     card.querySelector("small").appendChild(chip);
   });
+
+  applyDexPickerFilters();
 }
 
 function deleteLink(dexSlug, linkId) {

--- a/public/js/trainer_tabs.js
+++ b/public/js/trainer_tabs.js
@@ -1,0 +1,15 @@
+function watchTrainerTabs() {
+  const hash = window.location.hash;
+
+  if (!hash) {
+    return;
+  }
+
+  const tabButton = document.querySelector('[data-bs-target="' + hash + '"]');
+
+  if (!tabButton) {
+    return;
+  }
+
+  new bootstrap.Tab(tabButton).show();
+}

--- a/src/Controller/AlbumIndexController.php
+++ b/src/Controller/AlbumIndexController.php
@@ -72,12 +72,7 @@ final class AlbumIndexController extends AbstractController
         $allowedToEdit = $this->editDexIsGranted($dex, $requestedTrainerId);
 
         /** @var DexListItem[] $trainerDexList */
-        $trainerDexList = $allowedToEdit
-            ? array_values(array_filter(
-                $this->getTrainerDexListService->get(),
-                static fn (DexListItem $item): bool => $item->getSettings()->getSlug() !== $dexSlug,
-            ))
-            : [];
+        $trainerDexList = $allowedToEdit ? $this->getTrainerDexListService->get() : [];
 
         return $this->render('Album/index.html.twig', [
             'currentDexSlug' => $dexSlug,

--- a/src/Controller/AlbumIndexController.php
+++ b/src/Controller/AlbumIndexController.php
@@ -7,7 +7,6 @@ namespace App\Controller;
 use App\AlbumFilters\FromRequest;
 use App\Exception\NoLoggedUserException;
 use App\ResponseObject\Album\Dex;
-use App\ResponseObject\Album\DexListItem;
 use App\Security\User;
 use App\Security\UserTokenServiceInterface;
 use App\Service\Back\GetTrainerDexListService;
@@ -71,7 +70,6 @@ final class AlbumIndexController extends AbstractController
 
         $allowedToEdit = $this->editDexIsGranted($dex, $requestedTrainerId);
 
-        /** @var DexListItem[] $trainerDexList */
         $trainerDexList = $allowedToEdit ? $this->getTrainerDexListService->get() : [];
 
         return $this->render('Album/index.html.twig', [

--- a/src/Controller/TrainerIndexController.php
+++ b/src/Controller/TrainerIndexController.php
@@ -9,6 +9,7 @@ use App\DTO\DexFiltersRequest;
 use App\ResponseObject\Album\DexListItem;
 use App\Service\Back\GetTrainerDexListService;
 use App\Service\GetLabelsService;
+use App\Service\GetTrainerDexLinksTreeService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,6 +22,7 @@ final class TrainerIndexController extends AbstractController
     public function __construct(
         private readonly GetTrainerDexListService $getDexService,
         private readonly GetLabelsService $getLabelsService,
+        private readonly GetTrainerDexLinksTreeService $getTrainerDexLinksTreeService,
     ) {}
 
     #[Route('')]
@@ -39,6 +41,7 @@ final class TrainerIndexController extends AbstractController
                 'trainerDex' => $filteredTrainerDex,
                 'filters' => $filters,
                 'catchStates' => $this->getLabelsService->getCatchStates(),
+                'linksTree' => $this->getTrainerDexLinksTreeService->getTree(),
             ]
         );
     }

--- a/src/DTO/TrainerDexLinkEdge.php
+++ b/src/DTO/TrainerDexLinkEdge.php
@@ -12,7 +12,7 @@ final class TrainerDexLinkEdge
         private readonly string $id,
         private readonly string $mode,
         private readonly DexListItem $from,
-        private readonly DexListItem $to,
+        private readonly DexListItem $toDex,
     ) {}
 
     public function getId(): string
@@ -35,6 +35,6 @@ final class TrainerDexLinkEdge
 
     public function getTo(): DexListItem
     {
-        return $this->to;
+        return $this->toDex;
     }
 }

--- a/src/DTO/TrainerDexLinkEdge.php
+++ b/src/DTO/TrainerDexLinkEdge.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use App\ResponseObject\Album\DexListItem;
+
+final class TrainerDexLinkEdge
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $mode,
+        private readonly DexListItem $from,
+        private readonly DexListItem $to,
+    ) {}
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * 'to' for a one-directional sync from `from` to `to`, 'both' for a bidirectional sync.
+     */
+    public function getMode(): string
+    {
+        return $this->mode;
+    }
+
+    public function getFrom(): DexListItem
+    {
+        return $this->from;
+    }
+
+    public function getTo(): DexListItem
+    {
+        return $this->to;
+    }
+}

--- a/src/DTO/TrainerDexLinksTree.php
+++ b/src/DTO/TrainerDexLinksTree.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+final class TrainerDexLinksTree
+{
+    /**
+     * @param TrainerDexLinkEdge[] $edges
+     */
+    public function __construct(
+        private readonly array $edges,
+    ) {}
+
+    /**
+     * @return TrainerDexLinkEdge[]
+     */
+    public function getEdges(): array
+    {
+        return $this->edges;
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->edges;
+    }
+}

--- a/src/Service/GetTrainerDexLinksTreeService.php
+++ b/src/Service/GetTrainerDexLinksTreeService.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\DTO\TrainerDexLinkEdge;
+use App\DTO\TrainerDexLinksTree;
+use App\ResponseObject\Album\DexListItem;
+use App\ResponseObject\Album\TrainerDexLink;
+use App\Service\Back\GetTrainerDexListService;
+use App\Service\Back\TrainerDexLinkService;
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * Aggregates the trainer dex links across every one of the trainer's dexes into a single,
+ * deduplicated set of edges, since the back-end only exposes links one dex at a time
+ * (`GET /album_link/{dexSlug}`).
+ */
+class GetTrainerDexLinksTreeService
+{
+    public function __construct(
+        private readonly GetTrainerDexListService $getTrainerDexListService,
+        private readonly TrainerDexLinkService $trainerDexLinkService,
+    ) {}
+
+    public function getTree(): TrainerDexLinksTree
+    {
+        $dexList = $this->getTrainerDexListService->get();
+
+        /** @var array<string, DexListItem> $dexBySlug */
+        $dexBySlug = [];
+        foreach ($dexList as $item) {
+            $dexBySlug[$item->getSettings()->getSlug()] = $item;
+        }
+
+        /** @var array<string, TrainerDexLinkEdge> $edgesByPairKey */
+        $edgesByPairKey = [];
+
+        foreach ($dexList as $item) {
+            $sourceSlug = $item->getSettings()->getSlug();
+
+            foreach ($this->listLinksFor($sourceSlug) as $link) {
+                $edge = $this->resolveEdge($sourceSlug, $link, $dexBySlug);
+
+                if (null === $edge) {
+                    continue;
+                }
+
+                $pairKey = $this->pairKey($edge->getFrom()->getSettings()->getSlug(), $edge->getTo()->getSettings()->getSlug());
+
+                // A pair already known to be bidirectional stays bidirectional, whichever
+                // side of the pair it gets reported from next.
+                if (isset($edgesByPairKey[$pairKey]) && 'both' === $edgesByPairKey[$pairKey]->getMode()) {
+                    continue;
+                }
+
+                $edgesByPairKey[$pairKey] = $edge;
+            }
+        }
+
+        return new TrainerDexLinksTree(array_values($edgesByPairKey));
+    }
+
+    /**
+     * @return TrainerDexLink[]
+     */
+    private function listLinksFor(string $dexSlug): array
+    {
+        try {
+            return $this->trainerDexLinkService->list($dexSlug);
+        } catch (HttpExceptionInterface|TransportExceptionInterface) {
+            return [];
+        }
+    }
+
+    /**
+     * @param array<string, DexListItem> $dexBySlug
+     */
+    private function resolveEdge(
+        string $sourceSlug,
+        TrainerDexLink $link,
+        array $dexBySlug,
+    ): ?TrainerDexLinkEdge {
+        $targetSlug = $link->getTargetDexSlug();
+
+        [$fromSlug, $toSlug, $mode] = match ($link->getDirection()) {
+            'from' => [$targetSlug, $sourceSlug, 'to'],
+            'both' => [$sourceSlug, $targetSlug, 'both'],
+            default => [$sourceSlug, $targetSlug, 'to'],
+        };
+
+        $from = $dexBySlug[$fromSlug] ?? null;
+        $to = $dexBySlug[$toSlug] ?? null;
+
+        if (null === $from || null === $to) {
+            return null;
+        }
+
+        return new TrainerDexLinkEdge($link->getId(), $mode, $from, $to);
+    }
+
+    private function pairKey(string $slugA, string $slugB): string
+    {
+        return $slugA < $slugB ? "{$slugA}|{$slugB}" : "{$slugB}|{$slugA}";
+    }
+}

--- a/src/Service/GetTrainerDexLinksTreeService.php
+++ b/src/Service/GetTrainerDexLinksTreeService.php
@@ -92,13 +92,13 @@ class GetTrainerDexLinksTreeService
         };
 
         $from = $dexBySlug[$fromSlug] ?? null;
-        $to = $dexBySlug[$toSlug] ?? null;
+        $toDex = $dexBySlug[$toSlug] ?? null;
 
-        if (null === $from || null === $to) {
+        if (null === $from || null === $toDex) {
             return null;
         }
 
-        return new TrainerDexLinkEdge($link->getId(), $mode, $from, $to);
+        return new TrainerDexLinkEdge($link->getId(), $mode, $from, $toDex);
     }
 
     private function pairKey(string $slugA, string $slugB): string

--- a/templates/Album/_offcanvas.html.twig
+++ b/templates/Album/_offcanvas.html.twig
@@ -112,17 +112,11 @@
       <p class="form-text">
         {{ 'album.offcanvas.links.description'|trans }}
       </p>
-
-      <p class="form-text mb-1">{{ 'album.offcanvas.links.add.label'|trans }}</p>
-      <div class="dex-picker-grid mb-2" id="dex-picker-grid">
-        {% for item in trainerDexList %}
-          {% set thumbUrl = dexThumbUrl|format(item.dex.slug) %}
-          <div class="dex-pick-card" data-dex-slug="{{ item.settings.slug }}" role="button" tabindex="0">
-            <img src="{{ thumbUrl }}" alt="" loading="lazy">
-            <small><span class="pick-name">{{ locale is same as('fr') ? item.settings.frenchName : item.settings.name }}</span></small>
-          </div>
-        {% endfor %}
-      </div>
+      <p class="form-text mb-3">
+        <a href="{{ path('app_trainerindex_index', { '_fragment': 'section-links' }) }}">
+          <i class="bi bi-diagram-3"></i> {{ 'album.offcanvas.links.see_tree'|trans }}
+        </a>
+      </p>
 
       <div class="btn-group w-100 mb-2" role="group" aria-label="{{ 'album.offcanvas.links.title'|trans }}">
         <input type="radio" class="btn-check" name="link-direction" id="link-direction-to" value="to" autocomplete="off" checked>
@@ -138,6 +132,56 @@
       <button type="button" class="btn btn-primary w-100 mb-3" id="create-link" disabled>
         <i class="bi bi-plus-lg"></i> {{ 'album.offcanvas.links.create'|trans }}
       </button>
+
+      <div class="dex-picker-filters row g-2 mb-2">
+        <div class="col-12">
+          <label for="dex-picker-search" class="visually-hidden">{{ 'album.offcanvas.links.filters.search.label'|trans }}</label>
+          <div class="input-group input-group-sm">
+            <span class="input-group-text"><i class="bi bi-search"></i></span>
+            <input type="search" class="form-control" id="dex-picker-search" placeholder="{{ 'album.offcanvas.links.filters.search.label'|trans }}">
+          </div>
+        </div>
+        {% for attribute in ['shiny', 'premium', 'custom'] %}
+          <div class="col-4">
+            <label for="dex-picker-filter-{{ attribute }}" class="visually-hidden">{{ ('album.offcanvas.links.filters.attributes.'~attribute~'.label')|trans }}</label>
+            <select class="form-select form-select-sm" id="dex-picker-filter-{{ attribute }}">
+              <option value="">{{ ('album.offcanvas.links.filters.attributes.'~attribute~'.all')|trans }}</option>
+              <option value="1">{{ ('album.offcanvas.links.filters.attributes.'~attribute~'.on')|trans }}</option>
+              <option value="0">{{ ('album.offcanvas.links.filters.attributes.'~attribute~'.off')|trans }}</option>
+            </select>
+          </div>
+        {% endfor %}
+      </div>
+
+      <p class="form-text mb-1">{{ 'album.offcanvas.links.add.label'|trans }}</p>
+      <div class="dex-picker-grid mb-2" id="dex-picker-grid">
+        {% for item in trainerDexList %}
+          {% set isCurrent = item.settings.slug == currentDexSlug %}
+          {% set thumbUrl = dexThumbUrl|format(item.dex.slug) %}
+          <div
+            class="dex-pick-card{{ isCurrent ? ' dex-pick-card-current' : '' }}"
+            data-dex-slug="{{ item.settings.slug }}"
+            data-name="{{ (item.settings.name~' '~item.settings.frenchName)|lower }}"
+            data-is-shiny="{{ item.flags.isShiny ? '1' : '0' }}"
+            data-is-premium="{{ item.flags.isPremium ? '1' : '0' }}"
+            data-is-custom="{{ item.flags.isCustom ? '1' : '0' }}"
+            {% if not isCurrent %}role="button" tabindex="0"{% endif %}
+          >
+            {% if not isCurrent %}
+              <a class="dex-pick-view" href="{{ path('app_albumindex_index', { 'dexSlug': item.settings.slug }) }}" title="{{ 'album.offcanvas.links.view'|trans }}" aria-label="{{ 'album.offcanvas.links.view'|trans }}">
+                <i class="bi bi-eye"></i>
+              </a>
+            {% endif %}
+            <img src="{{ thumbUrl }}" alt="" loading="lazy">
+            <small>
+              <span class="pick-name">{{ locale is same as('fr') ? item.settings.frenchName : item.settings.name }}</span>
+              {% if isCurrent %}
+                <span class="chip-under chip-current">{{ 'album.offcanvas.links.current'|trans }}</span>
+              {% endif %}
+            </small>
+          </div>
+        {% endfor %}
+      </div>
     </div>
     {% endif %}
 

--- a/templates/Trainer/Section/_links.html.twig
+++ b/templates/Trainer/Section/_links.html.twig
@@ -1,0 +1,25 @@
+<p class="text-secondary">{{ 'trainer.links.intro'|trans }}</p>
+
+{% if linksTree.isEmpty %}
+  <p class="text-secondary">{{ 'trainer.links.empty'|trans }}</p>
+{% else %}
+  <div class="dex-links-tree">
+    {% for edge in linksTree.edges %}
+      {% set fromBannerUrl = dexBannerUrl|format(edge.from.dex.slug) %}
+      {% set toBannerUrl = dexBannerUrl|format(edge.to.dex.slug) %}
+      <div class="dex-links-edge">
+        <div class="dex-links-node">
+          <img src="{{ fromBannerUrl }}" alt="" loading="lazy">
+          <span>{{ locale is same as('fr') ? edge.from.settings.frenchName : edge.from.settings.name }}</span>
+        </div>
+        <div class="dex-links-arrow" title="{{ ('album.offcanvas.links.direction.'~(edge.mode == 'both' ? 'both' : 'to'))|trans }}">
+          <i class="bi {{ edge.mode == 'both' ? 'bi-arrow-left-right' : 'bi-arrow-right' }}"></i>
+        </div>
+        <div class="dex-links-node">
+          <img src="{{ toBannerUrl }}" alt="" loading="lazy">
+          <span>{{ locale is same as('fr') ? edge.to.settings.frenchName : edge.to.settings.name }}</span>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/templates/Trainer/_section.html.twig
+++ b/templates/Trainer/_section.html.twig
@@ -1,20 +1,38 @@
-<div class="accordion" id="trainerSection">
-  {% set sections = [
+{% set sections = [
     'personnal_data',
+    'links',
     'logout',
 ] %}
+
+<ul class="nav nav-tabs nav-fill mb-4" id="trainer-section-tab" role="tablist">
   {% for section in sections %}
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="heading_{{ section }}">
-        <button class="accordion-button" type="button collapsed" data-bs-toggle="collapse" data-bs-target="#collapse_{{ section }}" aria-expanded="true" aria-controls="collapse_{{ section }}">
-          {{ ('trainer.'~section~'.title')|trans }}
-        </button>
-      </h2>
-      <div id="collapse_{{ section }}" class="accordion-collapse collapse" aria-labelledby="heading_{{ section }}">
-        <div class="accordion-body">
-          {{ include('Trainer/Section/_'~section~'.html.twig') }}
-        </div>
-      </div>
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link{{ loop.first ? ' active' : '' }}"
+        id="tab-{{ section }}-tab"
+        data-bs-toggle="tab"
+        data-bs-target="#section-{{ section }}"
+        type="button"
+        role="tab"
+        aria-controls="section-{{ section }}"
+        aria-selected="{{ loop.first ? 'true' : 'false' }}"
+      >
+        {{ ('trainer.'~section~'.title')|trans }}
+      </button>
+    </li>
+  {% endfor %}
+</ul>
+
+<div class="tab-content" id="trainer-section-tab-content">
+  {% for section in sections %}
+    <div
+      class="tab-pane fade{{ loop.first ? ' show active' : '' }}"
+      id="section-{{ section }}"
+      role="tabpanel"
+      aria-labelledby="tab-{{ section }}-tab"
+      tabindex="0"
+    >
+      {{ include('Trainer/Section/_'~section~'.html.twig') }}
     </div>
   {% endfor %}
 </div>

--- a/templates/Trainer/index.html.twig
+++ b/templates/Trainer/index.html.twig
@@ -8,6 +8,8 @@
 {% block stylesheets %}
   {{ parent() }}
 
+  <link rel="stylesheet" href="{{ asset('css/trainer.css') }}">
+
   <style>
   {% include 'common/_catch_state_color_tokens.html.twig' %}
   {% include 'common/_catch_state_progress_bar_styles.html.twig' %}
@@ -36,11 +38,13 @@
   {{ parent() }}
   <script src="{{ asset('js/trainer_dex.js') }}"></script>
   <script src="{{ asset('js/trainer_filters.js') }}"></script>
+  <script src="{{ asset('js/trainer_tabs.js') }}"></script>
 
   <script>
     const locale = '{{ locale }}';
 
     watchAttributes();
     watchFilters();
+    watchTrainerTabs();
   </script>
 {% endblock foot_javascript %}

--- a/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
+++ b/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
@@ -55,7 +55,7 @@ final class TrainerPageTest extends WebTestCase
 
         $this->assertStringContainsString(
             '/connect/logout',
-            $crawler->filter('.accordion-item')->last()->filter('a')->attr('href') ?? ''
+            $crawler->filter('#section-logout a')->attr('href') ?? ''
         );
 
         $this->assertCount(0, $crawler->filter('.navbar-link'));
@@ -100,7 +100,7 @@ final class TrainerPageTest extends WebTestCase
 
         $this->assertStringContainsString(
             '/connect/logout',
-            $crawler->filter('.accordion-item')->last()->filter('a')->attr('href') ?? ''
+            $crawler->filter('#section-logout a')->attr('href') ?? ''
         );
 
         $this->assertCount(0, $crawler->filter('.navbar-link'));
@@ -146,7 +146,7 @@ final class TrainerPageTest extends WebTestCase
 
         $this->assertStringContainsString(
             '/connect/logout',
-            $crawler->filter('.accordion-item')->last()->filter('a')->attr('href') ?? ''
+            $crawler->filter('#section-logout a')->attr('href') ?? ''
         );
 
         $this->assertCount(0, $crawler->filter('.navbar-link'));

--- a/tests/src/Unit/DTO/TrainerDexLinkEdgeTest.php
+++ b/tests/src/Unit/DTO/TrainerDexLinkEdgeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DTO;
+
+use App\DTO\TrainerDexLinkEdge;
+use App\ResponseObject\Album\DexFlags;
+use App\ResponseObject\Album\DexListItem;
+use App\ResponseObject\Album\DexListItemRef;
+use App\ResponseObject\Album\DexListItemSettings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(TrainerDexLinkEdge::class)]
+final class TrainerDexLinkEdgeTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $from = $this->createDexListItem('swordshield');
+        $toDex = $this->createDexListItem('scarletviolet');
+
+        $edge = new TrainerDexLinkEdge('edge-1', 'both', $from, $toDex);
+
+        $this->assertSame('edge-1', $edge->getId());
+        $this->assertSame('both', $edge->getMode());
+        $this->assertSame($from, $edge->getFrom());
+        $this->assertSame($toDex, $edge->getTo());
+    }
+
+    private function createDexListItem(string $slug): DexListItem
+    {
+        return new DexListItem(
+            dex: new DexListItemRef(slug: $slug),
+            settings: new DexListItemSettings(
+                name: $slug,
+                frenchName: $slug,
+                slug: $slug,
+                displayTemplate: 'box',
+            ),
+            flags: new DexFlags(
+                isShiny: false,
+                isPrivate: false,
+                isOnHome: true,
+                isDisplayForm: true,
+                isReleased: true,
+                isPremium: false,
+                isCustom: false,
+            ),
+        );
+    }
+}

--- a/tests/src/Unit/DTO/TrainerDexLinksTreeTest.php
+++ b/tests/src/Unit/DTO/TrainerDexLinksTreeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DTO;
+
+use App\DTO\TrainerDexLinkEdge;
+use App\DTO\TrainerDexLinksTree;
+use App\ResponseObject\Album\DexFlags;
+use App\ResponseObject\Album\DexListItem;
+use App\ResponseObject\Album\DexListItemRef;
+use App\ResponseObject\Album\DexListItemSettings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(TrainerDexLinksTree::class)]
+final class TrainerDexLinksTreeTest extends TestCase
+{
+    public function testIsEmptyWithNoEdges(): void
+    {
+        $tree = new TrainerDexLinksTree([]);
+
+        $this->assertTrue($tree->isEmpty());
+        $this->assertSame([], $tree->getEdges());
+    }
+
+    public function testIsNotEmptyWithEdges(): void
+    {
+        $edge = new TrainerDexLinkEdge(
+            'edge-1',
+            'to',
+            $this->createDexListItem('swordshield'),
+            $this->createDexListItem('scarletviolet'),
+        );
+
+        $tree = new TrainerDexLinksTree([$edge]);
+
+        $this->assertFalse($tree->isEmpty());
+        $this->assertSame([$edge], $tree->getEdges());
+    }
+
+    private function createDexListItem(string $slug): DexListItem
+    {
+        return new DexListItem(
+            dex: new DexListItemRef(slug: $slug),
+            settings: new DexListItemSettings(
+                name: $slug,
+                frenchName: $slug,
+                slug: $slug,
+                displayTemplate: 'box',
+            ),
+            flags: new DexFlags(
+                isShiny: false,
+                isPrivate: false,
+                isOnHome: true,
+                isDisplayForm: true,
+                isReleased: true,
+                isPremium: false,
+                isCustom: false,
+            ),
+        );
+    }
+}

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -263,6 +263,10 @@ trainer:
         prefix: ""
         radical: "{dexName}"
         suffix: "setting have not been saved"
+  links:
+    title: "Dex links"
+    intro: "Here are all the links you have created between your dexes."
+    empty: "You haven't created any link between your dexes yet."
   filters:
     attributes:
       privacy:

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -147,6 +147,9 @@ album:
     links:
       title: Links
       description: A link synchronizes the catch state between this dex and another of your dexes.
+      see_tree: See the tree of all my links
+      view: View this dex
+      current: Current dex
       add:
         label: "Your other dexes — pick one to create or manage a link:"
       direction:
@@ -155,6 +158,25 @@ album:
         both: Both
       create: Create the link
       delete_title: Delete this link
+      filters:
+        search:
+          label: Search a dex
+        attributes:
+          shiny:
+            label: Shiny
+            all: All
+            "on": Shiny
+            "off": Regular
+          premium:
+            label: Premium
+            all: All
+            "on": Premium
+            "off": Free
+          custom:
+            label: Custom
+            all: All
+            "on": Custom
+            "off": Official
       toast:
         success: Link updated successfully.
         error: Something went wrong while updating the link.

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -268,6 +268,10 @@ trainer:
         prefix: "Le paramétrage de "
         radical: "{dexName}"
         suffix: "n'a pas été enregistré"
+  links:
+    title: "Liens entre dex"
+    intro: "Voici tous les liens que tu as créés entre tes dex."
+    empty: "Tu n'as pas encore créé de lien entre tes dex."
   filters:
     attributes:
       privacy:

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -153,6 +153,9 @@ album:
     links:
       title: Liens
       description: Un lien synchronise le statut de capture entre ce dex et un autre de tes dex.
+      see_tree: Voir l'arbre de tous mes liens
+      view: Voir ce dex
+      current: Dex actuel
       add:
         label: "Tes autres dex — choisis-en un pour créer ou gérer un lien :"
       direction:
@@ -161,6 +164,25 @@ album:
         both: Les deux
       create: Créer le lien
       delete_title: Supprimer ce lien
+      filters:
+        search:
+          label: Rechercher un dex
+        attributes:
+          shiny:
+            label: Chromatique
+            all: Tous
+            "on": Chromatiques
+            "off": Normaux
+          premium:
+            label: Premium
+            all: Tous
+            "on": Premiums
+            "off": Gratuits
+          custom:
+            label: Personnalisé
+            all: Tous
+            "on": Personnalisés
+            "off": Officiels
       toast:
         success: "Lien mis à jour avec succès."
         error: "Une erreur est survenue lors de la mise à jour du lien."


### PR DESCRIPTION
## Summary
- Offcanvas "Liens" section: search + shiny/premium/custom filters on the dex picker, a "view" link per card to jump to the target dex, current dex always shown but disabled, direction selector + create button moved above the grid.
- New "Links between dexes" tab on the Trainer page: aggregates and deduplicates all of a trainer's dex links (client only — pokenini-back still exposes links one dex at a time) into a banner-to-banner edge list. Offcanvas links to this section by anchor.
- Trainer page accordion replaced with horizontal nav-tabs (personal info / links / logout), matching the Admin page's tab pattern.

## Notes
- No visual QA was possible in the environment this was built in (no browser) — please check rendering after `make start`.
- New classes (`GetTrainerDexLinksTreeService`, DTOs) have no dedicated unit tests yet (100%-coverage gate will need addressing before merge).

## Test plan
- [ ] `make tests` passes (existing `TrainerPageTest` assertions were updated for the removed accordion markup)
- [ ] Manual visual check of the offcanvas filters, "view" link, current-dex card, and the new links-tree tab
- [ ] `make measures` (coverage/MSI) — expect gaps on the new classes