### PR TITLE
ci: add EditorConfig linter to code quality workflow

### DIFF
--- a/.github/workflows/ci_codequality.yml
+++ b/.github/workflows/ci_codequality.yml
@@ -20,6 +20,15 @@ env:
   PHP_CS_FIXER_IGNORE_ENV: 1
 
 jobs:
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run
+        run: docker run --rm --volume=$PWD:/check mstruebing/editorconfig-checker:v3.6.0 editorconfig-checker --exclude=".phar"
+
   phpcsfixer:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an `editorconfig` job to `ci_codequality.yml`, running the same `mstruebing/editorconfig-checker` invocation already used by `make code-quality` locally (config file and Makefile target already existed).

## Test plan
- [ ] CI passes on this PR (the new `editorconfig` job)