### PR TITLE
chore(tests): migrate to #[Test] attribute, createMock to createStub where unused

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,6 +36,17 @@
         <PossiblyUnusedMethod>
             <errorLevel type="suppress">
                 <directory name="src/Controller" />
+                <!--
+                    psalm/plugin-phpunit 0.19.7 resolves #[Test] attributes on trait-declared
+                    methods using the *consuming* class's import aliases instead of the trait's
+                    own, so it never recognizes these as PHPUnit test methods. Fixed upstream in
+                    0.20.x, but that requires Psalm 7 (still beta; psalm/plugin-symfony has no
+                    stable support for it yet). Remove these once both are upgraded.
+                -->
+                <file name="tests/src/Unit/Security/AuthenticatorAuthenticateClosedTestTrait.php" />
+                <file name="tests/src/Unit/Security/AuthenticatorAuthenticateOpenedTestTrait.php" />
+                <file name="tests/src/Unit/Security/AuthenticatorOnAuthentificationTestTrait.php" />
+                <file name="tests/src/Unit/Security/AuthenticatorSupportTestTrait.php" />
             </errorLevel>
         </PossiblyUnusedMethod>
 

--- a/tests/src/Browser/Admin/ForceActionTest.php
+++ b/tests/src/Browser/Admin/ForceActionTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -18,7 +19,8 @@ final class ForceActionTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testDismissingConfirmationKeepsActionPending(): void
+    #[Test]
+    public function dismissingConfirmationKeepsActionPending(): void
     {
         $client = $this->getNewClient();
 
@@ -45,7 +47,8 @@ final class ForceActionTest extends AbstractBrowserTestCase
         $this->assertTrue((bool) $client->executeScript('return window.__noNav === true;'));
     }
 
-    public function testAcceptingConfirmationSubmitsTheForm(): void
+    #[Test]
+    public function acceptingConfirmationSubmitsTheForm(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Admin/RedirectActionsTest.php
+++ b/tests/src/Browser/Admin/RedirectActionsTest.php
@@ -9,6 +9,7 @@ use App\Tests\Utils\GetUserToken;
 use Facebook\WebDriver\WebDriverBy;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\Client;
 
 /**
@@ -34,7 +35,8 @@ final class RedirectActionsTest extends AbstractBrowserTestCase
     ];
 
     #[DataProvider('providerActionItems')]
-    public function testActionItems(string $action, string $item, string $section): void
+    #[Test]
+    public function actionItems(string $action, string $item, string $section): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Admin/ToggleActionsTest.php
+++ b/tests/src/Browser/Admin/ToggleActionsTest.php
@@ -8,6 +8,7 @@ use App\Tests\Browser\AbstractBrowserTestCase;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -17,7 +18,8 @@ final class ToggleActionsTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testToggleActions(): void
+    #[Test]
+    public function toggleActions(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/CreditBadgeTooltipTest.php
+++ b/tests/src/Browser/Album/CreditBadgeTooltipTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * Regression guard: on touch devices there is no hover, so a tap on the
@@ -25,7 +26,8 @@ final class CreditBadgeTooltipTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testTappingCreditBadgeShowsTooltipInsteadOfNavigating(): void
+    #[Test]
+    public function tappingCreditBadgeShowsTooltipInsteadOfNavigating(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/ModalTest.php
+++ b/tests/src/Browser/Album/ModalTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class ModalTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testModalOpenning(): void
+    #[Test]
+    public function modalOpenning(): void
     {
         $client = $this->getNewClient();
 
@@ -36,7 +38,8 @@ final class ModalTest extends AbstractBrowserTestCase
         $this->assertSelectorWillBeVisible('#modal-blastoise-mega');
     }
 
-    public function testModalImageSwitch(): void
+    #[Test]
+    public function modalImageSwitch(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/OffcanvasTest.php
+++ b/tests/src/Browser/Album/OffcanvasTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class OffcanvasTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testOffcanvas(): void
+    #[Test]
+    public function offcanvas(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/PrivacyHomeToggleTest.php
+++ b/tests/src/Browser/Album/PrivacyHomeToggleTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
 
 /**
@@ -20,7 +21,8 @@ final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testSuccessTickIsOnHome(): void
+    #[Test]
+    public function successTickIsOnHome(): void
     {
         $client = $this->getNewClient();
 
@@ -49,7 +51,8 @@ final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
     }
 
-    public function testSuccessUntickIsPrivate(): void
+    #[Test]
+    public function successUntickIsPrivate(): void
     {
         $client = $this->getNewClient();
 
@@ -76,7 +79,8 @@ final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
     }
 
-    public function testErrorTickIsOnHome(): void
+    #[Test]
+    public function errorTickIsOnHome(): void
     {
         $client = $this->getNewClient();
 
@@ -104,7 +108,8 @@ final class PrivacyHomeToggleTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
     }
 
-    public function testErrorUntickIsPrivate(): void
+    #[Test]
+    public function errorUntickIsPrivate(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/ProgressBarPopoverTest.php
+++ b/tests/src/Browser/Album/ProgressBarPopoverTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class ProgressBarPopoverTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testPopoverOpensOnClick(): void
+    #[Test]
+    public function popoverOpensOnClick(): void
     {
         $client = $this->getNewClient();
 
@@ -44,7 +46,8 @@ final class ProgressBarPopoverTest extends AbstractBrowserTestCase
      * and color must come from CSS classes, not inline style, to survive
      * that sanitization and actually render.
      */
-    public function testPopoverColorDotSurvivesSanitization(): void
+    #[Test]
+    public function popoverColorDotSurvivesSanitization(): void
     {
         $client = $this->getNewClient();
 
@@ -74,7 +77,8 @@ final class ProgressBarPopoverTest extends AbstractBrowserTestCase
         $this->assertNotSame('rgba(0, 0, 0, 0)', $dotBackgroundColor);
     }
 
-    public function testPopoverTogglesClosedOnSecondClick(): void
+    #[Test]
+    public function popoverTogglesClosedOnSecondClick(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/ScreenshotModeTest.php
+++ b/tests/src/Browser/Album/ScreenshotModeTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class ScreenshotModeTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testScreenshotMode(): void
+    #[Test]
+    public function screenshotMode(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/SelectAndLabelTest.php
+++ b/tests/src/Browser/Album/SelectAndLabelTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
 
 /**
@@ -20,7 +21,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testActionCatchStateGoldSilverCrystal(): void
+    #[Test]
+    public function actionCatchStateGoldSilverCrystal(): void
     {
         $client = $this->getNewClient();
 
@@ -51,7 +53,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         );
     }
 
-    public function testActionCatchStateDemo(): void
+    #[Test]
+    public function actionCatchStateDemo(): void
     {
         $client = $this->getNewClient();
 
@@ -82,7 +85,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         );
     }
 
-    public function testActionCatchStateDemoList3(): void
+    #[Test]
+    public function actionCatchStateDemoList3(): void
     {
         $client = $this->getNewClient();
 
@@ -113,7 +117,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         );
     }
 
-    public function testActionCatchStateToggle(): void
+    #[Test]
+    public function actionCatchStateToggle(): void
     {
         $client = $this->getNewClient();
 
@@ -137,7 +142,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorIsVisible('#bulbasaur .album-case-action');
     }
 
-    public function testActionCatchStateToggleWithLabel(): void
+    #[Test]
+    public function actionCatchStateToggleWithLabel(): void
     {
         $client = $this->getNewClient();
 
@@ -161,7 +167,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorIsVisible('#bulbasaur .album-case-action');
     }
 
-    public function testActionCatchStateToggleAllEdit(): void
+    #[Test]
+    public function actionCatchStateToggleAllEdit(): void
     {
         $client = $this->getNewClient();
 
@@ -189,7 +196,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertCountFilter($crawler, 0, '.album-all-catch-state-read-action[hidden]');
     }
 
-    public function testActionCatchStateToggleAllEditThenRead(): void
+    #[Test]
+    public function actionCatchStateToggleAllEditThenRead(): void
     {
         $client = $this->getNewClient();
 
@@ -229,7 +237,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-read-action[hidden]');
     }
 
-    public function testActionCatchStateToggleAllEditWithAlreadyInEditMode(): void
+    #[Test]
+    public function actionCatchStateToggleAllEditWithAlreadyInEditMode(): void
     {
         $client = $this->getNewClient();
 
@@ -281,7 +290,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-read-action[hidden]');
     }
 
-    public function testActionCatchStateChangeSuccess(): void
+    #[Test]
+    public function actionCatchStateChangeSuccess(): void
     {
         $client = $this->getNewClient();
 
@@ -319,7 +329,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorAttributeNotContains('#bulbasaur', 'class', 'catch-state-no');
     }
 
-    public function testActionCatchStateChangeError(): void
+    #[Test]
+    public function actionCatchStateChangeError(): void
     {
         $client = $this->getNewClient();
 
@@ -359,7 +370,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertSelectorAttributeNotContains('#squirtle', 'class', 'catch-state-tobreed');
     }
 
-    public function testActionCatchStatePendingChangeBlocksUnload(): void
+    #[Test]
+    public function actionCatchStatePendingChangeBlocksUnload(): void
     {
         $client = $this->getNewClient();
 
@@ -393,7 +405,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertTrue($blocksUnload);
     }
 
-    public function testActionCatchStateResolvedChangeAllowsUnload(): void
+    #[Test]
+    public function actionCatchStateResolvedChangeAllowsUnload(): void
     {
         $client = $this->getNewClient();
 
@@ -429,7 +442,8 @@ final class SelectAndLabelTest extends AbstractBrowserTestCase
         $this->assertFalse($blocksUnload);
     }
 
-    public function testActionCatchStateFailedChangeAllowsUnload(): void
+    #[Test]
+    public function actionCatchStateFailedChangeAllowsUnload(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Album/ShareLinkTest.php
+++ b/tests/src/Browser/Album/ShareLinkTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class ShareLinkTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testClickingShareLinkWithWorkingClipboardShowsSuccessToastAndDoesNotNavigate(): void
+    #[Test]
+    public function clickingShareLinkWithWorkingClipboardShowsSuccessToastAndDoesNotNavigate(): void
     {
         $client = $this->getNewClient();
 
@@ -47,7 +49,8 @@ final class ShareLinkTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#shareToastError');
     }
 
-    public function testClickingShareLinkWithFailingClipboardShowsErrorToastAndDoesNotNavigate(): void
+    #[Test]
+    public function clickingShareLinkWithFailingClipboardShowsErrorToastAndDoesNotNavigate(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/AlbumDexList/JumbotronTest.php
+++ b/tests/src/Browser/AlbumDexList/JumbotronTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class JumbotronTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testJumbotronClosing(): void
+    #[Test]
+    public function jumbotronClosing(): void
     {
         $client = $this->getNewClient();
 
@@ -36,7 +38,8 @@ final class JumbotronTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#jumbotron');
     }
 
-    public function testJumbotronHiddenSaved(): void
+    #[Test]
+    public function jumbotronHiddenSaved(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Common/CommonTest.php
+++ b/tests/src/Browser/Common/CommonTest.php
@@ -8,6 +8,7 @@ use App\Tests\Browser\AbstractBrowserTestCase;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -17,7 +18,8 @@ final class CommonTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testOpenCookieManager(): void
+    #[Test]
+    public function openCookieManager(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Election/ElectionTest.php
+++ b/tests/src/Browser/Election/ElectionTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -19,7 +20,8 @@ final class ElectionTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testChecked(): void
+    #[Test]
+    public function checked(): void
     {
         $client = $this->getNewClient();
 
@@ -59,7 +61,8 @@ final class ElectionTest extends AbstractBrowserTestCase
         $this->assertSelectorTextContains('#election-counter-bottom', '1');
     }
 
-    public function testWelcomeModalVisible(): void
+    #[Test]
+    public function welcomeModalVisible(): void
     {
         $client = $this->getNewClient();
 
@@ -74,7 +77,8 @@ final class ElectionTest extends AbstractBrowserTestCase
         $this->assertSelectorIsNotVisible('#election-modal-filters-advanced');
     }
 
-    public function testWelcomeModalHidden(): void
+    #[Test]
+    public function welcomeModalHidden(): void
     {
         $client = $this->getNewClient();
 
@@ -89,7 +93,8 @@ final class ElectionTest extends AbstractBrowserTestCase
         $this->assertSelectorIsNotVisible('#election-modal-filters-advanced');
     }
 
-    public function testWelcomeModalHiddenBis(): void
+    #[Test]
+    public function welcomeModalHiddenBis(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Browser/Trainer/CustomAlbumTrainerTest.php
+++ b/tests/src/Browser/Trainer/CustomAlbumTrainerTest.php
@@ -8,6 +8,7 @@ use App\Tests\Browser\AbstractBrowserTestCase;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
 
 /**
@@ -18,7 +19,8 @@ final class CustomAlbumTrainerTest extends AbstractBrowserTestCase
 {
     use TestNavTrait;
 
-    public function testSuccessTick(): void
+    #[Test]
+    public function successTick(): void
     {
         $client = $this->getNewClient();
 
@@ -43,7 +45,8 @@ final class CustomAlbumTrainerTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
     }
 
-    public function testSuccessUntick(): void
+    #[Test]
+    public function successUntick(): void
     {
         $client = $this->getNewClient();
 
@@ -68,7 +71,8 @@ final class CustomAlbumTrainerTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#errorToast-goldsilvercrystal');
     }
 
-    public function testErrorTick(): void
+    #[Test]
+    public function errorTick(): void
     {
         $client = $this->getNewClient();
 
@@ -93,7 +97,8 @@ final class CustomAlbumTrainerTest extends AbstractBrowserTestCase
         $this->assertSelectorWillNotBeVisible('#successToast-redgreenblueyellow');
     }
 
-    public function testErrorUntick(): void
+    #[Test]
+    public function errorUntick(): void
     {
         $client = $this->getNewClient();
 

--- a/tests/src/Integration/Controller/Admin/ActionCalculateTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionCalculateTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -22,22 +23,26 @@ final class ActionCalculateTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAdminCalculateGamesBundlesAvailabilities(): void
+    #[Test]
+    public function adminCalculateGamesBundlesAvailabilities(): void
     {
         $this->testAdminCalculate('game_bundles_availabilities');
     }
 
-    public function testAdminCalculateGamesBundlesShiniesAvailabilities(): void
+    #[Test]
+    public function adminCalculateGamesBundlesShiniesAvailabilities(): void
     {
         $this->testAdminCalculate('game_bundles_shinies_availabilities');
     }
 
-    public function testAdminCalculatePokemonAvailabilities(): void
+    #[Test]
+    public function adminCalculatePokemonAvailabilities(): void
     {
         $this->testAdminCalculate('pokemon_availabilities');
     }
 
-    public function testAdminCalculateDexAvailabilities(): void
+    #[Test]
+    public function adminCalculateDexAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -63,7 +68,8 @@ final class ActionCalculateTest extends WebTestCase
         );
     }
 
-    public function testAdminCalculateWithErrorsThenGoToIndex(): void
+    #[Test]
+    public function adminCalculateWithErrorsThenGoToIndex(): void
     {
         $client = self::createClient();
 
@@ -96,7 +102,8 @@ final class ActionCalculateTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '.alert-danger');
     }
 
-    public function testAdminCalculateUnknown(): void
+    #[Test]
+    public function adminCalculateUnknown(): void
     {
         $client = self::createClient();
 
@@ -111,7 +118,8 @@ final class ActionCalculateTest extends WebTestCase
         $client->request('GET', '/fr/istration/action/calculate/truc');
     }
 
-    public function testAdminNonAdmin(): void
+    #[Test]
+    public function adminNonAdmin(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionInvalidateTest.php
@@ -10,6 +10,7 @@ use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -24,7 +25,8 @@ final class ActionInvalidateTest extends WebTestCase
     use TestNavTrait;
 
     #[DataProvider('providerInvalidateSuccess')]
-    public function testInvalidateSuccess(string $name): void
+    #[Test]
+    public function invalidateSuccess(string $name): void
     {
         $client = self::createClient();
 
@@ -70,7 +72,8 @@ final class ActionInvalidateTest extends WebTestCase
     }
 
     #[DataProvider('providerInvalidateNotExists')]
-    public function testInvalidateNotExists(string $name): void
+    #[Test]
+    public function invalidateNotExists(string $name): void
     {
         $client = self::createClient();
 
@@ -105,7 +108,8 @@ final class ActionInvalidateTest extends WebTestCase
         ];
     }
 
-    public function testAdminNonAdmin(): void
+    #[Test]
+    public function adminNonAdmin(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionTriggerTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class ActionTriggerTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAdminTriggerUpdateImages(): void
+    #[Test]
+    public function adminTriggerUpdateImages(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/ActionUpdateTest.php
+++ b/tests/src/Integration/Controller/Admin/ActionUpdateTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -22,32 +23,38 @@ final class ActionUpdateTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAdminUpdateLabels(): void
+    #[Test]
+    public function adminUpdateLabels(): void
     {
         $this->testAdminUpdate('labels');
     }
 
-    public function testAdminUpdateGamesCollectionsAndDex(): void
+    #[Test]
+    public function adminUpdateGamesCollectionsAndDex(): void
     {
         $this->testAdminUpdate('games_collections_and_dex');
     }
 
-    public function testAdminUpdatePokemons(): void
+    #[Test]
+    public function adminUpdatePokemons(): void
     {
         $this->testAdminUpdate('pokemons');
     }
 
-    public function testAdminUpdateRegionalDexNumbers(): void
+    #[Test]
+    public function adminUpdateRegionalDexNumbers(): void
     {
         $this->testAdminUpdate('regional_dex_numbers');
     }
 
-    public function testAdminUpdateGamesAvailabilities(): void
+    #[Test]
+    public function adminUpdateGamesAvailabilities(): void
     {
         $this->testAdminUpdate('games_availabilities');
     }
 
-    public function testAdminUpdateGamesShiniesAvailabilities(): void
+    #[Test]
+    public function adminUpdateGamesShiniesAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -76,12 +83,14 @@ final class ActionUpdateTest extends WebTestCase
         $this->assertStringNotContainsString('const types = JSON.parse', $crawler->outerHtml());
     }
 
-    public function testAdminUpdateCollections(): void
+    #[Test]
+    public function adminUpdateCollections(): void
     {
         $this->testAdminUpdate('collections_availabilities');
     }
 
-    public function testAdminUpdateUnknown(): void
+    #[Test]
+    public function adminUpdateUnknown(): void
     {
         $client = self::createClient();
 
@@ -96,7 +105,8 @@ final class ActionUpdateTest extends WebTestCase
         $client->request('GET', '/fr/istration/action/update/truc');
     }
 
-    public function testAdminNonAdmin(): void
+    #[Test]
+    public function adminNonAdmin(): void
     {
         $client = self::createClient();
 
@@ -110,7 +120,8 @@ final class ActionUpdateTest extends WebTestCase
         $client->request('POST', '/fr/istration/action/update/labels');
     }
 
-    public function testAdminUpdateThenGoToIndex(): void
+    #[Test]
+    public function adminUpdateThenGoToIndex(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/AdminPageTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminPageTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -21,7 +22,8 @@ final class AdminPageTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAdminHomeNotConnected(): void
+    #[Test]
+    public function adminHomeNotConnected(): void
     {
         $client = self::createClient();
 
@@ -30,7 +32,8 @@ final class AdminPageTest extends WebTestCase
         $this->assertResponseStatusCodeSame(307);
     }
 
-    public function testAdminHomeBadCredentials(): void
+    #[Test]
+    public function adminHomeBadCredentials(): void
     {
         $client = self::createClient();
 
@@ -43,7 +46,8 @@ final class AdminPageTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
-    public function testAdminHomeNotAllowed(): void
+    #[Test]
+    public function adminHomeNotAllowed(): void
     {
         $client = self::createClient();
 
@@ -55,7 +59,8 @@ final class AdminPageTest extends WebTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
-    public function testAdminIndexRedirectsToActions(): void
+    #[Test]
+    public function adminIndexRedirectsToActions(): void
     {
         $client = self::createClient();
 
@@ -69,7 +74,8 @@ final class AdminPageTest extends WebTestCase
         $this->assertResponseRedirects('/fr/istration/actions');
     }
 
-    public function testAdminHomeConnected(): void
+    #[Test]
+    public function adminHomeConnected(): void
     {
         $this->getAdminHomeConnected();
     }
@@ -77,7 +83,8 @@ final class AdminPageTest extends WebTestCase
     /**
      * @SuppressWarnings("PHPMD.ExcessiveMethodLength")
      */
-    public function testAdminHome(): void
+    #[Test]
+    public function adminHome(): void
     {
         $crawler = $this->getAdminHomeConnected();
 

--- a/tests/src/Integration/Controller/Admin/AdminReportsTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminReportsTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class AdminReportsTest extends WebTestCase
     /**
      * @SuppressWarnings("PHPMD.ExcessiveMethodLength")
      */
-    public function testAdminHome(): void
+    #[Test]
+    public function adminHome(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/AdminVersionsTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminVersionsTest.php
@@ -11,6 +11,7 @@ use App\Service\VersionsOverviewService;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[Group('api-mocked-testing')]
 final class AdminVersionsTest extends WebTestCase
 {
-    public function testVersionsTabShowsAllFourBricks(): void
+    #[Test]
+    public function versionsTabShowsAllFourBricks(): void
     {
         $client = self::createClient();
 
@@ -65,7 +67,8 @@ final class AdminVersionsTest extends WebTestCase
         $this->assertSame($expectedResourcesUpdatedAt, trim($crawler->filter('#versions-row-resources .versions-date')->text()));
     }
 
-    public function testVersionsTabShowsUnavailableBadgeWhenBricksCannotBeFetched(): void
+    #[Test]
+    public function versionsTabShowsUnavailableBadgeWhenBricksCannotBeFetched(): void
     {
         $client = self::createClient();
 
@@ -101,7 +104,8 @@ final class AdminVersionsTest extends WebTestCase
         $this->assertSame('', trim($crawler->filter('#versions-row-resources .versions-date')->text()));
     }
 
-    public function testVersionsNotConnected(): void
+    #[Test]
+    public function versionsNotConnected(): void
     {
         $client = self::createClient();
 
@@ -110,7 +114,8 @@ final class AdminVersionsTest extends WebTestCase
         $this->assertResponseStatusCodeSame(307);
     }
 
-    public function testVersionsNotAllowed(): void
+    #[Test]
+    public function versionsNotAllowed(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
+++ b/tests/src/Integration/Controller/Admin/PipelineStatusTest.php
@@ -8,6 +8,7 @@ use App\Controller\AdminController;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -17,7 +18,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[Group('api-mocked-testing')]
 final class PipelineStatusTest extends WebTestCase
 {
-    public function testPipelineStatusRenders(): void
+    #[Test]
+    public function pipelineStatusRenders(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Access/AccessPremiumTest.php
+++ b/tests/src/Integration/Controller/Album/Access/AccessPremiumTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class AccessPremiumTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAccessPremiumAlbum(): void
+    #[Test]
+    public function accessPremiumAlbum(): void
     {
         $client = self::createClient();
 
@@ -45,7 +47,8 @@ final class AccessPremiumTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.navbar-nav #private-tag');
     }
 
-    public function testTrainerAccessPremiumAlbum(): void
+    #[Test]
+    public function trainerAccessPremiumAlbum(): void
     {
         $client = self::createClient();
 
@@ -69,7 +72,8 @@ final class AccessPremiumTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.navbar-nav #private-tag');
     }
 
-    public function testAdminAccessPremiumAlbum(): void
+    #[Test]
+    public function adminAccessPremiumAlbum(): void
     {
         $client = self::createClient();
 
@@ -93,7 +97,8 @@ final class AccessPremiumTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.navbar-nav #private-tag');
     }
 
-    public function testAccessAnotherPremiumAlbum(): void
+    #[Test]
+    public function accessAnotherPremiumAlbum(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Access/AccessPrivateTest.php
+++ b/tests/src/Integration/Controller/Album/Access/AccessPrivateTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class AccessPrivateTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAccessOwnPublicAlbum(): void
+    #[Test]
+    public function accessOwnPublicAlbum(): void
     {
         $client = self::createClient();
 
@@ -45,7 +47,8 @@ final class AccessPrivateTest extends WebTestCase
         $this->assertSame('', $crawler->filter('input[name="t"]')->attr('value'));
     }
 
-    public function testAccessOwnPrivateAlbum(): void
+    #[Test]
+    public function accessOwnPrivateAlbum(): void
     {
         $client = self::createClient();
 
@@ -70,7 +73,8 @@ final class AccessPrivateTest extends WebTestCase
         $this->assertSame('', $crawler->filter('input[name="t"]')->attr('value'));
     }
 
-    public function testAccessAnotherPublicAlbum(): void
+    #[Test]
+    public function accessAnotherPublicAlbum(): void
     {
         $client = self::createClient();
 
@@ -95,7 +99,8 @@ final class AccessPrivateTest extends WebTestCase
         $this->assertSame('7b52009b64fd0a2a49e6d8a939753077792b0554', $crawler->filter('input[name="t"]')->attr('value'));
     }
 
-    public function testAccessAnotherPrivateAlbum(): void
+    #[Test]
+    public function accessAnotherPrivateAlbum(): void
     {
         $client = self::createClient();
 
@@ -108,7 +113,8 @@ final class AccessPrivateTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testAccessNonExistingAlbum(): void
+    #[Test]
+    public function accessNonExistingAlbum(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Access/AccessReleasedTest.php
+++ b/tests/src/Integration/Controller/Album/Access/AccessReleasedTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class AccessReleasedTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAccessOwnReleasedAlbum(): void
+    #[Test]
+    public function accessOwnReleasedAlbum(): void
     {
         $client = self::createClient();
 
@@ -44,7 +46,8 @@ final class AccessReleasedTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.navbar-nav #private-tag');
     }
 
-    public function testTrainerAccessUnreleasedAlbum(): void
+    #[Test]
+    public function trainerAccessUnreleasedAlbum(): void
     {
         $client = self::createClient();
 
@@ -57,7 +60,8 @@ final class AccessReleasedTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testAdminAccessUnreleasedAlbum(): void
+    #[Test]
+    public function adminAccessUnreleasedAlbum(): void
     {
         $client = self::createClient();
 
@@ -71,7 +75,8 @@ final class AccessReleasedTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.navbar-nav #private-tag');
     }
 
-    public function testAccessAnotherUnreleasedAlbum(): void
+    #[Test]
+    public function accessAnotherUnreleasedAlbum(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Access/RolesTest.php
+++ b/tests/src/Integration/Controller/Album/Access/RolesTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class RolesTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testReadNonConnectedNoToken(): void
+    #[Test]
+    public function readNonConnectedNoToken(): void
     {
         $client = self::createClient();
 
@@ -29,7 +31,8 @@ final class RolesTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testReadNonConnected(): void
+    #[Test]
+    public function readNonConnected(): void
     {
         $client = self::createClient();
 
@@ -38,7 +41,8 @@ final class RolesTest extends WebTestCase
         $this->assertNoConnectedNavBar($crawler);
     }
 
-    public function testReadTrainer(): void
+    #[Test]
+    public function readTrainer(): void
     {
         $client = self::createClient();
 
@@ -55,7 +59,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testReadCollector(): void
+    #[Test]
+    public function readCollector(): void
     {
         $client = self::createClient();
 
@@ -72,7 +77,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testReadAdmin(): void
+    #[Test]
+    public function readAdmin(): void
     {
         $client = self::createClient();
 
@@ -90,7 +96,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteNonConnected(): void
+    #[Test]
+    public function writeNonConnected(): void
     {
         $client = self::createClient();
 
@@ -99,7 +106,8 @@ final class RolesTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testWriteTrainer(): void
+    #[Test]
+    public function writeTrainer(): void
     {
         $client = self::createClient();
 
@@ -116,7 +124,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteCollector(): void
+    #[Test]
+    public function writeCollector(): void
     {
         $client = self::createClient();
 
@@ -133,7 +142,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteAdmin(): void
+    #[Test]
+    public function writeAdmin(): void
     {
         $client = self::createClient();
 
@@ -151,7 +161,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteTrainerOnPremiumDex(): void
+    #[Test]
+    public function writeTrainerOnPremiumDex(): void
     {
         $client = self::createClient();
 
@@ -168,7 +179,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteCollectorOnPremiumDex(): void
+    #[Test]
+    public function writeCollectorOnPremiumDex(): void
     {
         $client = self::createClient();
 
@@ -186,7 +198,8 @@ final class RolesTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.album-all-catch-state-edit-action');
     }
 
-    public function testWriteAdminOnPremiumDex(): void
+    #[Test]
+    public function writeAdminOnPremiumDex(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Access/TrainerTest.php
+++ b/tests/src/Integration/Controller/Album/Access/TrainerTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class TrainerTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAlbumTrainerLogged(): void
+    #[Test]
+    public function albumTrainerLogged(): void
     {
         $client = self::createClient();
 
@@ -39,7 +41,8 @@ final class TrainerTest extends WebTestCase
         $this->assertSame('', $crawler->filter('input[name="t"]')->attr('value'));
     }
 
-    public function testAlbumTrainerGiven(): void
+    #[Test]
+    public function albumTrainerGiven(): void
     {
         $client = self::createClient();
 
@@ -54,7 +57,8 @@ final class TrainerTest extends WebTestCase
         $this->assertSame('7b52009b64fd0a2a49e6d8a939753077792b0554', $crawler->filter('input[name="t"]')->attr('value'));
     }
 
-    public function testAlbumTrainerLoggedAndGiven(): void
+    #[Test]
+    public function albumTrainerLoggedAndGiven(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Action/UpdateTest.php
+++ b/tests/src/Integration/Controller/Album/Action/UpdateTest.php
@@ -9,6 +9,7 @@ use App\Service\ModifyTrainerDexService;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -19,7 +20,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[Group('api-mocked-testing')]
 final class UpdateTest extends WebTestCase
 {
-    public function testUpdateConnected(): void
+    #[Test]
+    public function updateConnected(): void
     {
         $client = self::createClient();
 
@@ -39,7 +41,8 @@ final class UpdateTest extends WebTestCase
         $this->assertResponseIsSuccessful();
     }
 
-    public function testUpdateNonConnected(): void
+    #[Test]
+    public function updateNonConnected(): void
     {
         $client = self::createClient();
 
@@ -61,7 +64,8 @@ final class UpdateTest extends WebTestCase
         $this->assertEquals('http://localhost/fr', $crawler->getBaseHref());
     }
 
-    public function testUpdatePremiumCollector(): void
+    #[Test]
+    public function updatePremiumCollector(): void
     {
         $client = self::createClient();
 
@@ -82,7 +86,8 @@ final class UpdateTest extends WebTestCase
         $this->assertResponseIsSuccessful();
     }
 
-    public function testUpdatePremiumNonCollector(): void
+    #[Test]
+    public function updatePremiumNonCollector(): void
     {
         $client = self::createClient();
 
@@ -102,7 +107,8 @@ final class UpdateTest extends WebTestCase
         $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }
 
-    public function testUpdateFailed(): void
+    #[Test]
+    public function updateFailed(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
+++ b/tests/src/Integration/Controller/Album/Dex/AlbumDexListTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -21,7 +22,8 @@ final class AlbumDexListTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testAlbumDexList(): void
+    #[Test]
+    public function albumDexList(): void
     {
         $client = self::createClient();
 
@@ -78,7 +80,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertStringNotContainsString('watchCatchStates();', $crawler->outerHtml());
     }
 
-    public function testAlbumDexListTilesAreAllClickable(): void
+    #[Test]
+    public function albumDexListTilesAreAllClickable(): void
     {
         $client = self::createClient();
 
@@ -105,7 +108,8 @@ final class AlbumDexListTest extends WebTestCase
         }
     }
 
-    public function testNonConnectedHome(): void
+    #[Test]
+    public function nonConnectedHome(): void
     {
         $client = self::createClient();
 
@@ -120,7 +124,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertEquals('http://localhost/fr', $crawler->getBaseHref());
     }
 
-    public function testConnectedHomeNoDex(): void
+    #[Test]
+    public function connectedHomeNoDex(): void
     {
         $client = self::createClient();
 
@@ -145,7 +150,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.dex-item');
     }
 
-    public function testConnectedHomeDexNoOnHome(): void
+    #[Test]
+    public function connectedHomeDexNoOnHome(): void
     {
         $client = self::createClient();
 
@@ -170,7 +176,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.dex-item');
     }
 
-    public function testConnectedHomeSomeDex(): void
+    #[Test]
+    public function connectedHomeSomeDex(): void
     {
         $client = self::createClient();
 
@@ -197,7 +204,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.dex-item h3');
     }
 
-    public function testAlbumDexListFrench(): void
+    #[Test]
+    public function albumDexListFrench(): void
     {
         $client = self::createClient();
 
@@ -245,7 +253,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '#jumbotron .jumbotron-close');
     }
 
-    public function testAlbumDexListEnglish(): void
+    #[Test]
+    public function albumDexListEnglish(): void
     {
         $client = self::createClient();
 
@@ -293,7 +302,8 @@ final class AlbumDexListTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '#jumbotron .jumbotron-close');
     }
 
-    public function testAlbumDexListCustomDexLinksToUniqueSettingsSlug(): void
+    #[Test]
+    public function albumDexListCustomDexLinksToUniqueSettingsSlug(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Display/CommonTest.php
+++ b/tests/src/Integration/Controller/Album/Display/CommonTest.php
@@ -10,6 +10,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -23,7 +24,8 @@ final class CommonTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testListRead(): void
+    #[Test]
+    public function listRead(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class CommonTest extends WebTestCase
         $this->assertNoConnectedNavBar($client->getCrawler());
     }
 
-    public function testListEdit(): void
+    #[Test]
+    public function listEdit(): void
     {
         $client = self::createClient();
 
@@ -54,7 +57,8 @@ final class CommonTest extends WebTestCase
         $this->assertTrainerAlbumNavBar($client->getCrawler());
     }
 
-    public function testListShiny(): void
+    #[Test]
+    public function listShiny(): void
     {
         $client = self::createClient();
 
@@ -66,7 +70,8 @@ final class CommonTest extends WebTestCase
     /**
      * Brand new dex has an issue with a division by zero.
      */
-    public function testListVirgin(): void
+    #[Test]
+    public function listVirgin(): void
     {
         $client = self::createClient();
 
@@ -79,16 +84,18 @@ final class CommonTest extends WebTestCase
     /**
      * Testing with caches cleared.
      */
-    public function testListCachesCleared(): void
+    #[Test]
+    public function listCachesCleared(): void
     {
         self::bootKernel();
         self::getContainer()->get('cache.app')->clear();
         self::ensureKernelShutdown();
 
-        $this->testListVirgin();
+        $this->listVirgin();
     }
 
-    public function testImageCreditBadgeIsShownWhenCreditExists(): void
+    #[Test]
+    public function imageCreditBadgeIsShownWhenCreditExists(): void
     {
         $client = self::createClient();
         $client->request('GET', '/fr/album/demolite?t=7b52009b64fd0a2a49e6d8a939753077792b0554');

--- a/tests/src/Integration/Controller/Album/Display/DexNumberTest.php
+++ b/tests/src/Integration/Controller/Album/Display/DexNumberTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class DexNumberTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDisplayDexNumber(): void
+    #[Test]
+    public function displayDexNumber(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Display/FormTest.php
+++ b/tests/src/Integration/Controller/Album/Display/FormTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class FormTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDisplayForm(): void
+    #[Test]
+    public function displayForm(): void
     {
         $client = self::createClient();
 
@@ -35,7 +37,8 @@ final class FormTest extends WebTestCase
         $this->assertEquals('♂️', $crawler->filter('#venusaur .album-case-forms')->text());
     }
 
-    public function testNonDisplayForm(): void
+    #[Test]
+    public function nonDisplayForm(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Display/IntroTest.php
+++ b/tests/src/Integration/Controller/Album/Display/IntroTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class IntroTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testIntroHome(): void
+    #[Test]
+    public function introHome(): void
     {
         $client = self::createClient();
 
@@ -77,7 +79,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroDemoList3(): void
+    #[Test]
+    public function introDemoList3(): void
     {
         $client = self::createClient();
 
@@ -130,7 +133,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroDemoLiteShiny(): void
+    #[Test]
+    public function introDemoLiteShiny(): void
     {
         $client = self::createClient();
 
@@ -185,7 +189,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroGoldSilverCrystal(): void
+    #[Test]
+    public function introGoldSilverCrystal(): void
     {
         $client = self::createClient();
 
@@ -242,7 +247,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroBlackWhiteFrench(): void
+    #[Test]
+    public function introBlackWhiteFrench(): void
     {
         $client = self::createClient();
 
@@ -299,7 +305,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroBlackWhiteEnglish(): void
+    #[Test]
+    public function introBlackWhiteEnglish(): void
     {
         $client = self::createClient();
 
@@ -351,7 +358,8 @@ final class IntroTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#intro .dex-version');
     }
 
-    public function testIntroDemoAnotherTrainer(): void
+    #[Test]
+    public function introDemoAnotherTrainer(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Display/ModalTest.php
+++ b/tests/src/Integration/Controller/Album/Display/ModalTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -21,7 +22,8 @@ final class ModalTest extends WebTestCase
     use TestNavTrait;
     use ModalTestTrait;
 
-    public function testModals(): void
+    #[Test]
+    public function modals(): void
     {
         $client = self::createClient();
 
@@ -34,7 +36,8 @@ final class ModalTest extends WebTestCase
         $this->assertCountFilter($crawler, 6, '.modal');
     }
 
-    public function testRegularModal(): void
+    #[Test]
+    public function regularModal(): void
     {
         $client = self::createClient();
 
@@ -68,7 +71,8 @@ final class ModalTest extends WebTestCase
         $this->assertModalItemFamilyLink($crawler, 'home', 'bulbasaur', 'fr', 'bulbasaur', false);
     }
 
-    public function testRegularModalInEnglish(): void
+    #[Test]
+    public function regularModalInEnglish(): void
     {
         $client = self::createClient();
 
@@ -102,7 +106,8 @@ final class ModalTest extends WebTestCase
         $this->assertModalItemFamilyLink($crawler, 'home', 'bulbasaur', 'en', 'bulbasaur', false);
     }
 
-    public function testShinyModal(): void
+    #[Test]
+    public function shinyModal(): void
     {
         $client = self::createClient();
 
@@ -136,7 +141,8 @@ final class ModalTest extends WebTestCase
         $this->assertModalItemFamilyLink($crawler, 'demoliteshiny', 'bulbasaur', 'fr', 'bulbasaur', false);
     }
 
-    public function testRegionalWithFormsModal(): void
+    #[Test]
+    public function regionalWithFormsModal(): void
     {
         $client = self::createClient();
 
@@ -173,7 +179,8 @@ final class ModalTest extends WebTestCase
         $this->assertModalItemFamilyLink($crawler, 'goldsilvercrystal', 'meganium', 'fr', 'chikorita', true);
     }
 
-    public function testWithFormsModal(): void
+    #[Test]
+    public function withFormsModal(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Display/OffcanvasTest.php
+++ b/tests/src/Integration/Controller/Album/Display/OffcanvasTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -21,7 +22,8 @@ final class OffcanvasTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testOffcanvasHome(): void
+    #[Test]
+    public function offcanvasHome(): void
     {
         $client = self::createClient();
 
@@ -71,7 +73,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/home');
     }
 
-    public function testIntroDemoList3(): void
+    #[Test]
+    public function introDemoList3(): void
     {
         $client = self::createClient();
 
@@ -118,7 +121,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/demolist3');
     }
 
-    public function testIntroDemoLiteShiny(): void
+    #[Test]
+    public function introDemoLiteShiny(): void
     {
         $client = self::createClient();
 
@@ -160,7 +164,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/demoliteshiny');
     }
 
-    public function testIntroGoldSilverCrystal(): void
+    #[Test]
+    public function introGoldSilverCrystal(): void
     {
         $client = self::createClient();
 
@@ -211,7 +216,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/goldsilvercrystal');
     }
 
-    public function testIntroBlackWhiteFrench(): void
+    #[Test]
+    public function introBlackWhiteFrench(): void
     {
         $client = self::createClient();
 
@@ -262,7 +268,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/blackwhite');
     }
 
-    public function testIntroBlackWhiteEnglish(): void
+    #[Test]
+    public function introBlackWhiteEnglish(): void
     {
         $client = self::createClient();
 
@@ -313,7 +320,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/en/album/blackwhite');
     }
 
-    public function testIntroDemoAnotherTrainer(): void
+    #[Test]
+    public function introDemoAnotherTrainer(): void
     {
         $client = self::createClient();
 
@@ -356,7 +364,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertResetLink($crawler, '/fr/album/demo?t=7b52009b64fd0a2a49e6d8a939753077792b0554');
     }
 
-    public function testSwitchesForOwner(): void
+    #[Test]
+    public function switchesForOwner(): void
     {
         $client = self::createClient();
 
@@ -377,7 +386,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertNull($isOnHome->attr('checked'));
     }
 
-    public function testSwitchesAbsentForAnotherTrainer(): void
+    #[Test]
+    public function switchesAbsentForAnotherTrainer(): void
     {
         $client = self::createClient();
 
@@ -390,7 +400,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#offcanvas form[data-dex]');
     }
 
-    public function testFlagToastsForOwner(): void
+    #[Test]
+    public function flagToastsForOwner(): void
     {
         $client = self::createClient();
 
@@ -404,7 +415,8 @@ final class OffcanvasTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '#errorToast-goldsilvercrystal');
     }
 
-    public function testFlagToastsAbsentForAnotherTrainer(): void
+    #[Test]
+    public function flagToastsAbsentForAnotherTrainer(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Localization/EnglishAlbumLocalizationTest.php
+++ b/tests/src/Integration/Controller/Album/Localization/EnglishAlbumLocalizationTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -21,7 +22,8 @@ final class EnglishAlbumLocalizationTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testListLanguage(): void
+    #[Test]
+    public function listLanguage(): void
     {
         $client = self::createClient();
 
@@ -34,7 +36,8 @@ final class EnglishAlbumLocalizationTest extends WebTestCase
         $this->assertNavigationBarEnglish($client);
     }
 
-    public function testListLanguageWriteMode(): void
+    #[Test]
+    public function listLanguageWriteMode(): void
     {
         $client = self::createClient();
 
@@ -51,7 +54,8 @@ final class EnglishAlbumLocalizationTest extends WebTestCase
         $this->assertNavigationBarEnglish($client);
     }
 
-    public function testListShiny(): void
+    #[Test]
+    public function listShiny(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Localization/FrenchAlbumLocalizationTest.php
+++ b/tests/src/Integration/Controller/Album/Localization/FrenchAlbumLocalizationTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -21,7 +22,8 @@ final class FrenchAlbumLocalizationTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testListEdit(): void
+    #[Test]
+    public function listEdit(): void
     {
         $client = self::createClient();
 
@@ -38,7 +40,8 @@ final class FrenchAlbumLocalizationTest extends WebTestCase
         $this->assertNavigationBarFrench($client);
     }
 
-    public function testListRead(): void
+    #[Test]
+    public function listRead(): void
     {
         $client = self::createClient();
 
@@ -51,7 +54,8 @@ final class FrenchAlbumLocalizationTest extends WebTestCase
         $this->assertNavigationBarFrench($client);
     }
 
-    public function testListLanguage(): void
+    #[Test]
+    public function listLanguage(): void
     {
         $client = self::createClient();
 
@@ -64,7 +68,8 @@ final class FrenchAlbumLocalizationTest extends WebTestCase
         $this->assertNavigationBarFrench($client);
     }
 
-    public function testListShiny(): void
+    #[Test]
+    public function listShiny(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/BoxTest.php
+++ b/tests/src/Integration/Controller/Album/Template/BoxTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class BoxTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexBoxTemplate(): void
+    #[Test]
+    public function dexBoxTemplate(): void
     {
         $client = self::createClient();
 
@@ -69,7 +71,8 @@ final class BoxTest extends WebTestCase
         );
     }
 
-    public function testFrenchDexBoxTemplate(): void
+    #[Test]
+    public function frenchDexBoxTemplate(): void
     {
         $client = self::createClient();
 
@@ -89,7 +92,8 @@ final class BoxTest extends WebTestCase
         );
     }
 
-    public function testEnglishDexBoxTemplate(): void
+    #[Test]
+    public function englishDexBoxTemplate(): void
     {
         $client = self::createClient();
 
@@ -109,7 +113,8 @@ final class BoxTest extends WebTestCase
         );
     }
 
-    public function testFilterDexBoxTemplate(): void
+    #[Test]
+    public function filterDexBoxTemplate(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/List3Test.php
+++ b/tests/src/Integration/Controller/Album/Template/List3Test.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class List3Test extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexList3Template(): void
+    #[Test]
+    public function dexList3Template(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class List3Test extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.box');
     }
 
-    public function testFilterDexList3Template(): void
+    #[Test]
+    public function filterDexList3Template(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/List5Test.php
+++ b/tests/src/Integration/Controller/Album/Template/List5Test.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class List5Test extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexList5Template(): void
+    #[Test]
+    public function dexList5Template(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class List5Test extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.box');
     }
 
-    public function testFilterDexList5Template(): void
+    #[Test]
+    public function filterDexList5Template(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/List7Test.php
+++ b/tests/src/Integration/Controller/Album/Template/List7Test.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class List7Test extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexList7Template(): void
+    #[Test]
+    public function dexList7Template(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class List7Test extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.box');
     }
 
-    public function testFilterDexList7Template(): void
+    #[Test]
+    public function filterDexList7Template(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/NoTemplateTest.php
+++ b/tests/src/Integration/Controller/Album/Template/NoTemplateTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class NoTemplateTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexNoDefinedTemplate(): void
+    #[Test]
+    public function dexNoDefinedTemplate(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class NoTemplateTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '.box h2');
     }
 
-    public function testFilterDexNoDefinedTemplate(): void
+    #[Test]
+    public function filterDexNoDefinedTemplate(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Album/Template/UnkownTemplateTest.php
+++ b/tests/src/Integration/Controller/Album/Template/UnkownTemplateTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class UnkownTemplateTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testDexUnknownTemplate(): void
+    #[Test]
+    public function dexUnknownTemplate(): void
     {
         $client = self::createClient();
 
@@ -40,7 +42,8 @@ final class UnkownTemplateTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '.box h2');
     }
 
-    public function testFilterDexUnknownTemplate(): void
+    #[Test]
+    public function filterDexUnknownTemplate(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Common/CommonItemsTest.php
+++ b/tests/src/Integration/Controller/Common/CommonItemsTest.php
@@ -9,6 +9,7 @@ use App\Controller\HomeController;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -21,7 +22,8 @@ final class CommonItemsTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testHome(): void
+    #[Test]
+    public function home(): void
     {
         $client = self::createClient();
 
@@ -33,14 +35,16 @@ final class CommonItemsTest extends WebTestCase
         $this->assertCommonItems($client, '/fr/album/dex');
     }
 
-    public function testConnect(): void
+    #[Test]
+    public function connect(): void
     {
         $client = self::createClient();
 
         $this->assertCommonItems($client, '/fr/connect');
     }
 
-    public function testAdministration(): void
+    #[Test]
+    public function administration(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Common/FooterTest.php
+++ b/tests/src/Integration/Controller/Common/FooterTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller\Common;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -17,7 +18,8 @@ final class FooterTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testFooter(): void
+    #[Test]
+    public function footer(): void
     {
         $client = self::createClient();
 
@@ -54,7 +56,8 @@ final class FooterTest extends WebTestCase
         );
     }
 
-    public function testFooterAsGuest(): void
+    #[Test]
+    public function footerAsGuest(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Common/IndexRedirectionTest.php
+++ b/tests/src/Integration/Controller/Common/IndexRedirectionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller\Common;
 
 use App\Controller\HomeController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -14,7 +15,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[CoversClass(HomeController::class)]
 final class IndexRedirectionTest extends WebTestCase
 {
-    public function testRedirection(): void
+    #[Test]
+    public function redirection(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Common/LocaleTest.php
+++ b/tests/src/Integration/Controller/Common/LocaleTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller\Common;
 
 use App\Controller\HomeController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -14,7 +15,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[CoversClass(HomeController::class)]
 final class LocaleTest extends WebTestCase
 {
-    public function testLocaleOk(): void
+    #[Test]
+    public function localeOk(): void
     {
         $client = self::createClient();
 
@@ -23,7 +25,8 @@ final class LocaleTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testLocaleNonOk(): void
+    #[Test]
+    public function localeNonOk(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Common/TrackerTest.php
+++ b/tests/src/Integration/Controller/Common/TrackerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller\Common;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -18,7 +19,8 @@ final class TrackerTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testTrackerAsGuest(): void
+    #[Test]
+    public function trackerAsGuest(): void
     {
         $client = self::createClient();
 
@@ -37,7 +39,8 @@ final class TrackerTest extends WebTestCase
         );
     }
 
-    public function testTrackerAsAdmin(): void
+    #[Test]
+    public function trackerAsAdmin(): void
     {
         $client = self::createClient();
 
@@ -61,7 +64,8 @@ final class TrackerTest extends WebTestCase
         );
     }
 
-    public function testTrackerAsCollector(): void
+    #[Test]
+    public function trackerAsCollector(): void
     {
         $client = self::createClient();
 
@@ -85,7 +89,8 @@ final class TrackerTest extends WebTestCase
         );
     }
 
-    public function testTrackerAsTrainer(): void
+    #[Test]
+    public function trackerAsTrainer(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Connect/ConnectTest.php
+++ b/tests/src/Integration/Controller/Connect/ConnectTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller\Connect;
 use App\Controller\ConnectController;
 use App\Tests\Common\Traits\TestNavTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -18,7 +19,8 @@ final class ConnectTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testConnectPage(): void
+    #[Test]
+    public function connectPage(): void
     {
         $client = self::createClient();
 
@@ -49,7 +51,8 @@ final class ConnectTest extends WebTestCase
         $this->assertCount(0, $crawler->filter('.navbar-link'));
     }
 
-    public function testGoogleConnectPage(): void
+    #[Test]
+    public function googleConnectPage(): void
     {
         $client = self::createClient();
 
@@ -67,7 +70,8 @@ final class ConnectTest extends WebTestCase
         );
     }
 
-    public function testFakeConnectPage(): void
+    #[Test]
+    public function fakeConnectPage(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Credits/CreditsTest.php
+++ b/tests/src/Integration/Controller/Credits/CreditsTest.php
@@ -8,6 +8,7 @@ use App\Controller\CreditsController;
 use App\Tests\Common\Traits\TestNavTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -19,7 +20,8 @@ final class CreditsTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testIndex(): void
+    #[Test]
+    public function index(): void
     {
         $client = self::createClient();
 
@@ -116,7 +118,8 @@ final class CreditsTest extends WebTestCase
         );
     }
 
-    public function testCreditLinkPointsToTheSourceUrl(): void
+    #[Test]
+    public function creditLinkPointsToTheSourceUrl(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/ElectionDexListTest.php
+++ b/tests/src/Integration/Controller/Election/ElectionDexListTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class ElectionDexListTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testIndex(): void
+    #[Test]
+    public function index(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/ElectionIndexTest.php
+++ b/tests/src/Integration/Controller/Election/ElectionIndexTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -22,7 +23,8 @@ final class ElectionIndexTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testIndex(): void
+    #[Test]
+    public function index(): void
     {
         $client = self::createClient();
 
@@ -77,7 +79,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testIndexShinyDex(): void
+    #[Test]
+    public function indexShinyDex(): void
     {
         $client = self::createClient();
 
@@ -136,7 +139,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testIndexWithoutDisplayForm(): void
+    #[Test]
+    public function indexWithoutDisplayForm(): void
     {
         $client = self::createClient();
 
@@ -199,7 +203,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testIndexDetachedCount(): void
+    #[Test]
+    public function indexDetachedCount(): void
     {
         $client = self::createClient();
 
@@ -262,7 +267,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testProgressVoteStep(): void
+    #[Test]
+    public function progressVoteStep(): void
     {
         $client = self::createClient();
 
@@ -325,7 +331,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testProgressLastPageStep(): void
+    #[Test]
+    public function progressLastPageStep(): void
     {
         $client = self::createClient();
 
@@ -391,7 +398,8 @@ final class ElectionIndexTest extends WebTestCase
         );
     }
 
-    public function testProgressLastOneStep(): void
+    #[Test]
+    public function progressLastOneStep(): void
     {
         $client = self::createClient();
 
@@ -455,7 +463,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '#election-lastpage-toast');
     }
 
-    public function testIndexNonTrainer(): void
+    #[Test]
+    public function indexNonTrainer(): void
     {
         $client = self::createClient();
 
@@ -469,7 +478,8 @@ final class ElectionIndexTest extends WebTestCase
         $client->request('GET', '/fr/election/demolite');
     }
 
-    public function testIndexNotFound(): void
+    #[Test]
+    public function indexNotFound(): void
     {
         $client = self::createClient();
 
@@ -482,7 +492,8 @@ final class ElectionIndexTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testImageCreditBadgeIsShownOnCandidateCard(): void
+    #[Test]
+    public function imageCreditBadgeIsShownOnCandidateCard(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/ElectionVoteTest.php
+++ b/tests/src/Integration/Controller/Election/ElectionVoteTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -21,7 +22,8 @@ final class ElectionVoteTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $client = self::createClient();
 
@@ -36,7 +38,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertSame("C'est quoi ton préféré ?", $crawler->filter('h1')->text());
     }
 
-    public function testVoteBis(): void
+    #[Test]
+    public function voteBis(): void
     {
         $client = self::createClient();
 
@@ -61,7 +64,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertSame("C'est quoi ton préféré ?", $crawler->filter('h1')->text());
     }
 
-    public function testVoteWithElectionSlug(): void
+    #[Test]
+    public function voteWithElectionSlug(): void
     {
         $client = self::createClient();
 
@@ -86,7 +90,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertSame("C'est quoi ton préféré ?", $crawler->filter('h1')->text());
     }
 
-    public function testVoteWithFilters(): void
+    #[Test]
+    public function voteWithFilters(): void
     {
         $client = self::createClient();
 
@@ -111,7 +116,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertSame("C'est quoi ton préféré ?", $crawler->filter('h1')->text());
     }
 
-    public function testEmptyVote(): void
+    #[Test]
+    public function emptyVote(): void
     {
         $client = self::createClient();
 
@@ -135,7 +141,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertStringContainsString('Data cannot be empty', $content);
     }
 
-    public function testBadVote(): void
+    #[Test]
+    public function badVote(): void
     {
         $client = self::createClient();
 
@@ -160,7 +167,8 @@ final class ElectionVoteTest extends WebTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testVoteNonTrainer(): void
+    #[Test]
+    public function voteNonTrainer(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/Filter/CollectionsTest.php
+++ b/tests/src/Integration/Controller/Election/Filter/CollectionsTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class CollectionsTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testFilterPogoShadowCollection(): void
+    #[Test]
+    public function filterPogoShadowCollection(): void
     {
         $client = self::createClient();
 
@@ -46,7 +48,8 @@ final class CollectionsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['pogoshadow']);
     }
 
-    public function testFilterNegativePogoShadowCollection(): void
+    #[Test]
+    public function filterNegativePogoShadowCollection(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/Filter/FormsTest.php
+++ b/tests/src/Integration/Controller/Election/Filter/FormsTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class FormsTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testFilterCategoryStart(): void
+    #[Test]
+    public function filterCategoryStart(): void
     {
         $client = self::createClient();
 
@@ -43,7 +45,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialMega(): void
+    #[Test]
+    public function filterSpecialMega(): void
     {
         $client = self::createClient();
 
@@ -66,7 +69,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialMegaAndGigantamax(): void
+    #[Test]
+    public function filterSpecialMegaAndGigantamax(): void
     {
         $client = self::createClient();
 
@@ -92,7 +96,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterRegionalPaldeanAndVariantAlternate(): void
+    #[Test]
+    public function filterRegionalPaldeanAndVariantAlternate(): void
     {
         $client = self::createClient();
 
@@ -116,7 +121,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialNull(): void
+    #[Test]
+    public function filterSpecialNull(): void
     {
         $client = self::createClient();
 
@@ -139,7 +145,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialNullAndMega(): void
+    #[Test]
+    public function filterSpecialNullAndMega(): void
     {
         $client = self::createClient();
 
@@ -163,7 +170,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialAllAndMega(): void
+    #[Test]
+    public function filterSpecialAllAndMega(): void
     {
         $client = self::createClient();
 
@@ -186,7 +194,8 @@ final class FormsTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSpecialUnknown(): void
+    #[Test]
+    public function filterSpecialUnknown(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/Filter/GamesTest.php
+++ b/tests/src/Integration/Controller/Election/Filter/GamesTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class GamesTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testFilterSwordShieldOriginalGame(): void
+    #[Test]
+    public function filterSwordShieldOriginalGame(): void
     {
         $client = self::createClient();
 
@@ -46,7 +48,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSwordShieldAndXYOriginalGame(): void
+    #[Test]
+    public function filterSwordShieldAndXYOriginalGame(): void
     {
         $client = self::createClient();
 
@@ -72,7 +75,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterOriginalGameUnknown(): void
+    #[Test]
+    public function filterOriginalGameUnknown(): void
     {
         $client = self::createClient();
 
@@ -95,7 +99,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSwordShieldGameBundle(): void
+    #[Test]
+    public function filterSwordShieldGameBundle(): void
     {
         $client = self::createClient();
 
@@ -121,7 +126,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSwordShieldGameBundleShiny(): void
+    #[Test]
+    public function filterSwordShieldGameBundleShiny(): void
     {
         $client = self::createClient();
 
@@ -147,7 +153,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterNotSwordShieldGameBundle(): void
+    #[Test]
+    public function filterNotSwordShieldGameBundle(): void
     {
         $client = self::createClient();
 
@@ -173,7 +180,8 @@ final class GamesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterNotSwordShieldGameBundleShiny(): void
+    #[Test]
+    public function filterNotSwordShieldGameBundleShiny(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Election/Filter/TypesTest.php
+++ b/tests/src/Integration/Controller/Election/Filter/TypesTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class TypesTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testFilterPrimaryTypeFire(): void
+    #[Test]
+    public function filterPrimaryTypeFire(): void
     {
         $client = self::createClient();
 
@@ -43,7 +45,8 @@ final class TypesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterSecondaryTypePoisonOrFlying(): void
+    #[Test]
+    public function filterSecondaryTypePoisonOrFlying(): void
     {
         $client = self::createClient();
 
@@ -69,7 +72,8 @@ final class TypesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterPrimaryTypeFightingAndSecondaryTypeFireOrWater(): void
+    #[Test]
+    public function filterPrimaryTypeFightingAndSecondaryTypeFireOrWater(): void
     {
         $client = self::createClient();
 
@@ -95,7 +99,8 @@ final class TypesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterPrimaryTypeFightingAndSecondaryTypeNullFireOrWater(): void
+    #[Test]
+    public function filterPrimaryTypeFightingAndSecondaryTypeNullFireOrWater(): void
     {
         $client = self::createClient();
 
@@ -121,7 +126,8 @@ final class TypesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterAnyTypeFire(): void
+    #[Test]
+    public function filterAnyTypeFire(): void
     {
         $client = self::createClient();
 
@@ -144,7 +150,8 @@ final class TypesTest extends WebTestCase
         $this->assertSelectedOptions($crawler, 'select#collection_availability', ['']);
     }
 
-    public function testFilterTypeUnknown(): void
+    #[Test]
+    public function filterTypeUnknown(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Home/HomeTest.php
+++ b/tests/src/Integration/Controller/Home/HomeTest.php
@@ -8,6 +8,7 @@ use App\Controller\HomeController;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -18,7 +19,8 @@ final class HomeTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testHome(): void
+    #[Test]
+    public function home(): void
     {
         $client = self::createClient();
 
@@ -51,7 +53,8 @@ final class HomeTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.home-menu-item');
     }
 
-    public function testHomeAsConnectedUser(): void
+    #[Test]
+    public function homeAsConnectedUser(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/OuterRoom/OuterRoomTest.php
+++ b/tests/src/Integration/Controller/OuterRoom/OuterRoomTest.php
@@ -8,6 +8,7 @@ use App\Controller\OuterRoomController;
 use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -19,7 +20,8 @@ final class OuterRoomTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testOuterRoomPageNonConnected(): void
+    #[Test]
+    public function outerRoomPageNonConnected(): void
     {
         $client = self::createClient();
 
@@ -28,7 +30,8 @@ final class OuterRoomTest extends WebTestCase
         $this->assertResponseStatusCodeSame(307);
     }
 
-    public function testOuterRoomPageConnectedAsTrainer(): void
+    #[Test]
+    public function outerRoomPageConnectedAsTrainer(): void
     {
         $client = self::createClient();
 
@@ -41,7 +44,8 @@ final class OuterRoomTest extends WebTestCase
         $this->assertResponseStatusCodeSame(302);
     }
 
-    public function testOuterRoomPageConnectedAsAdminOnly(): void
+    #[Test]
+    public function outerRoomPageConnectedAsAdminOnly(): void
     {
         $client = self::createClient();
 
@@ -54,7 +58,8 @@ final class OuterRoomTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testOuterRoomPageConnectedAsAdmin(): void
+    #[Test]
+    public function outerRoomPageConnectedAsAdmin(): void
     {
         $client = self::createClient();
 
@@ -68,7 +73,8 @@ final class OuterRoomTest extends WebTestCase
         $this->assertResponseStatusCodeSame(302);
     }
 
-    public function testOuterRoomPage(): void
+    #[Test]
+    public function outerRoomPage(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/StaticPage/StaticPageTest.php
+++ b/tests/src/Integration/Controller/StaticPage/StaticPageTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller\StaticPage;
 
 use App\Controller\StaticPageController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -14,7 +15,8 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 #[CoversClass(StaticPageController::class)]
 final class StaticPageTest extends WebTestCase
 {
-    public function testFrenchLegals(): void
+    #[Test]
+    public function frenchLegals(): void
     {
         $client = self::createClient();
 
@@ -35,7 +37,8 @@ final class StaticPageTest extends WebTestCase
         $this->assertStringContainsString('Mentions Légales', $crawler->filter('#main-container')->text());
     }
 
-    public function testEnglishLegals(): void
+    #[Test]
+    public function englishLegals(): void
     {
         $client = self::createClient();
 
@@ -56,7 +59,8 @@ final class StaticPageTest extends WebTestCase
         $this->assertStringContainsString('Legal Notice', $crawler->filter('#main-container')->text());
     }
 
-    public function testFrenchPolicy(): void
+    #[Test]
+    public function frenchPolicy(): void
     {
         $client = self::createClient();
 
@@ -77,7 +81,8 @@ final class StaticPageTest extends WebTestCase
         $this->assertStringContainsString('Politique de confidentialité', $crawler->filter('#main-container')->text());
     }
 
-    public function testEnglishPolicy(): void
+    #[Test]
+    public function englishPolicy(): void
     {
         $client = self::createClient();
 
@@ -98,7 +103,8 @@ final class StaticPageTest extends WebTestCase
         $this->assertStringContainsString('Privacy Policy', $crawler->filter('#main-container')->text());
     }
 
-    public function testFrenchCookies(): void
+    #[Test]
+    public function frenchCookies(): void
     {
         $client = self::createClient();
 
@@ -119,7 +125,8 @@ final class StaticPageTest extends WebTestCase
         $this->assertStringContainsString('Cookies', $crawler->filter('#main-container')->text());
     }
 
-    public function testEnglishCookies(): void
+    #[Test]
+    public function englishCookies(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Trainer/ActionTest.php
+++ b/tests/src/Integration/Controller/Trainer/ActionTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class ActionTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testActionConnected(): void
+    #[Test]
+    public function actionConnected(): void
     {
         $client = self::createClient();
 
@@ -40,7 +42,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testActionOnlyIsPrivate(): void
+    #[Test]
+    public function actionOnlyIsPrivate(): void
     {
         $client = self::createClient();
 
@@ -60,7 +63,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testActionOnlyIsOnHome(): void
+    #[Test]
+    public function actionOnlyIsOnHome(): void
     {
         $client = self::createClient();
 
@@ -80,7 +84,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testActionOnPremiumAsCollector(): void
+    #[Test]
+    public function actionOnPremiumAsCollector(): void
     {
         $client = self::createClient();
 
@@ -101,7 +106,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(200);
     }
 
-    public function testActionOnPremiumAsNonCollector(): void
+    #[Test]
+    public function actionOnPremiumAsNonCollector(): void
     {
         $client = self::createClient();
 
@@ -121,7 +127,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testActionNotConnected(): void
+    #[Test]
+    public function actionNotConnected(): void
     {
         $client = self::createClient();
 
@@ -137,7 +144,8 @@ final class ActionTest extends WebTestCase
         $this->assertResponseStatusCodeSame(307);
     }
 
-    public function testActionBadRequest(): void
+    #[Test]
+    public function actionBadRequest(): void
     {
         $client = self::createClient();
 
@@ -162,7 +170,8 @@ final class ActionTest extends WebTestCase
         $this->assertSame('{"error":"Fail to modify resources"}', $content);
     }
 
-    public function testActionFail(): void
+    #[Test]
+    public function actionFail(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Trainer/TrainerPageFiltersTest.php
+++ b/tests/src/Integration/Controller/Trainer/TrainerPageFiltersTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class TrainerPageFiltersTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testPrivacyFilterOn(): void
+    #[Test]
+    public function privacyFilterOn(): void
     {
         $client = self::createClient();
 
@@ -43,7 +45,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 15, '.trainer-dex-item');
     }
 
-    public function testPrivacyFilterOff(): void
+    #[Test]
+    public function privacyFilterOff(): void
     {
         $client = self::createClient();
 
@@ -66,7 +69,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 6, '.trainer-dex-item');
     }
 
-    public function testHomepagedFilterOn(): void
+    #[Test]
+    public function homepagedFilterOn(): void
     {
         $client = self::createClient();
 
@@ -89,7 +93,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 6, '.trainer-dex-item');
     }
 
-    public function testHomepagedFilterOff(): void
+    #[Test]
+    public function homepagedFilterOff(): void
     {
         $client = self::createClient();
 
@@ -112,7 +117,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 15, '.trainer-dex-item');
     }
 
-    public function testReleasedFilterOn(): void
+    #[Test]
+    public function releasedFilterOn(): void
     {
         $client = self::createClient();
 
@@ -135,7 +141,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 19, '.trainer-dex-item');
     }
 
-    public function testReleasedFilterOff(): void
+    #[Test]
+    public function releasedFilterOff(): void
     {
         $client = self::createClient();
 
@@ -158,7 +165,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '.trainer-dex-item');
     }
 
-    public function testShinyFilterOn(): void
+    #[Test]
+    public function shinyFilterOn(): void
     {
         $client = self::createClient();
 
@@ -181,7 +189,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 2, '.trainer-dex-item');
     }
 
-    public function testShinyFilterOff(): void
+    #[Test]
+    public function shinyFilterOff(): void
     {
         $client = self::createClient();
 
@@ -204,7 +213,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 19, '.trainer-dex-item');
     }
 
-    public function testPremiumFilterOn(): void
+    #[Test]
+    public function premiumFilterOn(): void
     {
         $client = self::createClient();
 
@@ -227,7 +237,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 3, '.trainer-dex-item');
     }
 
-    public function testPremiumFilterOff(): void
+    #[Test]
+    public function premiumFilterOff(): void
     {
         $client = self::createClient();
 
@@ -250,7 +261,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 18, '.trainer-dex-item');
     }
 
-    public function testAllFilterOff(): void
+    #[Test]
+    public function allFilterOff(): void
     {
         $client = self::createClient();
 
@@ -273,7 +285,8 @@ final class TrainerPageFiltersTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.trainer-dex-item');
     }
 
-    public function testAllFilterOn(): void
+    #[Test]
+    public function allFilterOn(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
+++ b/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\TestNavTrait;
 use App\Tests\Utils\GetUserToken;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -21,7 +22,8 @@ final class TrainerPageTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testTrainerPage(): void
+    #[Test]
+    public function trainerPage(): void
     {
         $client = self::createClient();
 
@@ -64,7 +66,8 @@ final class TrainerPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.dex_is_custom');
     }
 
-    public function testCollectorPage(): void
+    #[Test]
+    public function collectorPage(): void
     {
         $client = self::createClient();
 
@@ -108,7 +111,8 @@ final class TrainerPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '.dex_is_custom');
     }
 
-    public function testAdminTrainerPage(): void
+    #[Test]
+    public function adminTrainerPage(): void
     {
         $client = self::createClient();
 
@@ -153,7 +157,8 @@ final class TrainerPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 0, '.dex_is_custom');
     }
 
-    public function testTrainerPageNotAllowed(): void
+    #[Test]
+    public function trainerPageNotAllowed(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/ResponseObject/ActionLogTest.php
+++ b/tests/src/Integration/ResponseObject/ActionLogTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject;
 
 use App\ResponseObject\ActionLog;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ActionLog::class)]
 final class ActionLogTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -42,7 +44,8 @@ final class ActionLogTest extends KernelTestCase
         $this->assertNull($object->errorTrace);
     }
 
-    public function testDeserializeWithNullDetails(): void
+    #[Test]
+    public function deserializeWithNullDetails(): void
     {
         self::bootKernel();
 
@@ -65,7 +68,8 @@ final class ActionLogTest extends KernelTestCase
         $this->assertNull($object->details);
     }
 
-    public function testDeserializeWithDoneAt(): void
+    #[Test]
+    public function deserializeWithDoneAt(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Album/AlbumTest.php
+++ b/tests/src/Integration/ResponseObject/Album/AlbumTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Album\Album;
 use App\ResponseObject\Album\Dex;
 use App\ResponseObject\Common\Pokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -18,7 +19,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Album::class)]
 final class AlbumTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -47,7 +49,8 @@ final class AlbumTest extends KernelTestCase
         );
     }
 
-    public function testDeserializeWithNull(): void
+    #[Test]
+    public function deserializeWithNull(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Album/DexTest.php
+++ b/tests/src/Integration/ResponseObject/Album/DexTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Album\Dex;
 use App\ResponseObject\Album\DexFlags;
 use App\ResponseObject\Album\DexRegion;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -17,7 +18,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Dex::class)]
 final class DexTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -74,7 +76,8 @@ final class DexTest extends KernelTestCase
         $this->assertInstanceOf(DexRegion::class, $object->getRegion());
     }
 
-    public function testDeserializeWithNull(): void
+    #[Test]
+    public function deserializeWithNull(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Album/PokedexTest.php
+++ b/tests/src/Integration/ResponseObject/Album/PokedexTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Album\Dex;
 use App\ResponseObject\Album\Pokedex;
 use App\ResponseObject\Common\Pokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -18,7 +19,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Pokedex::class)]
 final class PokedexTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -37,7 +39,8 @@ final class PokedexTest extends KernelTestCase
         $this->assertNotSame($object->getReport(), $object->getFilteredReport());
     }
 
-    public function testDeserializeWithNull(): void
+    #[Test]
+    public function deserializeWithNull(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Album/ReportDetailTest.php
+++ b/tests/src/Integration/ResponseObject/Album/ReportDetailTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Album;
 
 use App\ResponseObject\Album\ReportDetail;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ReportDetail::class)]
 final class ReportDetailTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Album/ReportTest.php
+++ b/tests/src/Integration/ResponseObject/Album/ReportTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\ResponseObject\Album;
 use App\ResponseObject\Album\Report;
 use App\ResponseObject\Album\ReportDetail;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -16,7 +17,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Report::class)]
 final class ReportTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -61,7 +63,8 @@ final class ReportTest extends KernelTestCase
         $this->assertContainsOnlyInstancesOf(ReportDetail::class, $object->getDetail());
     }
 
-    public function testDeserializeWithNull(): void
+    #[Test]
+    public function deserializeWithNull(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/BrickVersionTest.php
+++ b/tests/src/Integration/ResponseObject/BrickVersionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject;
 
 use App\ResponseObject\BrickVersion;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(BrickVersion::class)]
 final class BrickVersionTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -36,7 +38,8 @@ final class BrickVersionTest extends KernelTestCase
         $this->assertSame('2026-08-05T09:12:00+00:00', $object->updatedAt?->format(\DateTimeInterface::ATOM));
     }
 
-    public function testDeserializeWithNullValues(): void
+    #[Test]
+    public function deserializeWithNullValues(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Common/PokemonTest.php
+++ b/tests/src/Integration/ResponseObject/Common/PokemonTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\ResponseObject\Common;
 use App\ResponseObject\Common\Pokemon;
 use App\ResponseObject\Common\PokemonCredit;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -16,7 +17,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Pokemon::class)]
 final class PokemonTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -114,7 +116,8 @@ final class PokemonTest extends KernelTestCase
         $this->assertSame('PokemonDB', $bigShinyCredit->getName());
     }
 
-    public function testDeserializeWithNullValues(): void
+    #[Test]
+    public function deserializeWithNullValues(): void
     {
         self::bootKernel();
 
@@ -198,7 +201,8 @@ final class PokemonTest extends KernelTestCase
         $this->assertSame('9999-0006-004', $object->getPokemonOrderNumber());
     }
 
-    public function testDeserializeWithNullForms(): void
+    #[Test]
+    public function deserializeWithNullForms(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Election/ElectionIndexTest.php
+++ b/tests/src/Integration/ResponseObject/Election/ElectionIndexTest.php
@@ -9,6 +9,7 @@ use App\ResponseObject\Common\Pokemon;
 use App\ResponseObject\Election\ElectionIndex;
 use App\ResponseObject\Election\TopPokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -19,7 +20,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ElectionIndex::class)]
 final class ElectionIndexTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -52,7 +54,8 @@ final class ElectionIndexTest extends KernelTestCase
         $this->assertSame(7, $object->getMetrics()['total_round_count']);
     }
 
-    public function testDeserializeWithNullAndEmptyArrays(): void
+    #[Test]
+    public function deserializeWithNullAndEmptyArrays(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Election/ElectionListTest.php
+++ b/tests/src/Integration/ResponseObject/Election/ElectionListTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\ResponseObject\Election;
 use App\ResponseObject\Common\Pokemon;
 use App\ResponseObject\Election\ElectionList;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -17,7 +18,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ElectionList::class)]
 final class ElectionListTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -33,7 +35,8 @@ final class ElectionListTest extends KernelTestCase
         $this->assertContainsOnlyInstancesOf(Pokemon::class, $object->getItems());
     }
 
-    public function testDeserializeWithNull(): void
+    #[Test]
+    public function deserializeWithNull(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Election/TopPokemonTest.php
+++ b/tests/src/Integration/ResponseObject/Election/TopPokemonTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Election;
 
 use App\ResponseObject\Election\TopPokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -16,7 +17,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(TopPokemon::class)]
 final class TopPokemonTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -96,7 +98,8 @@ final class TopPokemonTest extends KernelTestCase
         $this->assertFalse($object->getScore()->isSignificance());
     }
 
-    public function testDeserializeSignificant(): void
+    #[Test]
+    public function deserializeSignificant(): void
     {
         self::bootKernel();
 
@@ -145,7 +148,8 @@ final class TopPokemonTest extends KernelTestCase
         $this->assertTrue($object->getScore()->isSignificance());
     }
 
-    public function testDeserializeNullForms(): void
+    #[Test]
+    public function deserializeNullForms(): void
     {
         self::bootKernel();
 
@@ -187,7 +191,8 @@ final class TopPokemonTest extends KernelTestCase
         $this->assertNull($object->getPokemon()->getLabels()->getFormsFrenchLabel());
     }
 
-    public function testDeserializeArray(): void
+    #[Test]
+    public function deserializeArray(): void
     {
         self::bootKernel();
 
@@ -209,7 +214,8 @@ final class TopPokemonTest extends KernelTestCase
         $this->assertNotNull($objects[0]->getForms());
     }
 
-    public function testDeserializeEmptyArray(): void
+    #[Test]
+    public function deserializeEmptyArray(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/ImagePipelineStageStatusTest.php
+++ b/tests/src/Integration/ResponseObject/ImagePipelineStageStatusTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject;
 
 use App\ResponseObject\ImagePipelineStageStatus;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ImagePipelineStageStatus::class)]
 final class ImagePipelineStageStatusTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -36,7 +38,8 @@ final class ImagePipelineStageStatusTest extends KernelTestCase
         $this->assertSame('https://github.com/x/y/actions/runs/1', $object->url);
     }
 
-    public function testDeserializeWithNullUrl(): void
+    #[Test]
+    public function deserializeWithNullUrl(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/ImagePipelineStatusTest.php
+++ b/tests/src/Integration/ResponseObject/ImagePipelineStatusTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject;
 
 use App\ResponseObject\ImagePipelineStatus;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(ImagePipelineStatus::class)]
 final class ImagePipelineStatusTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/CatchStateTest.php
+++ b/tests/src/Integration/ResponseObject/Label/CatchStateTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\CatchState;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(CatchState::class)]
 final class CatchStateTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/CategoryFormTest.php
+++ b/tests/src/Integration/ResponseObject/Label/CategoryFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\CategoryForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(CategoryForm::class)]
 final class CategoryFormTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/CollectionTest.php
+++ b/tests/src/Integration/ResponseObject/Label/CollectionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\Collection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Collection::class)]
 final class CollectionTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/GameBundleTest.php
+++ b/tests/src/Integration/ResponseObject/Label/GameBundleTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\GameBundle;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(GameBundle::class)]
 final class GameBundleTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/LabelsTest.php
+++ b/tests/src/Integration/ResponseObject/Label/LabelsTest.php
@@ -14,6 +14,7 @@ use App\ResponseObject\Label\SpecialForm;
 use App\ResponseObject\Label\Type;
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -24,7 +25,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Labels::class)]
 final class LabelsTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/RegionalFormTest.php
+++ b/tests/src/Integration/ResponseObject/Label/RegionalFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\RegionalForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(RegionalForm::class)]
 final class RegionalFormTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/SpecialFormTest.php
+++ b/tests/src/Integration/ResponseObject/Label/SpecialFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\SpecialForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(SpecialForm::class)]
 final class SpecialFormTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/TypeTest.php
+++ b/tests/src/Integration/ResponseObject/Label/TypeTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\Type;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Type::class)]
 final class TypeTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/Label/VariantFormTest.php
+++ b/tests/src/Integration/ResponseObject/Label/VariantFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject\Label;
 
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(VariantForm::class)]
 final class VariantFormTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/ResponseObject/VersionsTest.php
+++ b/tests/src/Integration/ResponseObject/VersionsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\ResponseObject;
 
 use App\ResponseObject\Versions;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[CoversClass(Versions::class)]
 final class VersionsTest extends KernelTestCase
 {
-    public function testDeserialize(): void
+    #[Test]
+    public function deserialize(): void
     {
         self::bootKernel();
 
@@ -38,7 +40,8 @@ final class VersionsTest extends KernelTestCase
         $this->assertSame('2026-08-04T21:47:00+00:00', $object->api->updatedAt?->format(\DateTimeInterface::ATOM));
     }
 
-    public function testDeserializeWithNullBricks(): void
+    #[Test]
+    public function deserializeWithNullBricks(): void
     {
         self::bootKernel();
 

--- a/tests/src/Integration/Twig/ErrorPageTest.php
+++ b/tests/src/Integration/Twig/ErrorPageTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Twig;
 
 use App\Tests\Common\Traits\TestNavTrait;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +19,8 @@ final class ErrorPageTest extends WebTestCase
 {
     use TestNavTrait;
 
-    public function testError404(): void
+    #[Test]
+    public function error404(): void
     {
         $crawler = $this->renderErrorTemplate(404, 'Not Found');
 
@@ -28,7 +30,8 @@ final class ErrorPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '#main-container a');
     }
 
-    public function testError500(): void
+    #[Test]
+    public function error500(): void
     {
         $crawler = $this->renderErrorTemplate(500, 'Internal Server Error');
 
@@ -38,7 +41,8 @@ final class ErrorPageTest extends WebTestCase
         $this->assertCountFilter($crawler, 1, '#main-container a');
     }
 
-    public function testError512(): void
+    #[Test]
+    public function error512(): void
     {
         $crawler = $this->renderErrorTemplate(512, 'Custom Error');
 

--- a/tests/src/Unit/AlbumFilters/AlbumFilterBagTest.php
+++ b/tests/src/Unit/AlbumFilters/AlbumFilterBagTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\AlbumFilters;
 
 use App\AlbumFilters\AlbumFilterBag;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AlbumFilterBag::class)]
 final class AlbumFilterBagTest extends TestCase
 {
-    public function testToApiParams(): void
+    #[Test]
+    public function toApiParams(): void
     {
         $bag = new AlbumFilterBag(
             stringFilters: [
@@ -56,7 +58,8 @@ final class AlbumFilterBagTest extends TestCase
         );
     }
 
-    public function testToRouteParams(): void
+    #[Test]
+    public function toRouteParams(): void
     {
         $bag = new AlbumFilterBag(
             stringFilters: ['cs' => 'no', 'f' => 'pichu'],
@@ -74,7 +77,8 @@ final class AlbumFilterBagTest extends TestCase
         );
     }
 
-    public function testEmptyBag(): void
+    #[Test]
+    public function emptyBag(): void
     {
         $bag = new AlbumFilterBag();
 

--- a/tests/src/Unit/AlbumFilters/FromRequestTest.php
+++ b/tests/src/Unit/AlbumFilters/FromRequestTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\AlbumFilters;
 use App\AlbumFilters\AlbumFilterBag;
 use App\AlbumFilters\FromRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -16,7 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(FromRequest::class)]
 final class FromRequestTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $request = new Request([
             'cs' => 'no',
@@ -58,7 +60,8 @@ final class FromRequestTest extends TestCase
         );
     }
 
-    public function testGetWithNegatives(): void
+    #[Test]
+    public function getWithNegatives(): void
     {
         $request = new Request([
             'cs' => '!no',
@@ -83,7 +86,8 @@ final class FromRequestTest extends TestCase
         );
     }
 
-    public function testGetEmptyRequest(): void
+    #[Test]
+    public function getEmptyRequest(): void
     {
         $bag = FromRequest::get(new Request());
 

--- a/tests/src/Unit/Controller/AdminActionControllerTest.php
+++ b/tests/src/Unit/Controller/AdminActionControllerTest.php
@@ -9,6 +9,7 @@ use App\DTO\AdminAction;
 use App\Event\AdminActionSucceededEvent;
 use App\Service\Back\AdminActionService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -30,7 +31,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 #[CoversClass(AdminActionController::class)]
 final class AdminActionControllerTest extends TestCase
 {
-    public function testAction(): void
+    #[Test]
+    public function action(): void
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -106,21 +108,24 @@ final class AdminActionControllerTest extends TestCase
         $this->assertSame('/admin', $response->getTargetUrl());
     }
 
-    public function testFailUpdateLogs(): void
+    #[Test]
+    public function failUpdateLogs(): void
     {
         $controller = $this->assertFailActionLogs('update');
 
         $controller->update('something', new Request([], ['_token' => 'valid_token']));
     }
 
-    public function testFailCalculateLogs(): void
+    #[Test]
+    public function failCalculateLogs(): void
     {
         $controller = $this->assertFailActionLogs('calculate');
 
         $controller->calculate('something', new Request([], ['_token' => 'valid_token']));
     }
 
-    public function testTransportExceptionIsLogged(): void
+    #[Test]
+    public function transportExceptionIsLogged(): void
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -191,7 +196,8 @@ final class AdminActionControllerTest extends TestCase
         $controller->update('something', new Request([], ['_token' => 'valid_token']));
     }
 
-    public function testLogicExceptionPropagates(): void
+    #[Test]
+    public function logicExceptionPropagates(): void
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -237,7 +243,8 @@ final class AdminActionControllerTest extends TestCase
         $controller->invalidate('something', new Request([], ['_token' => 'valid_token']));
     }
 
-    public function testUpdateInvalidCsrfToken(): void
+    #[Test]
+    public function updateInvalidCsrfToken(): void
     {
         $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfManager
@@ -277,7 +284,8 @@ final class AdminActionControllerTest extends TestCase
         $controller->update('labels', new Request([], ['_token' => 'bad_token']));
     }
 
-    public function testCalculateInvalidCsrfToken(): void
+    #[Test]
+    public function calculateInvalidCsrfToken(): void
     {
         $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfManager
@@ -317,7 +325,8 @@ final class AdminActionControllerTest extends TestCase
         $controller->calculate('game_bundles_availabilities', new Request([], ['_token' => 'bad_token']));
     }
 
-    public function testInvalidateInvalidCsrfToken(): void
+    #[Test]
+    public function invalidateInvalidCsrfToken(): void
     {
         $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfManager
@@ -357,7 +366,8 @@ final class AdminActionControllerTest extends TestCase
         $controller->invalidate('labels', new Request([], ['_token' => 'bad_token']));
     }
 
-    public function testInvalidateReportsRedirectsToReportsPage(): void
+    #[Test]
+    public function invalidateReportsRedirectsToReportsPage(): void
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -433,7 +443,8 @@ final class AdminActionControllerTest extends TestCase
         $this->assertSame('/admin', $response->getTargetUrl());
     }
 
-    public function testTriggerAction(): void
+    #[Test]
+    public function triggerAction(): void
     {
         $adminActionService = $this->createMock(AdminActionService::class);
         $adminActionService
@@ -509,14 +520,16 @@ final class AdminActionControllerTest extends TestCase
         $this->assertSame('/admin', $response->getTargetUrl());
     }
 
-    public function testFailTriggerLogs(): void
+    #[Test]
+    public function failTriggerLogs(): void
     {
         $controller = $this->assertFailActionLogs('trigger', 'update_images');
 
         $controller->trigger('update_images', new Request([], ['_token' => 'valid_token']));
     }
 
-    public function testTriggerInvalidCsrfToken(): void
+    #[Test]
+    public function triggerInvalidCsrfToken(): void
     {
         $csrfManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfManager

--- a/tests/src/Unit/Controller/AdminControllerTest.php
+++ b/tests/src/Unit/Controller/AdminControllerTest.php
@@ -9,6 +9,7 @@ use App\DTO\AdminAction;
 use App\Service\Back\GetActionLogsService;
 use App\Service\Back\GetImagePipelineStatusService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,7 +26,8 @@ use Twig\Environment;
 #[CoversClass(AdminController::class)]
 final class AdminControllerTest extends TestCase
 {
-    public function testIndexRedirectsToActions(): void
+    #[Test]
+    public function indexRedirectsToActions(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
@@ -55,7 +57,8 @@ final class AdminControllerTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    public function testAdminAction(): void
+    #[Test]
+    public function adminAction(): void
     {
         $adminAction = new AdminAction(
             'truc',
@@ -146,7 +149,8 @@ final class AdminControllerTest extends TestCase
         );
     }
 
-    public function testAdminActionError(): void
+    #[Test]
+    public function adminActionError(): void
     {
         $adminAction = new AdminAction(
             'truc',

--- a/tests/src/Unit/Controller/AdminReportsControllerTest.php
+++ b/tests/src/Unit/Controller/AdminReportsControllerTest.php
@@ -8,6 +8,7 @@ use App\Controller\AdminReportsController;
 use App\DTO\AdminAction;
 use App\Service\Back\GetReportsService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -22,7 +23,8 @@ use Twig\Environment;
 #[CoversClass(AdminReportsController::class)]
 final class AdminReportsControllerTest extends TestCase
 {
-    public function testReports(): void
+    #[Test]
+    public function reports(): void
     {
         $adminAction = new AdminAction(
             'truc',
@@ -112,7 +114,8 @@ final class AdminReportsControllerTest extends TestCase
         );
     }
 
-    public function testReportsActionError(): void
+    #[Test]
+    public function reportsActionError(): void
     {
         $adminAction = new AdminAction(
             'truc',

--- a/tests/src/Unit/Controller/AlbumUpsertControllerTest.php
+++ b/tests/src/Unit/Controller/AlbumUpsertControllerTest.php
@@ -17,6 +17,7 @@ use App\Service\ModifyTrainerAlbumService;
 use App\Service\RequestedContentService;
 use App\Validator\CatchStates;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -29,7 +30,8 @@ use Psr\Container\ContainerInterface;
 #[CoversClass(ModifyTrainerAlbumService::class)]
 final class AlbumUpsertControllerTest extends TestCase
 {
-    public function testUpsert(): void
+    #[Test]
+    public function upsert(): void
     {
         $requestedContentService = $this->createMock(RequestedContentService::class);
         $requestedContentService
@@ -108,7 +110,8 @@ final class AlbumUpsertControllerTest extends TestCase
         $this->assertEmpty($response->getContent());
     }
 
-    public function testUpsertEmptyContentException(): void
+    #[Test]
+    public function upsertEmptyContentException(): void
     {
         $requestedContentService = $this->createMock(RequestedContentService::class);
         $requestedContentService
@@ -153,7 +156,8 @@ final class AlbumUpsertControllerTest extends TestCase
         $this->assertSame('{"error":"Content cannot be empty"}', $response->getContent());
     }
 
-    public function testUpsertInvalidJsonException(): void
+    #[Test]
+    public function upsertInvalidJsonException(): void
     {
         $requestedContentService = $this->createMock(RequestedContentService::class);
         $requestedContentService
@@ -198,7 +202,8 @@ final class AlbumUpsertControllerTest extends TestCase
         $this->assertSame('{"error":"Json is invalid"}', $response->getContent());
     }
 
-    public function testUpsertDexNotDefined(): void
+    #[Test]
+    public function upsertDexNotDefined(): void
     {
         $requestedContentService = $this->createMock(RequestedContentService::class);
         $requestedContentService

--- a/tests/src/Unit/Controller/Connect/DiscordControllerTest.php
+++ b/tests/src/Unit/Controller/Connect/DiscordControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Controller\Connect;
 
 use App\Controller\Connect\DiscordController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ final class DiscordControllerTest extends TestCase
 {
     use ConnectControllerTestTrait;
 
-    public function testGotoIgnoresSessionState(): void
+    #[Test]
+    public function gotoIgnoresSessionState(): void
     {
         $controller = new DiscordController();
 

--- a/tests/src/Unit/Controller/Connect/GoogleControllerTest.php
+++ b/tests/src/Unit/Controller/Connect/GoogleControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Controller\Connect;
 
 use App\Controller\Connect\GoogleController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ final class GoogleControllerTest extends TestCase
 {
     use ConnectControllerTestTrait;
 
-    public function testGotoDuringSilentReauthForcesConsent(): void
+    #[Test]
+    public function gotoDuringSilentReauthForcesConsent(): void
     {
         $controller = new GoogleController();
 
@@ -29,7 +31,8 @@ final class GoogleControllerTest extends TestCase
         );
     }
 
-    public function testGotoOnNormalLoginDoesNotForceConsent(): void
+    #[Test]
+    public function gotoOnNormalLoginDoesNotForceConsent(): void
     {
         $controller = new GoogleController();
 

--- a/tests/src/Unit/Controller/ConnectControllerTest.php
+++ b/tests/src/Unit/Controller/ConnectControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Controller;
 
 use App\Controller\ConnectController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ConnectController::class)]
 final class ConnectControllerTest extends TestCase
 {
-    public function testLogout(): void
+    #[Test]
+    public function logout(): void
     {
         $controller = new ConnectController();
 

--- a/tests/src/Unit/Controller/ElectionVoteControllerTest.php
+++ b/tests/src/Unit/Controller/ElectionVoteControllerTest.php
@@ -8,6 +8,7 @@ use App\Controller\ElectionVoteController;
 use App\Exception\ModifyFailedException;
 use App\Service\ElectionVoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -22,7 +23,8 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(ElectionVoteController::class)]
 final class ElectionVoteControllerTest extends TestCase
 {
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $request = new Request([], ['winners_slugs' => ['pichu'], 'losers_slugs' => ['pikachu']]);
 
@@ -68,7 +70,8 @@ final class ElectionVoteControllerTest extends TestCase
         $this->assertSame('/fr/election/demo', $response->getTargetUrl());
     }
 
-    public function testVoteEmpty(): void
+    #[Test]
+    public function voteEmpty(): void
     {
         $request = new Request();
 
@@ -97,7 +100,8 @@ final class ElectionVoteControllerTest extends TestCase
         );
     }
 
-    public function testVoteWithModifyFailed(): void
+    #[Test]
+    public function voteWithModifyFailed(): void
     {
         $request = new Request([], ['winners_slugs' => ['pichu'], 'losers_slugs' => ['pikachu']]);
 
@@ -150,7 +154,8 @@ final class ElectionVoteControllerTest extends TestCase
         $this->assertSame('/fr/election/demo', $response->getTargetUrl());
     }
 
-    public function testVoteNonvalid(): void
+    #[Test]
+    public function voteNonvalid(): void
     {
         $request = new Request([], ['winners_slugs' => ['pichu']]);
 

--- a/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerDexLinkControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Controller;
 use App\Controller\TrainerDexLinkController;
 use App\Service\Back\TrainerDexLinkService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
@@ -18,7 +19,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(TrainerDexLinkController::class)]
 final class TrainerDexLinkControllerTest extends TestCase
 {
-    public function testList(): void
+    #[Test]
+    public function list(): void
     {
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())
@@ -35,7 +37,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame('[{"id":"link-1"}]', $response->getContent());
     }
 
-    public function testListForwardsApiFailureStatusCode(): void
+    #[Test]
+    public function listForwardsApiFailureStatusCode(): void
     {
         $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(404);
@@ -57,7 +60,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    public function testCreateRejectsEmptyBody(): void
+    #[Test]
+    public function createRejectsEmptyBody(): void
     {
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->never())->method('create');
@@ -69,7 +73,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame(400, $response->getStatusCode());
     }
 
-    public function testCreateSucceeds(): void
+    #[Test]
+    public function createSucceeds(): void
     {
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())
@@ -84,7 +89,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame(201, $response->getStatusCode());
     }
 
-    public function testCreateForwardsApiFailureStatusCode(): void
+    #[Test]
+    public function createForwardsApiFailureStatusCode(): void
     {
         $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(409);
@@ -106,7 +112,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame(409, $response->getStatusCode());
     }
 
-    public function testDelete(): void
+    #[Test]
+    public function delete(): void
     {
         $service = $this->createMock(TrainerDexLinkService::class);
         $service->expects($this->once())->method('delete')->with('link-1');
@@ -118,7 +125,8 @@ final class TrainerDexLinkControllerTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
-    public function testDeleteForwardsApiFailureStatusCode(): void
+    #[Test]
+    public function deleteForwardsApiFailureStatusCode(): void
     {
         $apiResponse = $this->createStub(ResponseInterface::class);
         $apiResponse->method('getStatusCode')->willReturn(404);

--- a/tests/src/Unit/Controller/TrainerUpsertControllerTest.php
+++ b/tests/src/Unit/Controller/TrainerUpsertControllerTest.php
@@ -18,6 +18,7 @@ use App\Service\ModifyTrainerDexService;
 use App\Service\RequestedContentService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -33,7 +34,8 @@ final class TrainerUpsertControllerTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testUpsert(): void
+    #[Test]
+    public function upsert(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -86,7 +88,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertEmpty($response->getContent());
     }
 
-    public function testUpsertEmptyContentException(): void
+    #[Test]
+    public function upsertEmptyContentException(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -132,7 +135,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertSame('{"error":"Content cannot be empty"}', $response->getContent());
     }
 
-    public function testUpsertInvalidJsonException(): void
+    #[Test]
+    public function upsertInvalidJsonException(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -178,7 +182,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertSame('{"error":"Json is invalid"}', $response->getContent());
     }
 
-    public function testUpsertDexNotDefined(): void
+    #[Test]
+    public function upsertDexNotDefined(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -227,7 +232,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertSame('[]', $response->getContent());
     }
 
-    public function testUpsertNonPremiumDex(): void
+    #[Test]
+    public function upsertNonPremiumDex(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -308,7 +314,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertEmpty($response->getContent());
     }
 
-    public function testUpsertPremiumDexNotCollector(): void
+    #[Test]
+    public function upsertPremiumDexNotCollector(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService
@@ -395,7 +402,8 @@ final class TrainerUpsertControllerTest extends TestCase
         $this->assertSame('[]', $response->getContent());
     }
 
-    public function testUpsertModifyFail(): void
+    #[Test]
+    public function upsertModifyFail(): void
     {
         $getTrainerPokedexService = $this->createMock(GetTrainerPokedexService::class);
         $getTrainerPokedexService

--- a/tests/src/Unit/DTO/ActionLogDataTest.php
+++ b/tests/src/Unit/DTO/ActionLogDataTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\DTO;
 use App\DTO\ActionLogData;
 use App\ResponseObject\ActionLog;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ActionLogData::class)]
 final class ActionLogDataTest extends TestCase
 {
-    public function testConstructorWithoutLast(): void
+    #[Test]
+    public function constructorWithoutLast(): void
     {
         $actionLog = new ActionLog(
             new \DateTimeImmutable('2023-03-21 08:34:47+00'),
@@ -36,7 +38,8 @@ final class ActionLogDataTest extends TestCase
         $this->assertNull($actionLogData->getLast());
     }
 
-    public function testConstructorWithLast(): void
+    #[Test]
+    public function constructorWithLast(): void
     {
         $actionLogCurrent = new ActionLog(
             new \DateTimeImmutable('2023-03-21 08:34:47+00'),
@@ -65,7 +68,8 @@ final class ActionLogDataTest extends TestCase
         $this->assertSame($actionLogLast, $actionLogData->getLast());
     }
 
-    public function testConstructorWithoutCurrent(): void
+    #[Test]
+    public function constructorWithoutCurrent(): void
     {
         $actionLogData = new ActionLogData('truc');
 

--- a/tests/src/Unit/DTO/AdminActionTest.php
+++ b/tests/src/Unit/DTO/AdminActionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\AdminAction;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AdminAction::class)]
 final class AdminActionTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $adminAction = new AdminAction(
             'truc',

--- a/tests/src/Unit/DTO/DexFilterValueTest.php
+++ b/tests/src/Unit/DTO/DexFilterValueTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\DexFilterValue;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexFilterValue::class)]
 final class DexFilterValueTest extends TestCase
 {
-    public function testConstruct(): void
+    #[Test]
+    public function construct(): void
     {
         $dexFilterValue = new DexFilterValue(true);
 

--- a/tests/src/Unit/DTO/DexFiltersRequestTest.php
+++ b/tests/src/Unit/DTO/DexFiltersRequestTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\DexFiltersRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -15,7 +16,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(DexFiltersRequest::class)]
 final class DexFiltersRequestTest extends TestCase
 {
-    public function testDexFiltersFromRequestEmpty(): void
+    #[Test]
+    public function dexFiltersFromRequestEmpty(): void
     {
         $request = new Request([]);
 
@@ -28,7 +30,8 @@ final class DexFiltersRequestTest extends TestCase
         $this->assertNull($filters->premium->value);
     }
 
-    public function testDexFiltersFromRequest(): void
+    #[Test]
+    public function dexFiltersFromRequest(): void
     {
         $request = new Request([
             'p' => '1',
@@ -47,7 +50,8 @@ final class DexFiltersRequestTest extends TestCase
         $this->assertFalse($filters->premium->value);
     }
 
-    public function testDexFiltersFromRequestIgnoresUnknownParams(): void
+    #[Test]
+    public function dexFiltersFromRequestIgnoresUnknownParams(): void
     {
         $request = new Request([
             'p' => '1',

--- a/tests/src/Unit/DTO/DexFiltersTest.php
+++ b/tests/src/Unit/DTO/DexFiltersTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\DexFilters;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexFilters::class)]
 final class DexFiltersTest extends TestCase
 {
-    public function testCreateFromArrayEmpty(): void
+    #[Test]
+    public function createFromArrayEmpty(): void
     {
         $filters = DexFilters::createFromArray([]);
 
@@ -25,7 +27,8 @@ final class DexFiltersTest extends TestCase
         $this->assertNull($filters->premium->value);
     }
 
-    public function testCreateFromArray(): void
+    #[Test]
+    public function createFromArray(): void
     {
         $filters = DexFilters::createFromArray([
             'privacy' => '1',
@@ -42,20 +45,23 @@ final class DexFiltersTest extends TestCase
         $this->assertFalse($filters->premium->value);
     }
 
-    public function testNormalizerTrue(): void
+    #[Test]
+    public function normalizerTrue(): void
     {
         $filterValue = DexFilters::normalizer('1');
         $this->assertTrue($filterValue->value);
     }
 
-    public function testNormalizerFalse(): void
+    #[Test]
+    public function normalizerFalse(): void
     {
         $filterValue = DexFilters::normalizer('0');
 
         $this->assertFalse($filterValue->value);
     }
 
-    public function testNormalizerWithEmptyValue(): void
+    #[Test]
+    public function normalizerWithEmptyValue(): void
     {
         $filterValue = DexFilters::normalizer('');
 

--- a/tests/src/Unit/DTO/ElectionIndexDataTest.php
+++ b/tests/src/Unit/DTO/ElectionIndexDataTest.php
@@ -8,6 +8,7 @@ use App\DTO\ElectionIndexData;
 use App\DTO\ElectionMetrics;
 use App\DTO\ElectionTop;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionIndexData::class)]
 final class ElectionIndexDataTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $object = new ElectionIndexData(
             'list_type',

--- a/tests/src/Unit/DTO/ElectionIndexDataTest.php
+++ b/tests/src/Unit/DTO/ElectionIndexDataTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class ElectionIndexDataTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $object = new ElectionIndexData(
             'list_type',

--- a/tests/src/Unit/DTO/ElectionMetricsTest.php
+++ b/tests/src/Unit/DTO/ElectionMetricsTest.php
@@ -9,6 +9,7 @@ use App\DTO\ElectionMetricsCompletion;
 use App\DTO\ElectionMetricsCounts;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
@@ -21,7 +22,8 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 #[CoversClass(ElectionMetricsCompletion::class)]
 final class ElectionMetricsTest extends TestCase
 {
-    public function testPropertiesAreReadonly(): void
+    #[Test]
+    public function propertiesAreReadonly(): void
     {
         $this->assertTrue((new \ReflectionProperty(ElectionMetrics::class, 'viewCount'))->isReadOnly());
         $this->assertTrue((new \ReflectionProperty(ElectionMetrics::class, 'winCount'))->isReadOnly());
@@ -32,7 +34,8 @@ final class ElectionMetricsTest extends TestCase
         $this->assertTrue((new \ReflectionProperty(ElectionMetrics::class, 'totalRoundCount'))->isReadOnly());
     }
 
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $object = ElectionMetrics::createFromArray(
             [
@@ -58,7 +61,8 @@ final class ElectionMetricsTest extends TestCase
         $this->assertSame(13, $object->getTotalRoundCount());
     }
 
-    public function testWinnerAverageAcceptsInt(): void
+    #[Test]
+    public function winnerAverageAcceptsInt(): void
     {
         $object = ElectionMetrics::createFromArray(
             [
@@ -79,7 +83,8 @@ final class ElectionMetricsTest extends TestCase
      * @param array<string, mixed> $values
      */
     #[DataProvider('providerMissingTopLevelProperty')]
-    public function testMissingTopLevelProperty(array $values): void
+    #[Test]
+    public function missingTopLevelProperty(array $values): void
     {
         $this->expectException(MissingOptionsException::class);
 
@@ -120,7 +125,8 @@ final class ElectionMetricsTest extends TestCase
      * @param array<string, mixed> $values
      */
     #[DataProvider('providerBadTopLevelType')]
-    public function testBadTopLevelType(array $values): void
+    #[Test]
+    public function badTopLevelType(array $values): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -161,7 +167,8 @@ final class ElectionMetricsTest extends TestCase
      * @param array<string, mixed> $values
      */
     #[DataProvider('providerMissingSubKey')]
-    public function testMissingSubKey(array $values): void
+    #[Test]
+    public function missingSubKey(array $values): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -205,7 +212,8 @@ final class ElectionMetricsTest extends TestCase
      * @param array<string, mixed> $values
      */
     #[DataProvider('providerBadSubKeyType')]
-    public function testBadSubKeyType(array $values): void
+    #[Test]
+    public function badSubKeyType(array $values): void
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/tests/src/Unit/DTO/ElectionMetricsTest.php
+++ b/tests/src/Unit/DTO/ElectionMetricsTest.php
@@ -35,7 +35,7 @@ final class ElectionMetricsTest extends TestCase
     }
 
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $object = ElectionMetrics::createFromArray(
             [

--- a/tests/src/Unit/DTO/ElectionTopTest.php
+++ b/tests/src/Unit/DTO/ElectionTopTest.php
@@ -20,7 +20,7 @@ final class ElectionTopTest extends TestCase
     use ResponseObjectTrait;
 
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $object = new ElectionTop([
             $this->getStubTopPokemon(),

--- a/tests/src/Unit/DTO/ElectionTopTest.php
+++ b/tests/src/Unit/DTO/ElectionTopTest.php
@@ -8,6 +8,7 @@ use App\DTO\ElectionTop;
 use App\ResponseObject\Election\TopPokemon;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ final class ElectionTopTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $object = new ElectionTop([
             $this->getStubTopPokemon(),

--- a/tests/src/Unit/DTO/ElectionVoteTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteTest.php
@@ -28,7 +28,7 @@ final class ElectionVoteTest extends TestCase
     }
 
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',

--- a/tests/src/Unit/DTO/ElectionVoteTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\ElectionVote;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
@@ -17,7 +18,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(ElectionVote::class)]
 final class ElectionVoteTest extends TestCase
 {
-    public function testPropertiesAreReadonly(): void
+    #[Test]
+    public function propertiesAreReadonly(): void
     {
         $this->assertTrue((new \ReflectionProperty(ElectionVote::class, 'dexSlug'))->isReadOnly());
         $this->assertTrue((new \ReflectionProperty(ElectionVote::class, 'electionSlug'))->isReadOnly());
@@ -25,7 +27,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertTrue((new \ReflectionProperty(ElectionVote::class, 'losersSlugs'))->isReadOnly());
     }
 
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -40,7 +43,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pichu', 'raichu'], $object->losersSlugs);
     }
 
-    public function testWinnerAsLoser(): void
+    #[Test]
+    public function winnerAsLoser(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -55,7 +59,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pichu', 'raichu'], $object->losersSlugs);
     }
 
-    public function testWinnersAsLosers(): void
+    #[Test]
+    public function winnersAsLosers(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -70,7 +75,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['raichu'], $object->losersSlugs);
     }
 
-    public function testWithEmptyWinners(): void
+    #[Test]
+    public function withEmptyWinners(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -85,7 +91,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pikachu', 'raichu'], $object->losersSlugs);
     }
 
-    public function testWithEmptyLosers(): void
+    #[Test]
+    public function withEmptyLosers(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -100,7 +107,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pikachu', 'raichu'], $object->losersSlugs);
     }
 
-    public function testMissingDexSlug(): void
+    #[Test]
+    public function missingDexSlug(): void
     {
         $this->expectException(MissingOptionsException::class);
 
@@ -111,7 +119,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongDexSlug(): void
+    #[Test]
+    public function wrongDexSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -127,7 +136,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testMissingElectionSlug(): void
+    #[Test]
+    public function missingElectionSlug(): void
     {
         $object = ElectionVote::createFromArray([
             'dex_slug' => 'pokedex',
@@ -141,7 +151,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pichu', 'raichu'], $object->losersSlugs);
     }
 
-    public function testWrongValueForElectionSlug(): void
+    #[Test]
+    public function wrongValueForElectionSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -158,7 +169,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForWinnerSlug(): void
+    #[Test]
+    public function wrongValueForWinnerSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -174,7 +186,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForLosersSlugs(): void
+    #[Test]
+    public function wrongValueForLosersSlugs(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -190,7 +203,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testAnotherValue(): void
+    #[Test]
+    public function anotherValue(): void
     {
         $this->expectException(UndefinedOptionsException::class);
 

--- a/tests/src/Unit/DTO/UserInfoTest.php
+++ b/tests/src/Unit/DTO/UserInfoTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\UserInfo;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UserInfo::class)]
 final class UserInfoTest extends TestCase
 {
-    public function testConstrutorAndGetters(): void
+    #[Test]
+    public function construtorAndGetters(): void
     {
         $userInfo = new UserInfo(
             '20230321T0834470000',

--- a/tests/src/Unit/DTO/VersionsOverviewTest.php
+++ b/tests/src/Unit/DTO/VersionsOverviewTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\DTO;
 use App\DTO\VersionsOverview;
 use App\ResponseObject\BrickVersion;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VersionsOverview::class)]
 final class VersionsOverviewTest extends TestCase
 {
-    public function testConstrutorAndGetters(): void
+    #[Test]
+    public function construtorAndGetters(): void
     {
         $webVersion = new BrickVersion(
             '1.0',

--- a/tests/src/Unit/Event/AdminActionSucceededEventTest.php
+++ b/tests/src/Unit/Event/AdminActionSucceededEventTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Event;
 
 use App\Event\AdminActionSucceededEvent;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AdminActionSucceededEvent::class)]
 final class AdminActionSucceededEventTest extends TestCase
 {
-    public function testProperties(): void
+    #[Test]
+    public function properties(): void
     {
         $event = new AdminActionSucceededEvent('labels');
 

--- a/tests/src/Unit/EventListener/LabelsCacheInvalidationListenerTest.php
+++ b/tests/src/Unit/EventListener/LabelsCacheInvalidationListenerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\EventListener;
 use App\Event\AdminActionSucceededEvent;
 use App\EventListener\LabelsCacheInvalidationListener;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
@@ -16,7 +17,8 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
 #[CoversClass(LabelsCacheInvalidationListener::class)]
 final class LabelsCacheInvalidationListenerTest extends TestCase
 {
-    public function testInvalidatesLabelsCacheOnLabelsEvent(): void
+    #[Test]
+    public function invalidatesLabelsCacheOnLabelsEvent(): void
     {
         $cache = $this->createMock(TagAwareCacheInterface::class);
         $cache
@@ -29,7 +31,8 @@ final class LabelsCacheInvalidationListenerTest extends TestCase
         $listener(new AdminActionSucceededEvent('labels'));
     }
 
-    public function testDoesNotInvalidateForOtherNames(): void
+    #[Test]
+    public function doesNotInvalidateForOtherNames(): void
     {
         $cache = $this->createMock(TagAwareCacheInterface::class);
         $cache

--- a/tests/src/Unit/ResponseObject/Album/DexFlagsTest.php
+++ b/tests/src/Unit/ResponseObject/Album/DexFlagsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Album;
 
 use App\ResponseObject\Album\DexFlags;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexFlags::class)]
 final class DexFlagsTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $flags = new DexFlags(
             isShiny: true,

--- a/tests/src/Unit/ResponseObject/Album/DexListItemRefTest.php
+++ b/tests/src/Unit/ResponseObject/Album/DexListItemRefTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Album;
 
 use App\ResponseObject\Album\DexListItemRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexListItemRef::class)]
 final class DexListItemRefTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $ref = new DexListItemRef(slug: 'homepokemongo');
 

--- a/tests/src/Unit/ResponseObject/Album/DexListItemSettingsTest.php
+++ b/tests/src/Unit/ResponseObject/Album/DexListItemSettingsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Album;
 
 use App\ResponseObject\Album\DexListItemSettings;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexListItemSettings::class)]
 final class DexListItemSettingsTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $settings = new DexListItemSettings(
             name: 'Sword, Shield',

--- a/tests/src/Unit/ResponseObject/Album/DexListItemTest.php
+++ b/tests/src/Unit/ResponseObject/Album/DexListItemTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Album\DexListItemRef;
 use App\ResponseObject\Album\DexListItemSettings;
 use App\ResponseObject\Album\Report;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexListItem::class)]
 final class DexListItemTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $ref = new DexListItemRef(slug: 'swordshield');
         $settings = new DexListItemSettings(
@@ -45,7 +47,8 @@ final class DexListItemTest extends TestCase
         $this->assertNull($item->getReport());
     }
 
-    public function testGettersWithReport(): void
+    #[Test]
+    public function gettersWithReport(): void
     {
         $ref = new DexListItemRef(slug: 'swordshield');
         $settings = new DexListItemSettings(

--- a/tests/src/Unit/ResponseObject/Album/DexRegionTest.php
+++ b/tests/src/Unit/ResponseObject/Album/DexRegionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Album;
 
 use App\ResponseObject\Album\DexRegion;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexRegion::class)]
 final class DexRegionTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $region = new DexRegion('Kanto', 'Kanto');
 

--- a/tests/src/Unit/ResponseObject/Album/TrainerDexLinkTest.php
+++ b/tests/src/Unit/ResponseObject/Album/TrainerDexLinkTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Album;
 
 use App\ResponseObject\Album\TrainerDexLink;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TrainerDexLink::class)]
 final class TrainerDexLinkTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $link = new TrainerDexLink(
             id: 'link-1',

--- a/tests/src/Unit/ResponseObject/Common/GameBundlesGroupTest.php
+++ b/tests/src/Unit/ResponseObject/Common/GameBundlesGroupTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Common;
 use App\ResponseObject\Common\GameBundlesGroup;
 use App\ResponseObject\Common\PokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesGroup::class)]
 final class GameBundlesGroupTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $normal1 = new PokemonSlugRef('xy');
         $shiny1 = new PokemonSlugRef('omegarubyalphasapphire');
@@ -26,7 +28,8 @@ final class GameBundlesGroupTest extends TestCase
         $this->assertSame([$shiny1], $group->getShiny());
     }
 
-    public function testEmptyArrays(): void
+    #[Test]
+    public function emptyArrays(): void
     {
         $group = new GameBundlesGroup(normal: [], shiny: []);
 

--- a/tests/src/Unit/ResponseObject/Common/PokemonCreditRowTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonCreditRowTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Common\PokemonCredit;
 use App\ResponseObject\Common\PokemonCreditRow;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonCreditRow::class)]
 final class PokemonCreditRowTest extends TestCase
 {
-    public function testGettersExposeConstructorValues(): void
+    #[Test]
+    public function gettersExposeConstructorValues(): void
     {
         $smallRegular = new PokemonCredit(credit: 'PokéSprite - https://github.com/msikma/pokesprite');
         $bigRegular = new PokemonCredit(credit: 'PokemonDB - https://pokemondb.net/sprites/bulbasaur');
@@ -43,7 +45,8 @@ final class PokemonCreditRowTest extends TestCase
     }
 
     #[DataProvider('providerExactlyOneSlotSet')]
-    public function testHasAnyCreditIsTrueWhenExactlyOneSlotIsSet(
+    #[Test]
+    public function hasAnyCreditIsTrueWhenExactlyOneSlotIsSet(
         ?PokemonCredit $smallRegularCredit,
         ?PokemonCredit $smallShinyCredit,
         ?PokemonCredit $bigRegularCredit,
@@ -78,7 +81,8 @@ final class PokemonCreditRowTest extends TestCase
         ];
     }
 
-    public function testHasAnyCreditIsFalseWhenAllFourSlotsAreNull(): void
+    #[Test]
+    public function hasAnyCreditIsFalseWhenAllFourSlotsAreNull(): void
     {
         $row = new PokemonCreditRow(
             pokemonSlug: 'venusaur',

--- a/tests/src/Unit/ResponseObject/Common/PokemonCreditTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonCreditTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Common;
 
 use App\ResponseObject\Common\PokemonCredit;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonCredit::class)]
 final class PokemonCreditTest extends TestCase
 {
-    public function testGettersExtractNameAndUrlFromMergedCredit(): void
+    #[Test]
+    public function gettersExtractNameAndUrlFromMergedCredit(): void
     {
         $credit = new PokemonCredit(credit: 'PokéSprite - https://github.com/msikma/pokesprite');
 
@@ -22,7 +24,8 @@ final class PokemonCreditTest extends TestCase
         $this->assertSame('https://github.com/msikma/pokesprite', $credit->getUrl());
     }
 
-    public function testGettersFallBackToFullCreditWhenNoUrlPresent(): void
+    #[Test]
+    public function gettersFallBackToFullCreditWhenNoUrlPresent(): void
     {
         $credit = new PokemonCredit(credit: 'PokéSprite');
 
@@ -30,7 +33,8 @@ final class PokemonCreditTest extends TestCase
         $this->assertNull($credit->getUrl());
     }
 
-    public function testGettersFallBackToRawCreditWhenOnlyUrlPresent(): void
+    #[Test]
+    public function gettersFallBackToRawCreditWhenOnlyUrlPresent(): void
     {
         $credit = new PokemonCredit(credit: 'https://serebii.net');
 
@@ -38,7 +42,8 @@ final class PokemonCreditTest extends TestCase
         $this->assertSame('https://serebii.net', $credit->getUrl());
     }
 
-    public function testExtractUrlIsPubliclyCallable(): void
+    #[Test]
+    public function extractUrlIsPubliclyCallable(): void
     {
         $this->assertSame(
             'https://github.com/msikma/pokesprite',
@@ -46,7 +51,8 @@ final class PokemonCreditTest extends TestCase
         );
     }
 
-    public function testExtractNameIsPubliclyCallable(): void
+    #[Test]
+    public function extractNameIsPubliclyCallable(): void
     {
         $this->assertSame(
             'PokéSprite',

--- a/tests/src/Unit/ResponseObject/Common/PokemonDataTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonDataTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Common\PokemonData;
 use App\ResponseObject\Common\PokemonLabels;
 use App\ResponseObject\Common\PokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonData::class)]
 final class PokemonDataTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $familyLead = new PokemonSlugRef('charmander');
         $originalGameBundle = new PokemonSlugRef('xy');
@@ -67,7 +69,8 @@ final class PokemonDataTest extends TestCase
         $this->assertSame([$bundle2], $data->getGameBundlesShiny());
     }
 
-    public function testNullableFamilyLead(): void
+    #[Test]
+    public function nullableFamilyLead(): void
     {
         $data = new PokemonData(
             slug: 'bulbasaur',
@@ -98,7 +101,8 @@ final class PokemonDataTest extends TestCase
         $this->assertSame(1, $data->getRegionalDexNumber());
     }
 
-    public function testNullableLabels(): void
+    #[Test]
+    public function nullableLabels(): void
     {
         $data = new PokemonData(
             slug: 'bulbasaur',
@@ -130,7 +134,8 @@ final class PokemonDataTest extends TestCase
         $this->assertSame('', $data->getFormsFrenchLabel());
     }
 
-    public function testCredits(): void
+    #[Test]
+    public function credits(): void
     {
         $smallRegular = new PokemonCredit(credit: 'PokéSprite - https://github.com/msikma/pokesprite');
         $bigShiny = new PokemonCredit(credit: 'PokemonDB - https://pokemondb.net/sprites/bulbasaur-shiny');

--- a/tests/src/Unit/ResponseObject/Common/PokemonFormsTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonFormsTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Label\RegionalForm;
 use App\ResponseObject\Label\SpecialForm;
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonForms::class)]
 final class PokemonFormsTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $category = new CategoryForm('Starter', 'de Départ', 'starter');
         $regional = new RegionalForm('Alolan', "d'Alola", 'alolan');
@@ -33,7 +35,8 @@ final class PokemonFormsTest extends TestCase
         $this->assertSame($variant, $forms->getVariant());
     }
 
-    public function testNullable(): void
+    #[Test]
+    public function nullable(): void
     {
         $forms = new PokemonForms(null, null, null, null);
 

--- a/tests/src/Unit/ResponseObject/Common/PokemonLabelsTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonLabelsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Common;
 
 use App\ResponseObject\Common\PokemonLabels;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonLabels::class)]
 final class PokemonLabelsTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $labels = new PokemonLabels(
             name: 'Mega Charizard Y',
@@ -33,7 +35,8 @@ final class PokemonLabelsTest extends TestCase
         $this->assertSame('Méga Y', $labels->getFormsFrenchLabel());
     }
 
-    public function testNullableFields(): void
+    #[Test]
+    public function nullableFields(): void
     {
         $labels = new PokemonLabels(
             name: 'Bulbasaur',

--- a/tests/src/Unit/ResponseObject/Common/PokemonSlugRefTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonSlugRefTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Common;
 
 use App\ResponseObject\Common\PokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonSlugRef::class)]
 final class PokemonSlugRefTest extends TestCase
 {
-    public function testGetSlug(): void
+    #[Test]
+    public function getSlug(): void
     {
         $ref = new PokemonSlugRef('bulbasaur');
 

--- a/tests/src/Unit/ResponseObject/Common/PokemonTypesTest.php
+++ b/tests/src/Unit/ResponseObject/Common/PokemonTypesTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Common;
 use App\ResponseObject\Common\PokemonTypes;
 use App\ResponseObject\Label\Type;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonTypes::class)]
 final class PokemonTypesTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $primary = new Type('Grass', 'Plante', 'grass', '#78C850');
         $secondary = new Type('Poison', 'Poison', 'poison', '#A040A0');
@@ -26,7 +28,8 @@ final class PokemonTypesTest extends TestCase
         $this->assertSame($secondary, $types->getSecondary());
     }
 
-    public function testNullableSecondary(): void
+    #[Test]
+    public function nullableSecondary(): void
     {
         $primary = new Type('Fire', 'Feu', 'fire', '#FF9D55');
         $types = new PokemonTypes($primary, null);

--- a/tests/src/Unit/ResponseObject/Election/ElectionDexListItemTest.php
+++ b/tests/src/Unit/ResponseObject/Election/ElectionDexListItemTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Election\ElectionReport;
 use App\ResponseObject\Election\ElectionReportCompletion;
 use App\ResponseObject\Election\ElectionReportMetrics;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionDexListItem::class)]
 final class ElectionDexListItemTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $flags = new DexFlags(
             isShiny: false,
@@ -54,7 +56,8 @@ final class ElectionDexListItemTest extends TestCase
         $this->assertNull($item->getReport());
     }
 
-    public function testNullableGetters(): void
+    #[Test]
+    public function nullableGetters(): void
     {
         $item = new ElectionDexListItem(
             slug: 'test',
@@ -83,7 +86,8 @@ final class ElectionDexListItemTest extends TestCase
         $this->assertNull($item->getReport());
     }
 
-    public function testGettersWithReport(): void
+    #[Test]
+    public function gettersWithReport(): void
     {
         $flags = new DexFlags(
             isShiny: false,

--- a/tests/src/Unit/ResponseObject/Election/ElectionReportCompletionTest.php
+++ b/tests/src/Unit/ResponseObject/Election/ElectionReportCompletionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 
 use App\ResponseObject\Election\ElectionReportCompletion;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionReportCompletion::class)]
 final class ElectionReportCompletionTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $completion = new ElectionReportCompletion(atMaxCount: 5, underMaxCount: 1);
 

--- a/tests/src/Unit/ResponseObject/Election/ElectionReportMetricsTest.php
+++ b/tests/src/Unit/ResponseObject/Election/ElectionReportMetricsTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 use App\ResponseObject\Election\ElectionReportCompletion;
 use App\ResponseObject\Election\ElectionReportMetrics;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionReportMetrics::class)]
 final class ElectionReportMetricsTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $completion = new ElectionReportCompletion(atMaxCount: 5, underMaxCount: 1);
         $metrics = new ElectionReportMetrics(completion: $completion, dexTotalCount: 48, roundCount: 7, totalRoundCount: 8);

--- a/tests/src/Unit/ResponseObject/Election/ElectionReportTest.php
+++ b/tests/src/Unit/ResponseObject/Election/ElectionReportTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Election\ElectionReport;
 use App\ResponseObject\Election\ElectionReportCompletion;
 use App\ResponseObject\Election\ElectionReportMetrics;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionReport::class)]
 final class ElectionReportTest extends TestCase
 {
-    public function testGetters(): void
+    #[Test]
+    public function getters(): void
     {
         $metrics = new ElectionReportMetrics(
             completion: new ElectionReportCompletion(atMaxCount: 5, underMaxCount: 1),

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonFormsTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonFormsTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Label\RegionalForm;
 use App\ResponseObject\Label\SpecialForm;
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonForms::class)]
 final class TopPokemonFormsTest extends TestCase
 {
-    public function testAllNull(): void
+    #[Test]
+    public function allNull(): void
     {
         $object = new TopPokemonForms(null, null, null, null);
 
@@ -28,7 +30,8 @@ final class TopPokemonFormsTest extends TestCase
         $this->assertNull($object->getVariant());
     }
 
-    public function testAllSet(): void
+    #[Test]
+    public function allSet(): void
     {
         $category = new CategoryForm('Legendary', 'Légendaire', 'legendary');
         $regional = new RegionalForm('Alolan', "d'Alola", 'alolan');

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonGameBundlesTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonGameBundlesTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 use App\ResponseObject\Election\TopPokemonGameBundles;
 use App\ResponseObject\Election\TopPokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonGameBundles::class)]
 final class TopPokemonGameBundlesTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $ref1 = new TopPokemonSlugRef('redgreenblueyellow');
         $ref2 = new TopPokemonSlugRef('goldsilvercrystal');
@@ -25,7 +27,8 @@ final class TopPokemonGameBundlesTest extends TestCase
         $this->assertSame([$ref2], $object->getShiny());
     }
 
-    public function testEmpty(): void
+    #[Test]
+    public function empty(): void
     {
         $object = new TopPokemonGameBundles([], []);
 

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonInfoTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonInfoTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Election\TopPokemonInfo;
 use App\ResponseObject\Election\TopPokemonLabels;
 use App\ResponseObject\Election\TopPokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonInfo::class)]
 final class TopPokemonInfoTest extends TestCase
 {
-    public function testConstructorAllFields(): void
+    #[Test]
+    public function constructorAllFields(): void
     {
         $labels = new TopPokemonLabels('Mega Venusaur', 'Mega Florizarre', 'Venusaur', 'Florizarre', 'Mega', 'Mega');
         $familyLead = new TopPokemonSlugRef('bulbasaur');
@@ -54,7 +56,8 @@ final class TopPokemonInfoTest extends TestCase
         $this->assertSame($gameBundles, $object->getGameBundles());
     }
 
-    public function testNullableFields(): void
+    #[Test]
+    public function nullableFields(): void
     {
         $labels = new TopPokemonLabels('Blastoise', 'Tortank', 'Blastoise', 'Tortank', null, null);
         $familyLead = new TopPokemonSlugRef('squirtle');
@@ -82,7 +85,8 @@ final class TopPokemonInfoTest extends TestCase
         $this->assertNull($object->getRegionalDexNumber());
     }
 
-    public function testNullFamilyLead(): void
+    #[Test]
+    public function nullFamilyLead(): void
     {
         $labels = new TopPokemonLabels('Bulbasaur', 'Bulbizarre', 'Bulbasaur', 'Bulbizarre', null, null);
         $gameBundles = new TopPokemonGameBundles([], []);
@@ -107,7 +111,8 @@ final class TopPokemonInfoTest extends TestCase
         $this->assertNull($object->getFamilyLead());
     }
 
-    public function testRegionalDexNumber(): void
+    #[Test]
+    public function regionalDexNumber(): void
     {
         $labels = new TopPokemonLabels('Raichu', 'Raichu', 'Raichu', 'Raichu', null, null);
         $familyLead = new TopPokemonSlugRef('pichu');
@@ -133,7 +138,8 @@ final class TopPokemonInfoTest extends TestCase
         $this->assertSame(14, $object->getRegionalDexNumber());
     }
 
-    public function testCredits(): void
+    #[Test]
+    public function credits(): void
     {
         $labels = new TopPokemonLabels('Bulbasaur', 'Bulbizarre', 'Bulbasaur', 'Bulbizarre', null, null);
         $gameBundles = new TopPokemonGameBundles([], []);

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonLabelsTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonLabelsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 
 use App\ResponseObject\Election\TopPokemonLabels;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonLabels::class)]
 final class TopPokemonLabelsTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new TopPokemonLabels('Mega Venusaur', 'Mega Florizarre', 'Venusaur', 'Florizarre', 'Mega', 'Mega');
 
@@ -26,7 +28,8 @@ final class TopPokemonLabelsTest extends TestCase
         $this->assertSame('Mega', $object->getFormsFrenchLabel());
     }
 
-    public function testNullForms(): void
+    #[Test]
+    public function nullForms(): void
     {
         $object = new TopPokemonLabels('Bulbasaur', 'Bulbizarre', 'Bulbasaur', 'Bulbizarre', null, null);
 

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonScoreTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonScoreTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 
 use App\ResponseObject\Election\TopPokemonScore;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonScore::class)]
 final class TopPokemonScoreTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new TopPokemonScore(1250.5, true);
 

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonSlugRefTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonSlugRefTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 
 use App\ResponseObject\Election\TopPokemonSlugRef;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonSlugRef::class)]
 final class TopPokemonSlugRefTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new TopPokemonSlugRef('bulbasaur');
 

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonTest.php
@@ -12,6 +12,7 @@ use App\ResponseObject\Election\TopPokemonLabels;
 use App\ResponseObject\Election\TopPokemonScore;
 use App\ResponseObject\Election\TopPokemonTypes;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +21,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemon::class)]
 final class TopPokemonTest extends TestCase
 {
-    public function testFlattenedGettersAndCredits(): void
+    #[Test]
+    public function flattenedGettersAndCredits(): void
     {
         $smallRegular = new PokemonCredit(credit: 'PokéSprite - https://github.com/msikma/pokesprite');
         $bigShiny = new PokemonCredit(credit: 'PokemonDB - https://pokemondb.net/sprites/bulbasaur-shiny');

--- a/tests/src/Unit/ResponseObject/Election/TopPokemonTypesTest.php
+++ b/tests/src/Unit/ResponseObject/Election/TopPokemonTypesTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Election;
 use App\ResponseObject\Election\TopPokemonTypes;
 use App\ResponseObject\Label\Type;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TopPokemonTypes::class)]
 final class TopPokemonTypesTest extends TestCase
 {
-    public function testBothNull(): void
+    #[Test]
+    public function bothNull(): void
     {
         $object = new TopPokemonTypes(null, null);
 
@@ -23,7 +25,8 @@ final class TopPokemonTypesTest extends TestCase
         $this->assertNull($object->getSecondary());
     }
 
-    public function testBothSet(): void
+    #[Test]
+    public function bothSet(): void
     {
         $primary = new Type('Grass', 'Plante', 'grass', '#78C850');
         $secondary = new Type('Poison', 'Poison', 'poison', '#A040A0');
@@ -34,7 +37,8 @@ final class TopPokemonTypesTest extends TestCase
         $this->assertSame($secondary, $object->getSecondary());
     }
 
-    public function testOnlyPrimary(): void
+    #[Test]
+    public function onlyPrimary(): void
     {
         $primary = new Type('Normal', 'Normal', 'normal', '#A8A878');
         $object = new TopPokemonTypes($primary, null);

--- a/tests/src/Unit/ResponseObject/Label/CatchStateTest.php
+++ b/tests/src/Unit/ResponseObject/Label/CatchStateTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 
 use App\ResponseObject\Label\CatchState;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CatchState::class)]
 final class CatchStateTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new CatchState(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/CategoryFormTest.php
+++ b/tests/src/Unit/ResponseObject/Label/CategoryFormTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\AbstractForm;
 use App\ResponseObject\Label\CategoryForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CategoryForm::class)]
 final class CategoryFormTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new CategoryForm(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/CollectionTest.php
+++ b/tests/src/Unit/ResponseObject/Label/CollectionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 
 use App\ResponseObject\Label\Collection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Collection::class)]
 final class CollectionTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new Collection(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/FormsTest.php
+++ b/tests/src/Unit/ResponseObject/Label/FormsTest.php
@@ -10,6 +10,7 @@ use App\ResponseObject\Label\RegionalForm;
 use App\ResponseObject\Label\SpecialForm;
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Forms::class)]
 final class FormsTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $category = [new CategoryForm('Starter', 'de Départ', 'starter')];
         $regional = [
@@ -45,7 +47,8 @@ final class FormsTest extends TestCase
         $this->assertSame($variant, $object->getVariant());
     }
 
-    public function testConstructorWithAllEmpty(): void
+    #[Test]
+    public function constructorWithAllEmpty(): void
     {
         $object = new Forms([], [], [], []);
 

--- a/tests/src/Unit/ResponseObject/Label/GameBundleTest.php
+++ b/tests/src/Unit/ResponseObject/Label/GameBundleTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\GameBundle;
 use App\ResponseObject\Label\Generation;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundle::class)]
 final class GameBundleTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new GameBundle(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/GenerationTest.php
+++ b/tests/src/Unit/ResponseObject/Label/GenerationTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 
 use App\ResponseObject\Label\Generation;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Generation::class)]
 final class GenerationTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new Generation('gen_y');
 

--- a/tests/src/Unit/ResponseObject/Label/LabelsTest.php
+++ b/tests/src/Unit/ResponseObject/Label/LabelsTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\Labels;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,7 +18,8 @@ final class LabelsTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = $this->getStubLabels();
 
@@ -31,7 +33,8 @@ final class LabelsTest extends TestCase
         $this->assertCount(8, $object->getCollections());
     }
 
-    public function testConstructorWithAllEmpty(): void
+    #[Test]
+    public function constructorWithAllEmpty(): void
     {
         $object = new Labels([], [], [], [], [], [], [], []);
 

--- a/tests/src/Unit/ResponseObject/Label/RegionalFormTest.php
+++ b/tests/src/Unit/ResponseObject/Label/RegionalFormTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\AbstractForm;
 use App\ResponseObject\Label\RegionalForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RegionalForm::class)]
 final class RegionalFormTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new RegionalForm(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/SpecialFormTest.php
+++ b/tests/src/Unit/ResponseObject/Label/SpecialFormTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\AbstractForm;
 use App\ResponseObject\Label\SpecialForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(SpecialForm::class)]
 final class SpecialFormTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new SpecialForm(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/TypeTest.php
+++ b/tests/src/Unit/ResponseObject/Label/TypeTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 
 use App\ResponseObject\Label\Type;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Type::class)]
 final class TypeTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new Type(
             'Toto',

--- a/tests/src/Unit/ResponseObject/Label/VariantFormTest.php
+++ b/tests/src/Unit/ResponseObject/Label/VariantFormTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\ResponseObject\Label;
 use App\ResponseObject\Label\AbstractForm;
 use App\ResponseObject\Label\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VariantForm::class)]
 final class VariantFormTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $object = new VariantForm(
             'Toto',

--- a/tests/src/Unit/Security/AuthenticationEntryPointTest.php
+++ b/tests/src/Unit/Security/AuthenticationEntryPointTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Security;
 
 use App\Security\AuthenticationEntryPoint;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +20,8 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(AuthenticationEntryPoint::class)]
 final class AuthenticationEntryPointTest extends TestCase
 {
-    public function testStartWithNoProvider(): void
+    #[Test]
+    public function startWithNoProvider(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
@@ -35,7 +37,8 @@ final class AuthenticationEntryPointTest extends TestCase
         $this->assertSame('/home', $response->getTargetUrl());
     }
 
-    public function testStartWithGoogleProviderRedirectsToGoogleAndSavesTargetPath(): void
+    #[Test]
+    public function startWithGoogleProviderRedirectsToGoogleAndSavesTargetPath(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
@@ -53,7 +56,8 @@ final class AuthenticationEntryPointTest extends TestCase
         $this->assertSame('http://localhost/fr/some-page', $request->getSession()->get('_security_target_path'));
     }
 
-    public function testStartWithDiscordProviderRedirectsToDiscordAndSavesTargetPath(): void
+    #[Test]
+    public function startWithDiscordProviderRedirectsToDiscordAndSavesTargetPath(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router
@@ -71,7 +75,8 @@ final class AuthenticationEntryPointTest extends TestCase
         $this->assertSame('http://localhost/fr/some-page', $request->getSession()->get('_security_target_path'));
     }
 
-    public function testStartWithUnknownProviderFallsBackToHome(): void
+    #[Test]
+    public function startWithUnknownProviderFallsBackToHome(): void
     {
         $router = $this->createMock(RouterInterface::class);
         $router

--- a/tests/src/Unit/Security/AuthenticatorAuthenticateClosedTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorAuthenticateClosedTestTrait.php
@@ -11,6 +11,7 @@ use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
  */
 trait AuthenticatorAuthenticateClosedTestTrait
 {
-    public function testClosedAuthenticateUser(): void
+    #[Test]
+    public function closedAuthenticateUser(): void
     {
         $authenticator = $this->getClosedAuthenticator([]);
 
@@ -41,7 +43,8 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testClosedAuthenticateTrainer(): void
+    #[Test]
+    public function closedAuthenticateTrainer(): void
     {
         $authenticator = $this->getClosedAuthenticator(['ROLE_TRAINER']);
 
@@ -61,7 +64,8 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testClosedAuthenticateCollector(): void
+    #[Test]
+    public function closedAuthenticateCollector(): void
     {
         $authenticator = $this->getClosedAuthenticator(['ROLE_COLLECTOR']);
 
@@ -81,7 +85,8 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testClosedAuthenticateAdmin(): void
+    #[Test]
+    public function closedAuthenticateAdmin(): void
     {
         $authenticator = $this->getClosedAuthenticator(['ROLE_ADMIN']);
 
@@ -101,7 +106,8 @@ trait AuthenticatorAuthenticateClosedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testClosedAuthenticateAdminTrainer(): void
+    #[Test]
+    public function closedAuthenticateAdminTrainer(): void
     {
         $authenticator = $this->getClosedAuthenticator(['ROLE_TRAINER', 'ROLE_ADMIN']);
 

--- a/tests/src/Unit/Security/AuthenticatorAuthenticateOpenedTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorAuthenticateOpenedTestTrait.php
@@ -11,6 +11,7 @@ use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
  */
 trait AuthenticatorAuthenticateOpenedTestTrait
 {
-    public function testOpenedAuthenticateUser(): void
+    #[Test]
+    public function openedAuthenticateUser(): void
     {
         $authenticator = $this->getOpenedAuthenticator([]);
 
@@ -40,7 +42,8 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testOpenedAuthenticateTrainer(): void
+    #[Test]
+    public function openedAuthenticateTrainer(): void
     {
         $authenticator = $this->getOpenedAuthenticator(['ROLE_TRAINER']);
 
@@ -60,7 +63,8 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testOpenedAuthenticateCollector(): void
+    #[Test]
+    public function openedAuthenticateCollector(): void
     {
         $authenticator = $this->getOpenedAuthenticator(['ROLE_COLLECTOR']);
 
@@ -80,7 +84,8 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testOpenedAuthenticateAdmin(): void
+    #[Test]
+    public function openedAuthenticateAdmin(): void
     {
         $authenticator = $this->getOpenedAuthenticator(['ROLE_ADMIN']);
 
@@ -100,7 +105,8 @@ trait AuthenticatorAuthenticateOpenedTestTrait
         $this->assertEquals($this->getAuthenticatorProviderName(), $user->getProviderName());
     }
 
-    public function testOpenedAuthenticateAdminTrainer(): void
+    #[Test]
+    public function openedAuthenticateAdminTrainer(): void
     {
         $authenticator = $this->getOpenedAuthenticator(['ROLE_TRAINER', 'ROLE_ADMIN']);
 

--- a/tests/src/Unit/Security/AuthenticatorOnAuthentificationTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorOnAuthentificationTestTrait.php
@@ -9,6 +9,7 @@ use App\Service\Back\GetUserInfoService;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,7 +24,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  */
 trait AuthenticatorOnAuthentificationTestTrait
 {
-    public function testOnAuthenticationSuccessNotATrainer(): void
+    #[Test]
+    public function onAuthenticationSuccessNotATrainer(): void
     {
         $user = new User(
             '1',
@@ -53,7 +55,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationSuccessTrainer(): void
+    #[Test]
+    public function onAuthenticationSuccessTrainer(): void
     {
         $user = new User(
             '1',
@@ -85,7 +88,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationSuccessWithTargetPath(): void
+    #[Test]
+    public function onAuthenticationSuccessWithTargetPath(): void
     {
         $user = new User(
             '1',
@@ -115,7 +119,8 @@ trait AuthenticatorOnAuthentificationTestTrait
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationFailure(): void
+    #[Test]
+    public function onAuthenticationFailure(): void
     {
         $authenticator = $this->getOnAuthenticationAuthenticator([]);
 

--- a/tests/src/Unit/Security/AuthenticatorSupportTestTrait.php
+++ b/tests/src/Unit/Security/AuthenticatorSupportTestTrait.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Security;
 
 use App\Service\Back\GetUserInfoService;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -14,7 +15,8 @@ use Symfony\Component\Routing\RouterInterface;
  */
 trait AuthenticatorSupportTestTrait
 {
-    public function testSupports(): void
+    #[Test]
+    public function supports(): void
     {
         $clientRegistry = $this->createStub(ClientRegistry::class);
 

--- a/tests/src/Unit/Security/FakeAuthenticatorAuthenticateTest.php
+++ b/tests/src/Unit/Security/FakeAuthenticatorAuthenticateTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Security;
 use App\Security\FakeAuthenticator;
 use App\Security\User;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -18,7 +19,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 #[CoversClass(FakeAuthenticator::class)]
 final class FakeAuthenticatorAuthenticateTest extends TestCase
 {
-    public function testAuthenticateUser(): void
+    #[Test]
+    public function authenticateUser(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator();
 
@@ -37,7 +39,8 @@ final class FakeAuthenticatorAuthenticateTest extends TestCase
         $this->assertEquals('uninvited', $user->getUserIdentifier());
     }
 
-    public function testAuthenticateTrainer(): void
+    #[Test]
+    public function authenticateTrainer(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator();
 
@@ -56,7 +59,8 @@ final class FakeAuthenticatorAuthenticateTest extends TestCase
         $this->assertEquals('trainer', $user->getUserIdentifier());
     }
 
-    public function testAuthenticateCollector(): void
+    #[Test]
+    public function authenticateCollector(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator();
 
@@ -75,7 +79,8 @@ final class FakeAuthenticatorAuthenticateTest extends TestCase
         $this->assertEquals('collector', $user->getUserIdentifier());
     }
 
-    public function testAuthenticateAdmin(): void
+    #[Test]
+    public function authenticateAdmin(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator();
 
@@ -94,7 +99,8 @@ final class FakeAuthenticatorAuthenticateTest extends TestCase
         $this->assertEquals('admin', $user->getUserIdentifier());
     }
 
-    public function testAuthenticateTokenNeverExpires(): void
+    #[Test]
+    public function authenticateTokenNeverExpires(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator();
 

--- a/tests/src/Unit/Security/FakeAuthenticatorOnAuthentificationTest.php
+++ b/tests/src/Unit/Security/FakeAuthenticatorOnAuthentificationTest.php
@@ -8,6 +8,7 @@ use App\Security\FakeAuthenticator;
 use App\Security\User;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +25,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 #[CoversClass(FakeAuthenticator::class)]
 final class FakeAuthenticatorOnAuthentificationTest extends TestCase
 {
-    public function testOnAuthenticationSuccessNotATrainer(): void
+    #[Test]
+    public function onAuthenticationSuccessNotATrainer(): void
     {
         $user = new User(
             '1',
@@ -52,7 +54,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationSuccessTrainer(): void
+    #[Test]
+    public function onAuthenticationSuccessTrainer(): void
     {
         $user = new User(
             '1',
@@ -84,7 +87,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationSuccessWithTargetPath(): void
+    #[Test]
+    public function onAuthenticationSuccessWithTargetPath(): void
     {
         $user = new User(
             '1',
@@ -114,7 +118,8 @@ final class FakeAuthenticatorOnAuthentificationTest extends TestCase
         $this->assertSame('TestProvider', $session->get('_security_provider'));
     }
 
-    public function testOnAuthenticationFailure(): void
+    #[Test]
+    public function onAuthenticationFailure(): void
     {
         $fakeAuthenticator = $this->getFakeAuthenticator([]);
 

--- a/tests/src/Unit/Security/FakeAuthenticatorTest.php
+++ b/tests/src/Unit/Security/FakeAuthenticatorTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Security;
 
 use App\Security\FakeAuthenticator;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -16,7 +17,8 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(FakeAuthenticator::class)]
 final class FakeAuthenticatorTest extends TestCase
 {
-    public function testSupports(): void
+    #[Test]
+    public function supports(): void
     {
         $authenticator = new FakeAuthenticator(
             $this->createStub(RouterInterface::class),

--- a/tests/src/Unit/Security/UserGetProfileTest.php
+++ b/tests/src/Unit/Security/UserGetProfileTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Security;
 use App\Security\User;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(User::class)]
 final class UserGetProfileTest extends TestCase
 {
-    public function testGetProfileAsDefault(): void
+    #[Test]
+    public function getProfileAsDefault(): void
     {
         $user = new User(
             '12',
@@ -26,7 +28,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('user', $user->getProfile());
     }
 
-    public function testGetProfileAsTrainer(): void
+    #[Test]
+    public function getProfileAsTrainer(): void
     {
         $user = new User(
             '12',
@@ -38,7 +41,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('trainer', $user->getProfile());
     }
 
-    public function testGetProfileAsCollector(): void
+    #[Test]
+    public function getProfileAsCollector(): void
     {
         $user = new User(
             '12',
@@ -50,7 +54,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('collector', $user->getProfile());
     }
 
-    public function testGetProfileAsAdmin(): void
+    #[Test]
+    public function getProfileAsAdmin(): void
     {
         $user = new User(
             '12',
@@ -62,7 +67,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('admin', $user->getProfile());
     }
 
-    public function testGetProfileAsTrainerAndAdmin(): void
+    #[Test]
+    public function getProfileAsTrainerAndAdmin(): void
     {
         $user = new User(
             '12',
@@ -75,7 +81,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('admin', $user->getProfile());
     }
 
-    public function testGetProfileAsCollectorAndAdmin(): void
+    #[Test]
+    public function getProfileAsCollectorAndAdmin(): void
     {
         $user = new User(
             '12',
@@ -88,7 +95,8 @@ final class UserGetProfileTest extends TestCase
         $this->assertEquals('admin', $user->getProfile());
     }
 
-    public function testGetProfileAsTrainerAndCollector(): void
+    #[Test]
+    public function getProfileAsTrainerAndCollector(): void
     {
         $user = new User(
             '12',

--- a/tests/src/Unit/Security/UserProviderTest.php
+++ b/tests/src/Unit/Security/UserProviderTest.php
@@ -9,6 +9,7 @@ use App\Security\UserProvider;
 use App\Security\UserRefresher;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[CoversClass(UserProvider::class)]
 final class UserProviderTest extends TestCase
 {
-    public function testLoadUserByIdentifier(): void
+    #[Test]
+    public function loadUserByIdentifier(): void
     {
         $refresher = $this->createMock(UserRefresher::class);
         $refresher
@@ -36,7 +38,8 @@ final class UserProviderTest extends TestCase
         $provider->loadUserByIdentifier('douze');
     }
 
-    public function testRefreshUser(): void
+    #[Test]
+    public function refreshUser(): void
     {
         $user = new User(
             'douze',
@@ -60,7 +63,8 @@ final class UserProviderTest extends TestCase
         $provider->refreshUser($user);
     }
 
-    public function testRefreshUserWrongUser(): void
+    #[Test]
+    public function refreshUserWrongUser(): void
     {
         $refresher = $this->createMock(UserRefresher::class);
         $refresher
@@ -78,7 +82,8 @@ final class UserProviderTest extends TestCase
         $provider->refreshUser($notUser);
     }
 
-    public function testUpgradePassword(): void
+    #[Test]
+    public function upgradePassword(): void
     {
         $refresher = $this->createMock(UserRefresher::class);
         $refresher
@@ -95,7 +100,8 @@ final class UserProviderTest extends TestCase
         $this->assertSame($initialUser, $user);
     }
 
-    public function testSupportsClass(): void
+    #[Test]
+    public function supportsClass(): void
     {
         $refresher = $this->createMock(UserRefresher::class);
         $refresher

--- a/tests/src/Unit/Security/UserRefresherTest.php
+++ b/tests/src/Unit/Security/UserRefresherTest.php
@@ -13,6 +13,7 @@ use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
@@ -23,7 +24,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
 #[CoversClass(UserRefresher::class)]
 final class UserRefresherTest extends TestCase
 {
-    public function testRefreshExpiredTokenPreservesOldRefreshTokenWhenProviderOmitsIt(): void
+    #[Test]
+    public function refreshExpiredTokenPreservesOldRefreshTokenWhenProviderOmitsIt(): void
     {
         $oauthProvider = $this->createMock(AbstractProvider::class);
         $expectedExpiry = time() + 3600;
@@ -76,7 +78,8 @@ final class UserRefresherTest extends TestCase
         $this->assertSame($expectedExpiry, $newUser->getAccessToken()->getExpires());
     }
 
-    public function testRefreshExpiredTokenUsesNewRefreshTokenWhenProviderReturnsOne(): void
+    #[Test]
+    public function refreshExpiredTokenUsesNewRefreshTokenWhenProviderReturnsOne(): void
     {
         $oauthProvider = $this->createMock(AbstractProvider::class);
         $oauthProvider
@@ -110,7 +113,8 @@ final class UserRefresherTest extends TestCase
         $this->assertSame('new-refresh', $newUser->getAccessToken()->getRefreshToken());
     }
 
-    public function testRefreshExpiredTokenWithoutRefreshToken(): void
+    #[Test]
+    public function refreshExpiredTokenWithoutRefreshToken(): void
     {
         $clientRegistry = $this->createMock(ClientRegistry::class);
         $clientRegistry
@@ -135,7 +139,8 @@ final class UserRefresherTest extends TestCase
         $provider->refresh($user);
     }
 
-    public function testRefreshExpiredTokenWhenProviderRejectsRefreshToken(): void
+    #[Test]
+    public function refreshExpiredTokenWhenProviderRejectsRefreshToken(): void
     {
         $oauthProvider = $this->createMock(AbstractProvider::class);
         $identityProviderException = new IdentityProviderException('invalid_grant', 400, 'invalid_grant');
@@ -185,7 +190,8 @@ final class UserRefresherTest extends TestCase
         $refresher->refresh($user);
     }
 
-    public function testRefreshExpiredTokenLooksUpClientWithLowercasedProviderName(): void
+    #[Test]
+    public function refreshExpiredTokenLooksUpClientWithLowercasedProviderName(): void
     {
         $invalidClientException = new InvalidOAuth2ClientException(
             'There is no OAuth2 client called "Google". Available are: google, discord'
@@ -231,7 +237,8 @@ final class UserRefresherTest extends TestCase
         $refresher->refresh($user);
     }
 
-    public function testRefreshNotExpiredToken(): void
+    #[Test]
+    public function refreshNotExpiredToken(): void
     {
         $clientRegistry = $this->createMock(ClientRegistry::class);
         $clientRegistry

--- a/tests/src/Unit/Security/UserRolesTest.php
+++ b/tests/src/Unit/Security/UserRolesTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Security;
 use App\Security\User;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(User::class)]
 final class UserRolesTest extends TestCase
 {
-    public function testAddAdminRole(): void
+    #[Test]
+    public function addAdminRole(): void
     {
         $user = new User(
             '12',
@@ -29,7 +31,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_ADMIN'], $user->getRoles());
     }
 
-    public function testAddTrainerRole(): void
+    #[Test]
+    public function addTrainerRole(): void
     {
         $user = new User(
             '12',
@@ -43,7 +46,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_TRAINER'], $user->getRoles());
     }
 
-    public function testAddCollectorRole(): void
+    #[Test]
+    public function addCollectorRole(): void
     {
         $user = new User(
             '12',
@@ -57,7 +61,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_COLLECTOR'], $user->getRoles());
     }
 
-    public function testAddTrainerAndAdminRole(): void
+    #[Test]
+    public function addTrainerAndAdminRole(): void
     {
         $user = new User(
             '12',
@@ -72,7 +77,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_TRAINER', 'ROLE_ADMIN'], $user->getRoles());
     }
 
-    public function testAddTrainerAndCollectorRole(): void
+    #[Test]
+    public function addTrainerAndCollectorRole(): void
     {
         $user = new User(
             '12',
@@ -87,7 +93,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_TRAINER', 'ROLE_COLLECTOR'], $user->getRoles());
     }
 
-    public function testAddTrainerRoleTwice(): void
+    #[Test]
+    public function addTrainerRoleTwice(): void
     {
         $user = new User(
             '12',
@@ -102,7 +109,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_TRAINER'], $user->getRoles());
     }
 
-    public function testAddAdminRoleTwice(): void
+    #[Test]
+    public function addAdminRoleTwice(): void
     {
         $user = new User(
             '12',
@@ -117,7 +125,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_ADMIN'], $user->getRoles());
     }
 
-    public function testAddCollectorRoleTwice(): void
+    #[Test]
+    public function addCollectorRoleTwice(): void
     {
         $user = new User(
             '12',
@@ -132,7 +141,8 @@ final class UserRolesTest extends TestCase
         $this->assertEquals(['ROLE_USER', 'ROLE_COLLECTOR'], $user->getRoles());
     }
 
-    public function testIsATrainer(): void
+    #[Test]
+    public function isATrainer(): void
     {
         $user = new User(
             '12',
@@ -147,7 +157,8 @@ final class UserRolesTest extends TestCase
         $this->assertTrue($user->isATrainer());
     }
 
-    public function testIsACollector(): void
+    #[Test]
+    public function isACollector(): void
     {
         $user = new User(
             '12',
@@ -162,7 +173,8 @@ final class UserRolesTest extends TestCase
         $this->assertTrue($user->isACollector());
     }
 
-    public function testIsAnAdmin(): void
+    #[Test]
+    public function isAnAdmin(): void
     {
         $user = new User(
             '12',
@@ -177,7 +189,8 @@ final class UserRolesTest extends TestCase
         $this->assertTrue($user->isAnAdmin());
     }
 
-    public function testIsATrainerAndAnAdmin(): void
+    #[Test]
+    public function isATrainerAndAnAdmin(): void
     {
         $user = new User(
             '12',
@@ -197,7 +210,8 @@ final class UserRolesTest extends TestCase
         $this->assertFalse($user->isACollector());
     }
 
-    public function testIsATrainerAndACollector(): void
+    #[Test]
+    public function isATrainerAndACollector(): void
     {
         $user = new User(
             '12',

--- a/tests/src/Unit/Security/UserTest.php
+++ b/tests/src/Unit/Security/UserTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Security;
 use App\Security\User;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(User::class)]
 final class UserTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $user = new User(
             '12',
@@ -29,7 +31,8 @@ final class UserTest extends TestCase
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
     }
 
-    public function testGetAccessToken(): void
+    #[Test]
+    public function getAccessToken(): void
     {
         $user = new User(
             '12',

--- a/tests/src/Unit/Security/UserTokenServiceTest.php
+++ b/tests/src/Unit/Security/UserTokenServiceTest.php
@@ -9,6 +9,7 @@ use App\Security\User;
 use App\Security\UserTokenService;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -18,7 +19,8 @@ use Symfony\Bundle\SecurityBundle\Security;
 #[CoversClass(UserTokenService::class)]
 final class UserTokenServiceTest extends TestCase
 {
-    public function testGetLoggedUserId(): void
+    #[Test]
+    public function getLoggedUserId(): void
     {
         $security = $this->createMock(Security::class);
         $security
@@ -40,7 +42,8 @@ final class UserTokenServiceTest extends TestCase
         );
     }
 
-    public function testFailGetLoggedUserId(): void
+    #[Test]
+    public function failGetLoggedUserId(): void
     {
         $security = $this->createMock(Security::class);
         $security
@@ -56,7 +59,8 @@ final class UserTokenServiceTest extends TestCase
         $service->getLoggedUserId();
     }
 
-    public function testCompare(): void
+    #[Test]
+    public function compare(): void
     {
         $security = $this->createMock(Security::class);
         $security
@@ -75,7 +79,8 @@ final class UserTokenServiceTest extends TestCase
         $this->assertTrue($service->compare('7b52009b64fd0a2a49e6d8a939753077792b0554'));
     }
 
-    public function testCompareWithNoLoggedUser(): void
+    #[Test]
+    public function compareWithNoLoggedUser(): void
     {
         $security = $this->createMock(Security::class);
         $security
@@ -88,7 +93,8 @@ final class UserTokenServiceTest extends TestCase
         $this->assertFalse($service->compare('7b52009b64fd0a2a49e6d8a939753077792b0554'));
     }
 
-    public function testGetLoggedUser(): void
+    #[Test]
+    public function getLoggedUser(): void
     {
         $user = new User(
             '12',
@@ -111,7 +117,8 @@ final class UserTokenServiceTest extends TestCase
         );
     }
 
-    public function testGetLoggedUserTokenWithoutUser(): void
+    #[Test]
+    public function getLoggedUserTokenWithoutUser(): void
     {
         $security = $this->createMock(Security::class);
         $security

--- a/tests/src/Unit/Service/AppVersionServiceTest.php
+++ b/tests/src/Unit/Service/AppVersionServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\AppVersionService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Filesystem\Filesystem;
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\ItemInterface;
 #[CoversClass(AppVersionService::class)]
 final class AppVersionServiceTest extends TestCase
 {
-    public function testGetVersionReturnsFileContent(): void
+    #[Test]
+    public function getVersionReturnsFileContent(): void
     {
         file_put_contents(self::getDir().'/resources/metadata/version', '1.2.12');
 
@@ -31,7 +33,8 @@ final class AppVersionServiceTest extends TestCase
         $this->assertSame('1.2.12', $service->getVersion());
     }
 
-    public function testGetVersionReturnsFallbackForMissingFile(): void
+    #[Test]
+    public function getVersionReturnsFallbackForMissingFile(): void
     {
         $service = new AppVersionService(
             self::getDir(),
@@ -42,7 +45,8 @@ final class AppVersionServiceTest extends TestCase
         $this->assertSame('0.0.toto', $service->getVersion('non_existent_file'));
     }
 
-    public function testGetVersionIsCached(): void
+    #[Test]
+    public function getVersionIsCached(): void
     {
         $tmpDir = sys_get_temp_dir().'/pokenini_version_test_'.uniqid();
         mkdir($tmpDir.'/resources/metadata', 0o755, true);
@@ -59,7 +63,8 @@ final class AppVersionServiceTest extends TestCase
         rmdir($tmpDir);
     }
 
-    public function testGetVersionInvalidatedOnFileChange(): void
+    #[Test]
+    public function getVersionInvalidatedOnFileChange(): void
     {
         $tmpDir = sys_get_temp_dir().'/pokenini_version_test_'.uniqid();
         mkdir($tmpDir.'/resources/metadata', 0o755, true);
@@ -81,7 +86,8 @@ final class AppVersionServiceTest extends TestCase
         rmdir($tmpDir);
     }
 
-    public function testGetVersionCachesPerFilename(): void
+    #[Test]
+    public function getVersionCachesPerFilename(): void
     {
         $tmpDir = sys_get_temp_dir().'/pokenini_version_test_'.uniqid();
         mkdir($tmpDir.'/resources/metadata', 0o755, true);
@@ -100,7 +106,8 @@ final class AppVersionServiceTest extends TestCase
         rmdir($tmpDir);
     }
 
-    public function testGetVersionUsesCorrectCacheKey(): void
+    #[Test]
+    public function getVersionUsesCorrectCacheKey(): void
     {
         $tmpDir = sys_get_temp_dir().'/pokenini_version_test_'.uniqid();
         mkdir($tmpDir.'/resources/metadata', 0o755, true);
@@ -125,7 +132,8 @@ final class AppVersionServiceTest extends TestCase
         rmdir($tmpDir);
     }
 
-    public function testGetVersionIncludesFilenameInCacheKey(): void
+    #[Test]
+    public function getVersionIncludesFilenameInCacheKey(): void
     {
         $tmpDir = sys_get_temp_dir().'/pokenini_version_test_'.uniqid();
         mkdir($tmpDir.'/resources/metadata', 0o755, true);
@@ -150,7 +158,8 @@ final class AppVersionServiceTest extends TestCase
         rmdir($tmpDir);
     }
 
-    public function testGetVersionCallbackReadsFile(): void
+    #[Test]
+    public function getVersionCallbackReadsFile(): void
     {
         $item = $this->createStub(ItemInterface::class);
 
@@ -170,7 +179,8 @@ final class AppVersionServiceTest extends TestCase
         $this->assertSame('1.2.12', $service->getVersion());
     }
 
-    public function testGetUpdatedAtReturnsFileMtime(): void
+    #[Test]
+    public function getUpdatedAtReturnsFileMtime(): void
     {
         file_put_contents(self::getDir().'/resources/metadata/version', '1.2.12');
         $expectedMtime = filemtime(self::getDir().'/resources/metadata/version');
@@ -185,7 +195,8 @@ final class AppVersionServiceTest extends TestCase
         $this->assertSame($expectedMtime, $service->getUpdatedAt()?->getTimestamp());
     }
 
-    public function testGetUpdatedAtReturnsNullForMissingFile(): void
+    #[Test]
+    public function getUpdatedAtReturnsNullForMissingFile(): void
     {
         $service = new AppVersionService(self::getDir(), new ArrayAdapter(), new Filesystem());
 

--- a/tests/src/Unit/Service/Back/AdminActionServiceTest.php
+++ b/tests/src/Unit/Service/Back/AdminActionServiceTest.php
@@ -11,6 +11,7 @@ use App\Service\Back\AdminActionService;
 use App\Tests\Utils\WithConsecutive;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -23,7 +24,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(AdminActionService::class)]
 final class AdminActionServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -114,7 +116,8 @@ final class AdminActionServiceTest extends TestCase
         $this->assertSame('', $adminAction->error);
     }
 
-    public function testExecuteWithContentAndError(): void
+    #[Test]
+    public function executeWithContentAndError(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -205,7 +208,8 @@ final class AdminActionServiceTest extends TestCase
         $this->assertSame('oops', $adminAction->error);
     }
 
-    public function testExecuteWithoutLoggedUser(): void
+    #[Test]
+    public function executeWithoutLoggedUser(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger

--- a/tests/src/Unit/Service/Back/GetActionLogsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetActionLogsServiceTest.php
@@ -9,6 +9,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetActionLogsService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -33,7 +34,8 @@ final class GetActionLogsServiceTest extends AbstractTestBackService
     public const ENDPOINT = 'istration/action-logs';
     public const RESPONSE_CONTENT = '/app/tests/resources/unit/service/back/action-logs.json';
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         /** @var GetActionLogsService $service */
         $service = $this->getServiceWithLoggedUser(
@@ -47,7 +49,8 @@ final class GetActionLogsServiceTest extends AbstractTestBackService
         $this->assertServiceGet($service);
     }
 
-    public function testWithoutLoggedUser(): void
+    #[Test]
+    public function withoutLoggedUser(): void
     {
         /** @var GetActionLogsService $service */
         $service = $this->getServiceWithoutLoggedUser(

--- a/tests/src/Unit/Service/Back/GetAlbumDexListServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetAlbumDexListServiceTest.php
@@ -12,6 +12,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetAlbumDexListService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(GetAlbumDexListService::class)]
 final class GetAlbumDexListServiceTest extends AbstractTestBackService
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = '{"doesnt": "matter"}';
 
@@ -45,7 +47,8 @@ final class GetAlbumDexListServiceTest extends AbstractTestBackService
         );
     }
 
-    public function testGetWithEmptyTrainerId(): void
+    #[Test]
+    public function getWithEmptyTrainerId(): void
     {
         $json = '{"doesnt": "matter"}';
 
@@ -68,7 +71,8 @@ final class GetAlbumDexListServiceTest extends AbstractTestBackService
         );
     }
 
-    public function testGetWithTrainerId(): void
+    #[Test]
+    public function getWithTrainerId(): void
     {
         $json = '{"doesnt": "matter"}';
 

--- a/tests/src/Unit/Service/Back/GetCreditsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetCreditsServiceTest.php
@@ -9,6 +9,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetCreditsService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -23,7 +24,8 @@ final class GetCreditsServiceTest extends AbstractTestBackService
     public const ENDPOINT = 'credits';
     public const RESPONSE_CONTENT = '/app/tests/resources/unit/service/back/credits.json';
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = (new Filesystem())->readFile(self::RESPONSE_CONTENT);
 

--- a/tests/src/Unit/Service/Back/GetElectionDexListServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetElectionDexListServiceTest.php
@@ -10,6 +10,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetElectionDexListService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -20,7 +21,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(GetElectionDexListService::class)]
 final class GetElectionDexListServiceTest extends AbstractTestBackService
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = '{"doesnt": "matter"}';
 
@@ -43,7 +45,8 @@ final class GetElectionDexListServiceTest extends AbstractTestBackService
         );
     }
 
-    public function testWithoutLoggedUser(): void
+    #[Test]
+    public function withoutLoggedUser(): void
     {
         $json = '{"doesnt": "matter"}';
 

--- a/tests/src/Unit/Service/Back/GetElectionIndexServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetElectionIndexServiceTest.php
@@ -10,6 +10,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetElectionIndexService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -23,7 +24,8 @@ final class GetElectionIndexServiceTest extends AbstractTestBackService
 {
     public const RESPONSE_CONTENT = '{"type":"pick"}';
 
-    public function testGetWithElectionSlug(): void
+    #[Test]
+    public function getWithElectionSlug(): void
     {
         $serializer = $this->createMock(SerializerInterface::class);
         $electionIndex = $this->getElectionIndex();
@@ -48,7 +50,8 @@ final class GetElectionIndexServiceTest extends AbstractTestBackService
         $this->assertSame($electionIndex, $result);
     }
 
-    public function testGetWithoutElectionSlug(): void
+    #[Test]
+    public function getWithoutElectionSlug(): void
     {
         $serializer = $this->createMock(SerializerInterface::class);
         $electionIndex = $this->getElectionIndex();
@@ -73,7 +76,8 @@ final class GetElectionIndexServiceTest extends AbstractTestBackService
         $this->assertSame($electionIndex, $result);
     }
 
-    public function testClientException(): void
+    #[Test]
+    public function clientException(): void
     {
         $serializer = $this->createStub(SerializerInterface::class);
 

--- a/tests/src/Unit/Service/Back/GetImagePipelineStatusServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetImagePipelineStatusServiceTest.php
@@ -8,6 +8,7 @@ use App\Exception\NoLoggedUserException;
 use App\Security\UserTokenServiceInterface;
 use App\Service\Back\GetImagePipelineStatusService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -29,21 +30,24 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(GetImagePipelineStatusService::class)]
 final class GetImagePipelineStatusServiceTest extends TestCase
 {
-    public function testGetReturnsNullWhenNoRunExists(): void
+    #[Test]
+    public function getReturnsNullWhenNoRunExists(): void
     {
         $service = $this->getService('{}', 'https://back.domain/istration/action/trigger/update_images/status');
 
         $this->assertNull($service->get(false));
     }
 
-    public function testGetWithRefreshAppendsQueryParam(): void
+    #[Test]
+    public function getWithRefreshAppendsQueryParam(): void
     {
         $service = $this->getService('{}', 'https://back.domain/istration/action/trigger/update_images/status?refresh=1');
 
         $this->assertNull($service->get(true));
     }
 
-    public function testGetReturnsNullWhenNoRunExistsWithSurroundingWhitespace(): void
+    #[Test]
+    public function getReturnsNullWhenNoRunExistsWithSurroundingWhitespace(): void
     {
         // Proves the trim() call matters: pokenini-back's JsonResponse body
         // could plausibly include trailing whitespace/newlines depending on
@@ -53,7 +57,8 @@ final class GetImagePipelineStatusServiceTest extends TestCase
         $this->assertNull($service->get(false));
     }
 
-    public function testGetDeserializesStatus(): void
+    #[Test]
+    public function getDeserializesStatus(): void
     {
         $json = <<<'JSON'
             {

--- a/tests/src/Unit/Service/Back/GetLabelsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetLabelsServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetLabelsService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -26,7 +27,8 @@ final class GetLabelsServiceTest extends AbstractTestBackService
     public const ENDPOINT = 'labels';
     public const RESPONSE_CONTENT = '/app/tests/resources/unit/service/back/labels.json';
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = (new Filesystem())->readFile(self::RESPONSE_CONTENT);
 
@@ -65,7 +67,8 @@ final class GetLabelsServiceTest extends AbstractTestBackService
         $this->assertCount(8, $object->getCollections());
     }
 
-    public function testWithoutLoggedUser(): void
+    #[Test]
+    public function withoutLoggedUser(): void
     {
         $json = (new Filesystem())->readFile(self::RESPONSE_CONTENT);
 

--- a/tests/src/Unit/Service/Back/GetPokedexServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetPokedexServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetPokedexService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -22,7 +23,8 @@ final class GetPokedexServiceTest extends AbstractTestBackService
 {
     use ResponseObjectTrait;
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = '{"doesnt": "matter"}';
 
@@ -66,7 +68,8 @@ final class GetPokedexServiceTest extends AbstractTestBackService
         $this->assertSame(0, $album->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetWithTrainerId(): void
+    #[Test]
+    public function getWithTrainerId(): void
     {
         $json = '{"doesnt": "matter"}';
 

--- a/tests/src/Unit/Service/Back/GetPokemonsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetPokemonsServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetPokemonsService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -23,7 +24,8 @@ final class GetPokemonsServiceTest extends AbstractTestBackService
 {
     use ResponseObjectTrait;
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $electionList = $this
             ->getService(
@@ -42,7 +44,8 @@ final class GetPokemonsServiceTest extends AbstractTestBackService
         $this->assertCount(3, $electionList->getItems());
     }
 
-    public function testGetWithFilters(): void
+    #[Test]
+    public function getWithFilters(): void
     {
         $electionList = $this
             ->getService(
@@ -69,7 +72,8 @@ final class GetPokemonsServiceTest extends AbstractTestBackService
         $this->assertCount(3, $electionList->getItems());
     }
 
-    public function testGetWithoutLoggedUser(): void
+    #[Test]
+    public function getWithoutLoggedUser(): void
     {
         $dir = '/app/tests/resources/unit/service/back';
         $filename = "{$dir}/pokemons_123__3.json";

--- a/tests/src/Unit/Service/Back/GetReportsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetReportsServiceTest.php
@@ -8,6 +8,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetReportsService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -22,7 +23,8 @@ final class GetReportsServiceTest extends AbstractTestBackService
     public const ENDPOINT = 'istration/reports';
     public const RESPONSE_CONTENT = '/app/tests/resources/unit/service/back/reports.json';
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         /** @var GetReportsService $service */
         $service = $this->getServiceWithLoggedUser(
@@ -41,7 +43,8 @@ final class GetReportsServiceTest extends AbstractTestBackService
         $this->assertCount(6, $reports['catch_state_usage']);
     }
 
-    public function testGetWithoutLoggedUser(): void
+    #[Test]
+    public function getWithoutLoggedUser(): void
     {
         /** @var GetReportsService $service */
         $service = $this->getServiceWithoutLoggedUser(

--- a/tests/src/Unit/Service/Back/GetTrainerDexListServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetTrainerDexListServiceTest.php
@@ -12,6 +12,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\GetTrainerDexListService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(GetTrainerDexListService::class)]
 final class GetTrainerDexListServiceTest extends AbstractTestBackService
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $json = '{"doesnt": "matter"}';
 

--- a/tests/src/Unit/Service/Back/GetUserInfoServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetUserInfoServiceTest.php
@@ -11,6 +11,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\GetUserInfoService;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,7 +28,8 @@ final class GetUserInfoServiceTest extends TestCase
     public const ENDPOINT = 'user';
     public const RESPONSE_CONTENT = '/app/tests/resources/unit/service/back/user.json';
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -111,7 +113,8 @@ final class GetUserInfoServiceTest extends TestCase
         $this->assertSame(['ROLE_TRAINER', 'ROLE_COLLECTOR'], $userInfo->getRoles());
     }
 
-    public function testGetWithoutLoggedUser(): void
+    #[Test]
+    public function getWithoutLoggedUser(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger

--- a/tests/src/Unit/Service/Back/GetVersionsServiceTest.php
+++ b/tests/src/Unit/Service/Back/GetVersionsServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\Back\GetVersionsService;
 use App\Tests\Utils\RealSerializerFactory;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Exception\TransportException;
@@ -24,7 +25,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(GetVersionsService::class)]
 final class GetVersionsServiceTest extends TestCase
 {
-    public function testGetDeserializesVersions(): void
+    #[Test]
+    public function getDeserializesVersions(): void
     {
         $versions = $this->getServiceWithResponseBody(
             '{"back":{"version":"1.2.12","updated_at":"2026-08-05T09:12:00+00:00"},"api":{"version":"1.2.13","updated_at":"2026-08-04T21:47:00+00:00"}}'
@@ -36,7 +38,8 @@ final class GetVersionsServiceTest extends TestCase
         $this->assertSame('2026-08-04T21:47:00+00:00', $versions->api->updatedAt?->format(\DateTimeInterface::ATOM));
     }
 
-    public function testGetHandlesNullApiField(): void
+    #[Test]
+    public function getHandlesNullApiField(): void
     {
         $versions = $this->getServiceWithResponseBody(
             '{"back":{"version":"1.2.12","updated_at":"2026-08-05T09:12:00+00:00"},"api":{"version":null,"updated_at":null}}'
@@ -47,7 +50,8 @@ final class GetVersionsServiceTest extends TestCase
         $this->assertNull($versions->api->updatedAt);
     }
 
-    public function testGetReturnsNullFieldsOnTransportError(): void
+    #[Test]
+    public function getReturnsNullFieldsOnTransportError(): void
     {
         $client = $this->createMock(HttpClientInterface::class);
         $client
@@ -66,7 +70,8 @@ final class GetVersionsServiceTest extends TestCase
         $this->assertNull($versions->api->updatedAt);
     }
 
-    public function testGetReturnsNullFieldsOnSerializeError(): void
+    #[Test]
+    public function getReturnsNullFieldsOnSerializeError(): void
     {
         $userTokenService = $this->buildUserTokenService();
 
@@ -117,7 +122,8 @@ final class GetVersionsServiceTest extends TestCase
      * Symfony\Component\Serializer\Exception\NotNormalizableValueException — not \TypeError —
      * when a field's JSON type doesn't match the declared PHP type.
      */
-    public function testGetReturnsNullFieldsOnNotNormalizableValue(): void
+    #[Test]
+    public function getReturnsNullFieldsOnNotNormalizableValue(): void
     {
         $versions = $this->getServiceWithResponseBody(
             '{"back":{"x":1},"api":{"version":null,"updated_at":null}}'

--- a/tests/src/Unit/Service/Back/ModifyAlbumServiceTest.php
+++ b/tests/src/Unit/Service/Back/ModifyAlbumServiceTest.php
@@ -8,6 +8,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\ModifyAlbumService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -18,7 +19,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(ModifyAlbumService::class)]
 final class ModifyAlbumServiceTest extends AbstractTestBackService
 {
-    public function testModifyPatch(): void
+    #[Test]
+    public function modifyPatch(): void
     {
         $this
             ->getService(
@@ -35,7 +37,8 @@ final class ModifyAlbumServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testModifyPut(): void
+    #[Test]
+    public function modifyPut(): void
     {
         $this
             ->getService(
@@ -52,7 +55,8 @@ final class ModifyAlbumServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testModifyPost(): void
+    #[Test]
+    public function modifyPost(): void
     {
         $logger = $this->createStub(LoggerInterface::class);
 
@@ -81,7 +85,8 @@ final class ModifyAlbumServiceTest extends AbstractTestBackService
         );
     }
 
-    public function testModifyPatchWithoutLoggedUser(): void
+    #[Test]
+    public function modifyPatchWithoutLoggedUser(): void
     {
         /** @var ModifyAlbumService $service */
         $service = $this->getServiceWithoutLoggedUser(

--- a/tests/src/Unit/Service/Back/ModifyDexServiceTest.php
+++ b/tests/src/Unit/Service/Back/ModifyDexServiceTest.php
@@ -8,6 +8,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\ModifyDexService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -18,7 +19,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(ModifyDexService::class)]
 final class ModifyDexServiceTest extends AbstractTestBackService
 {
-    public function testModify(): void
+    #[Test]
+    public function modify(): void
     {
         $this
             ->getService(
@@ -32,7 +34,8 @@ final class ModifyDexServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testModifyWithoutLoggedUser(): void
+    #[Test]
+    public function modifyWithoutLoggedUser(): void
     {
         /** @var ModifyDexService $service */
         $service = $this->getServiceWithoutLoggedUser(

--- a/tests/src/Unit/Service/Back/PostElectionVoteServiceTest.php
+++ b/tests/src/Unit/Service/Back/PostElectionVoteServiceTest.php
@@ -9,6 +9,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\PostElectionVoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -20,7 +21,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(PostElectionVoteService::class)]
 final class PostElectionVoteServiceTest extends AbstractTestBackService
 {
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -37,7 +39,8 @@ final class PostElectionVoteServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testVoteAllLosers(): void
+    #[Test]
+    public function voteAllLosers(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -54,7 +57,8 @@ final class PostElectionVoteServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testVoteAllWinners(): void
+    #[Test]
+    public function voteAllWinners(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -71,7 +75,8 @@ final class PostElectionVoteServiceTest extends AbstractTestBackService
         ;
     }
 
-    public function testVoteWithoutLoggedUser(): void
+    #[Test]
+    public function voteWithoutLoggedUser(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',

--- a/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
+++ b/tests/src/Unit/Service/Back/TrainerDexLinkServiceTest.php
@@ -9,6 +9,7 @@ use App\Security\UserTokenServiceInterface;
 use App\Service\Back\AbstractBackService;
 use App\Service\Back\TrainerDexLinkService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -19,7 +20,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(TrainerDexLinkService::class)]
 final class TrainerDexLinkServiceTest extends AbstractTestBackService
 {
-    public function testList(): void
+    #[Test]
+    public function list(): void
     {
         $json = '[{"id":"link-1"}]';
         $links = [new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique')];
@@ -37,7 +39,8 @@ final class TrainerDexLinkServiceTest extends AbstractTestBackService
         $this->assertSame($links, $service->list('national'));
     }
 
-    public function testListAsJson(): void
+    #[Test]
+    public function listAsJson(): void
     {
         $json = '[{"id":"link-1"}]';
         $links = [new TrainerDexLink('link-1', 'to', 'shiny', 'Shiny Living', 'Vivarium Chromatique')];
@@ -60,7 +63,8 @@ final class TrainerDexLinkServiceTest extends AbstractTestBackService
         $this->assertSame($json, $service->listAsJson('national'));
     }
 
-    public function testCreate(): void
+    #[Test]
+    public function create(): void
     {
         /** @var TrainerDexLinkService $service */
         $service = $this->getServiceWithLoggedUser(
@@ -73,7 +77,8 @@ final class TrainerDexLinkServiceTest extends AbstractTestBackService
         $service->create('national', '{"targetDexSlug":"shiny","bidirectional":true}');
     }
 
-    public function testDelete(): void
+    #[Test]
+    public function delete(): void
     {
         /** @var TrainerDexLinkService $service */
         $service = $this->getServiceWithLoggedUser('DELETE', '', 'album_link/link-1');

--- a/tests/src/Unit/Service/ElectionIndexServiceTest.php
+++ b/tests/src/Unit/Service/ElectionIndexServiceTest.php
@@ -9,6 +9,7 @@ use App\ResponseObject\Election\ElectionIndex;
 use App\Service\Back\GetElectionIndexService;
 use App\Service\ElectionIndexService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -19,7 +20,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 #[CoversClass(ElectionIndexService::class)]
 final class ElectionIndexServiceTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $dexSlug = 'test-dex';
         $electionSlug = 'test-election';
@@ -66,7 +68,8 @@ final class ElectionIndexServiceTest extends TestCase
         $this->assertFalse($result->isTheLastPage);
     }
 
-    public function testGetHttpException(): void
+    #[Test]
+    public function getHttpException(): void
     {
         $dexSlug = 'test-dex';
         $electionSlug = 'test-election';
@@ -89,7 +92,8 @@ final class ElectionIndexServiceTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testGetTransportException(): void
+    #[Test]
+    public function getTransportException(): void
     {
         $dexSlug = 'test-dex';
         $electionSlug = 'test-election';

--- a/tests/src/Unit/Service/ElectionVoteServiceTest.php
+++ b/tests/src/Unit/Service/ElectionVoteServiceTest.php
@@ -9,6 +9,7 @@ use App\Exception\ModifyFailedException;
 use App\Service\Back\PostElectionVoteService;
 use App\Service\ElectionVoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -19,7 +20,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 #[CoversClass(ElectionVoteService::class)]
 final class ElectionVoteServiceTest extends TestCase
 {
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -41,7 +43,8 @@ final class ElectionVoteServiceTest extends TestCase
         $service->vote($electionVote);
     }
 
-    public function testVoteWinnerAsLoser(): void
+    #[Test]
+    public function voteWinnerAsLoser(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -63,7 +66,8 @@ final class ElectionVoteServiceTest extends TestCase
         $service->vote($electionVote);
     }
 
-    public function testVoteAllLosers(): void
+    #[Test]
+    public function voteAllLosers(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -85,7 +89,8 @@ final class ElectionVoteServiceTest extends TestCase
         $service->vote($electionVote);
     }
 
-    public function testVoteAllWinners(): void
+    #[Test]
+    public function voteAllWinners(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -107,7 +112,8 @@ final class ElectionVoteServiceTest extends TestCase
         $service->vote($electionVote);
     }
 
-    public function testVoteWithHttpException(): void
+    #[Test]
+    public function voteWithHttpException(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',
@@ -129,7 +135,8 @@ final class ElectionVoteServiceTest extends TestCase
         $service->vote($electionVote);
     }
 
-    public function testVoteWithTransportException(): void
+    #[Test]
+    public function voteWithTransportException(): void
     {
         $electionVote = ElectionVote::createFromArray([
             'dex_slug' => 'demo',

--- a/tests/src/Unit/Service/GetCreditsServiceTest.php
+++ b/tests/src/Unit/Service/GetCreditsServiceTest.php
@@ -8,6 +8,7 @@ use App\ResponseObject\Common\PokemonCreditRow;
 use App\Service\Back\GetCreditsService as BackGetCreditsService;
 use App\Service\GetCreditsService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -18,7 +19,8 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 #[CoversClass(GetCreditsService::class)]
 final class GetCreditsServiceTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $rows = [new PokemonCreditRow(
             pokemonSlug: 'bulbasaur',
@@ -43,7 +45,8 @@ final class GetCreditsServiceTest extends TestCase
         $this->assertSame($rows, $service->get());
     }
 
-    public function testCacheIsInvalidatedByCreditsTag(): void
+    #[Test]
+    public function cacheIsInvalidatedByCreditsTag(): void
     {
         $rows = [new PokemonCreditRow(
             pokemonSlug: 'bulbasaur',

--- a/tests/src/Unit/Service/GetLabelsServiceTest.php
+++ b/tests/src/Unit/Service/GetLabelsServiceTest.php
@@ -8,6 +8,7 @@ use App\Service\Back\GetLabelsService as BackGetLabelsService;
 use App\Service\GetLabelsService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
@@ -20,12 +21,14 @@ final class GetLabelsServiceTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testGetCatchStates(): void
+    #[Test]
+    public function getCatchStates(): void
     {
         $this->getService()->getCatchStates();
     }
 
-    public function testGetAllLabels(): void
+    #[Test]
+    public function getAllLabels(): void
     {
         $backService = $this->createMock(BackGetLabelsService::class);
         $backService
@@ -41,7 +44,8 @@ final class GetLabelsServiceTest extends TestCase
         $this->assertNotEmpty($labels->getTypes());
     }
 
-    public function testCacheIsInvalidatedByLabelsTag(): void
+    #[Test]
+    public function cacheIsInvalidatedByLabelsTag(): void
     {
         $backService = $this->createMock(BackGetLabelsService::class);
         $backService

--- a/tests/src/Unit/Service/GetPokemonsListServiceTest.php
+++ b/tests/src/Unit/Service/GetPokemonsListServiceTest.php
@@ -9,6 +9,7 @@ use App\Service\Back\GetPokemonsService;
 use App\Service\GetPokemonsListService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,7 +20,8 @@ final class GetPokemonsListServiceTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $getPokemonsService = $this->createMock(GetPokemonsService::class);
         $getPokemonsService
@@ -48,7 +50,8 @@ final class GetPokemonsListServiceTest extends TestCase
         $this->assertCount(2, $list->getItems());
     }
 
-    public function testGetWithFilters(): void
+    #[Test]
+    public function getWithFilters(): void
     {
         $getPokemonsService = $this->createMock(GetPokemonsService::class);
         $getPokemonsService

--- a/tests/src/Unit/Service/GetResourcesVersionServiceTest.php
+++ b/tests/src/Unit/Service/GetResourcesVersionServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\GetResourcesVersionService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Exception\TransportException;
@@ -19,7 +20,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(GetResourcesVersionService::class)]
 final class GetResourcesVersionServiceTest extends TestCase
 {
-    public function testGetReturnsVersionAndUpdatedAtFromLastModifiedHeader(): void
+    #[Test]
+    public function getReturnsVersionAndUpdatedAtFromLastModifiedHeader(): void
     {
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getContent')->willReturn("1.9.7\n");
@@ -41,7 +43,8 @@ final class GetResourcesVersionServiceTest extends TestCase
         $this->assertSame('2026-08-05T09:12:00+00:00', $brickVersion->updatedAt?->format(\DateTimeInterface::ATOM));
     }
 
-    public function testGetReturnsNullUpdatedAtWhenLastModifiedHeaderAbsent(): void
+    #[Test]
+    public function getReturnsNullUpdatedAtWhenLastModifiedHeaderAbsent(): void
     {
         $response = $this->createMock(ResponseInterface::class);
         $response
@@ -74,7 +77,8 @@ final class GetResourcesVersionServiceTest extends TestCase
         $this->assertNull($brickVersion->updatedAt);
     }
 
-    public function testGetReturnsNullBrickVersionOnTransportError(): void
+    #[Test]
+    public function getReturnsNullBrickVersionOnTransportError(): void
     {
         $exception = $this->createStub(TransportException::class);
 
@@ -96,7 +100,8 @@ final class GetResourcesVersionServiceTest extends TestCase
         $this->assertNull($brickVersion->updatedAt);
     }
 
-    public function testGetReturnsNullBrickVersionOnHttpError(): void
+    #[Test]
+    public function getReturnsNullBrickVersionOnHttpError(): void
     {
         $response = $this->createMock(ResponseInterface::class);
         $response

--- a/tests/src/Unit/Service/GetTrainerPokedexServiceTest.php
+++ b/tests/src/Unit/Service/GetTrainerPokedexServiceTest.php
@@ -8,6 +8,7 @@ use App\Service\Back\GetPokedexService;
 use App\Service\GetTrainerPokedexService;
 use App\Tests\Common\Traits\ResponseObjectTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -21,7 +22,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
 {
     use ResponseObjectTrait;
 
-    public function testGetPokedexData(): void
+    #[Test]
+    public function getPokedexData(): void
     {
         $getPokedexService = $this->createMock(GetPokedexService::class);
         $getPokedexService
@@ -48,7 +50,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertSame(0, $pokedexData->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetPokedexDataWithFilters(): void
+    #[Test]
+    public function getPokedexDataWithFilters(): void
     {
         $getPokedexService = $this->createMock(GetPokedexService::class);
         $getPokedexService
@@ -84,7 +87,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertSame(0, $pokedexData->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetPokedexDataWithTrainerId(): void
+    #[Test]
+    public function getPokedexDataWithTrainerId(): void
     {
         $getPokedexService = $this->createMock(GetPokedexService::class);
         $getPokedexService
@@ -112,7 +116,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertSame(0, $pokedexData->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetPokedexDataWithNullTrainerId(): void
+    #[Test]
+    public function getPokedexDataWithNullTrainerId(): void
     {
         $getPokedexService = $this->createMock(GetPokedexService::class);
         $getPokedexService
@@ -139,7 +144,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertSame(0, $pokedexData->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetPokedexDataWithEmptyTrainerId(): void
+    #[Test]
+    public function getPokedexDataWithEmptyTrainerId(): void
     {
         $getPokedexService = $this->createMock(GetPokedexService::class);
         $getPokedexService
@@ -166,7 +172,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertSame(0, $pokedexData->getPokedex()->getFilteredReport()->getTotalCaught());
     }
 
-    public function testGetPokedexDataHttpException(): void
+    #[Test]
+    public function getPokedexDataHttpException(): void
     {
         $exception = $this->createStub(HttpExceptionInterface::class);
 
@@ -191,7 +198,8 @@ final class GetTrainerPokedexServiceTest extends TestCase
         $this->assertNull($dexData);
     }
 
-    public function testGetPokedexDataTransportException(): void
+    #[Test]
+    public function getPokedexDataTransportException(): void
     {
         $exception = $this->createStub(TransportExceptionInterface::class);
 

--- a/tests/src/Unit/Service/ModifyTrainerAlbumServiceTest.php
+++ b/tests/src/Unit/Service/ModifyTrainerAlbumServiceTest.php
@@ -8,6 +8,7 @@ use App\Exception\ModifyFailedException;
 use App\Service\Back\ModifyAlbumService;
 use App\Service\ModifyTrainerAlbumService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,7 +21,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 #[CoversClass(ModifyTrainerAlbumService::class)]
 final class ModifyTrainerAlbumServiceTest extends TestCase
 {
-    public function testModifyAlbum(): void
+    #[Test]
+    public function modifyAlbum(): void
     {
         $modifyAlbumService = $this->createMock(ModifyAlbumService::class);
         $modifyAlbumService
@@ -48,7 +50,8 @@ final class ModifyTrainerAlbumServiceTest extends TestCase
         $service->modifyAlbum('douze', 'treize', '{"ceci": "est-du-contenu"}');
     }
 
-    public function testModifyDexWithHttpException(): void
+    #[Test]
+    public function modifyDexWithHttpException(): void
     {
         $exception = $this->createStub(HttpExceptionInterface::class);
 
@@ -82,7 +85,8 @@ final class ModifyTrainerAlbumServiceTest extends TestCase
         $service->modifyAlbum('douze', 'treize', '{"ceci": "est-du-contenu"}');
     }
 
-    public function testModifyDexWithNoRequest(): void
+    #[Test]
+    public function modifyDexWithNoRequest(): void
     {
         $modifyAlbumService = $this->createMock(ModifyAlbumService::class);
         $modifyAlbumService
@@ -102,7 +106,8 @@ final class ModifyTrainerAlbumServiceTest extends TestCase
         $service->modifyAlbum('douze', 'treize', '{"ceci": "est-du-contenu"}');
     }
 
-    public function testModifyDexWithTransportException(): void
+    #[Test]
+    public function modifyDexWithTransportException(): void
     {
         $exception = $this->createStub(TransportExceptionInterface::class);
 

--- a/tests/src/Unit/Service/ModifyTrainerDexServiceTest.php
+++ b/tests/src/Unit/Service/ModifyTrainerDexServiceTest.php
@@ -8,6 +8,7 @@ use App\Exception\ModifyFailedException;
 use App\Service\Back\ModifyDexService;
 use App\Service\ModifyTrainerDexService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -18,7 +19,8 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 #[CoversClass(ModifyTrainerDexService::class)]
 final class ModifyTrainerDexServiceTest extends TestCase
 {
-    public function testModifyDex(): void
+    #[Test]
+    public function modifyDex(): void
     {
         $modifyDexService = $this->createMock(ModifyDexService::class);
         $modifyDexService
@@ -36,7 +38,8 @@ final class ModifyTrainerDexServiceTest extends TestCase
         $service->modifyDex('douze', '{"ceci": "est-du-contenu"}');
     }
 
-    public function testModifyDexWithHttpException(): void
+    #[Test]
+    public function modifyDexWithHttpException(): void
     {
         $exception = $this->createStub(HttpExceptionInterface::class);
 
@@ -60,7 +63,8 @@ final class ModifyTrainerDexServiceTest extends TestCase
         $service->modifyDex('douze', '{"ceci": "est-du-contenu"}');
     }
 
-    public function testModifyDexWithTransportException(): void
+    #[Test]
+    public function modifyDexWithTransportException(): void
     {
         $exception = $this->createStub(TransportExceptionInterface::class);
 

--- a/tests/src/Unit/Service/RequestedContentServiceTest.php
+++ b/tests/src/Unit/Service/RequestedContentServiceTest.php
@@ -8,6 +8,7 @@ use App\Exception\EmptyContentException;
 use App\Exception\InvalidJsonException;
 use App\Service\RequestedContentService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -22,7 +23,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[CoversClass(RequestedContentService::class)]
 final class RequestedContentServiceTest extends TestCase
 {
-    public function testGetContent(): void
+    #[Test]
+    public function getContent(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);
         $validator
@@ -53,7 +55,8 @@ final class RequestedContentServiceTest extends TestCase
         );
     }
 
-    public function testGetContentNoRequest(): void
+    #[Test]
+    public function getContentNoRequest(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);
         $validator
@@ -73,7 +76,8 @@ final class RequestedContentServiceTest extends TestCase
         );
     }
 
-    public function testGetContentBadRequest(): void
+    #[Test]
+    public function getContentBadRequest(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);
         $validator
@@ -100,7 +104,8 @@ final class RequestedContentServiceTest extends TestCase
         $service->getContent(new Json());
     }
 
-    public function testGetContentBadJson(): void
+    #[Test]
+    public function getContentBadJson(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);
         $validator

--- a/tests/src/Unit/Service/VersionsOverviewServiceTest.php
+++ b/tests/src/Unit/Service/VersionsOverviewServiceTest.php
@@ -11,6 +11,7 @@ use App\Service\Back\GetVersionsService;
 use App\Service\GetResourcesVersionService;
 use App\Service\VersionsOverviewService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,7 +20,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VersionsOverviewService::class)]
 final class VersionsOverviewServiceTest extends TestCase
 {
-    public function testGetCombinesAllFourVersions(): void
+    #[Test]
+    public function getCombinesAllFourVersions(): void
     {
         $webUpdatedAt = new \DateTimeImmutable('2026-08-05T09:12:00+00:00');
         $backUpdatedAt = new \DateTimeImmutable('2026-08-04T21:47:00+00:00');
@@ -53,7 +55,8 @@ final class VersionsOverviewServiceTest extends TestCase
         $this->assertSame($resourcesUpdatedAt, $overview->resources->updatedAt);
     }
 
-    public function testGetHandlesUnavailableBricks(): void
+    #[Test]
+    public function getHandlesUnavailableBricks(): void
     {
         $appVersionService = $this->createStub(AppVersionService::class);
         $appVersionService->method('getVersion')->willReturn('1.2.12');

--- a/tests/src/Unit/Twig/AppExtensionTest.php
+++ b/tests/src/Unit/Twig/AppExtensionTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Twig;
 use App\Service\AppVersionService;
 use App\Twig\AppExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Twig\Node\Node;
 use Twig\TwigFilter;
@@ -18,7 +19,8 @@ use Twig\TwigFunction;
 #[CoversClass(AppExtension::class)]
 final class AppExtensionTest extends TestCase
 {
-    public function testGetFilters(): void
+    #[Test]
+    public function getFilters(): void
     {
         $extension = new AppExtension($this->createStub(AppVersionService::class));
 
@@ -63,7 +65,8 @@ final class AppExtensionTest extends TestCase
         $this->assertEquals('htmlNl2br', $htmlNl2brCallable[1]);
     }
 
-    public function testGetFunctions(): void
+    #[Test]
+    public function getFunctions(): void
     {
         $extension = new AppExtension($this->createStub(AppVersionService::class));
 
@@ -83,7 +86,8 @@ final class AppExtensionTest extends TestCase
         $this->assertEquals('getVersion', $versionFunctionCallable[1]);
     }
 
-    public function testKsort(): void
+    #[Test]
+    public function ksort(): void
     {
         $extension = new AppExtension($this->createStub(AppVersionService::class));
 
@@ -103,7 +107,8 @@ final class AppExtensionTest extends TestCase
         );
     }
 
-    public function testSha1(): void
+    #[Test]
+    public function sha1(): void
     {
         $extension = new AppExtension($this->createStub(AppVersionService::class));
 
@@ -111,14 +116,16 @@ final class AppExtensionTest extends TestCase
         $this->assertSame('f7e79ca8eb0b31ee4d5d6c181416667ffee528ed', $extension->sha1('titi'));
     }
 
-    public function testHtmlNl2br(): void
+    #[Test]
+    public function htmlNl2br(): void
     {
         $extension = new AppExtension($this->createStub(AppVersionService::class));
 
         $this->assertSame("a<br>\nb", $extension->htmlNl2br("a\nb"));
     }
 
-    public function testVersion(): void
+    #[Test]
+    public function version(): void
     {
         $versionService = $this->createMock(AppVersionService::class);
         $versionService
@@ -133,7 +140,8 @@ final class AppExtensionTest extends TestCase
         $this->assertSame('1.2.12', $extension->getVersion());
     }
 
-    public function testVersionDelegatesToService(): void
+    #[Test]
+    public function versionDelegatesToService(): void
     {
         $versionService = $this->createMock(AppVersionService::class);
         $versionService

--- a/tests/src/Unit/Twig/AppRequestExtensionTest.php
+++ b/tests/src/Unit/Twig/AppRequestExtensionTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Twig;
 use App\Twig\AppRequestExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -17,7 +18,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[CoversClass(AppRequestExtension::class)]
 final class AppRequestExtensionTest extends TestCase
 {
-    public function testGetArrayFromRequestWithoutRequest(): void
+    #[Test]
+    public function getArrayFromRequestWithoutRequest(): void
     {
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack
@@ -37,7 +39,8 @@ final class AppRequestExtensionTest extends TestCase
      * @param array<int, string>                       $expected
      */
     #[DataProvider('providerGetArrayFromRequestWithRequest')]
-    public function testGetArrayFromRequestWithRequest(array $query, string $name, array $expected): void
+    #[Test]
+    public function getArrayFromRequestWithRequest(array $query, string $name, array $expected): void
     {
         $request = new Request($query);
 

--- a/tests/src/Unit/Twig/AppTranslatorExtensionTest.php
+++ b/tests/src/Unit/Twig/AppTranslatorExtensionTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Twig;
 use App\Twig\AppTranslatorExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\TwigFilter;
@@ -17,7 +18,8 @@ use Twig\TwigFilter;
 #[CoversClass(AppTranslatorExtension::class)]
 final class AppTranslatorExtensionTest extends TestCase
 {
-    public function testGetFilters(): void
+    #[Test]
+    public function getFilters(): void
     {
         $translator = $this->createStub(TranslatorInterface::class);
         $extension = new AppTranslatorExtension($translator);
@@ -42,7 +44,8 @@ final class AppTranslatorExtensionTest extends TestCase
      * @param array<string, int> $params
      */
     #[DataProvider('providerAlmostExactly')]
-    public function testAlmostExactly(
+    #[Test]
+    public function almostExactly(
         string $text,
         array $params,
         string $return,

--- a/tests/src/Unit/Utils/JsonDecoderTest.php
+++ b/tests/src/Unit/Utils/JsonDecoderTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Utils;
 use App\Utils\JsonDecoder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(JsonDecoder::class)]
 final class JsonDecoderTest extends TestCase
 {
-    public function testDecodeOneColor(): void
+    #[Test]
+    public function decodeOneColor(): void
     {
         $this->assertEquals(
             [
@@ -30,17 +32,20 @@ final class JsonDecoderTest extends TestCase
         );
     }
 
-    public function testDecodeEmptyObject(): void
+    #[Test]
+    public function decodeEmptyObject(): void
     {
         $this->assertEquals([], JsonDecoder::decode('{}'));
     }
 
-    public function testDecodeEmptyArray(): void
+    #[Test]
+    public function decodeEmptyArray(): void
     {
         $this->assertEquals([], JsonDecoder::decode('[]'));
     }
 
-    public function testDecodeManyColors(): void
+    #[Test]
+    public function decodeManyColors(): void
     {
         $this->assertEquals(
             [
@@ -87,7 +92,8 @@ final class JsonDecoderTest extends TestCase
         );
     }
 
-    public function testDecodeMaxDepth(): void
+    #[Test]
+    public function decodeMaxDepth(): void
     {
         $this->assertEquals(
             [
@@ -106,7 +112,8 @@ final class JsonDecoderTest extends TestCase
     }
 
     #[DataProvider('providerDecodeException')]
-    public function testDecodeException(string $json): void
+    #[Test]
+    public function decodeException(string $json): void
     {
         $this->expectException(\JsonException::class);
 

--- a/tests/src/Unit/Validator/CatchStatesTest.php
+++ b/tests/src/Unit/Validator/CatchStatesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Validator;
 
 use App\Validator\CatchStates;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CatchStates::class)]
 final class CatchStatesTest extends TestCase
 {
-    public function testValidatedBy(): void
+    #[Test]
+    public function validatedBy(): void
     {
         $constraint = new CatchStates();
 

--- a/tests/src/Unit/Validator/CatchStatesValidatorTest.php
+++ b/tests/src/Unit/Validator/CatchStatesValidatorTest.php
@@ -96,7 +96,7 @@ final class CatchStatesValidatorTest extends ConstraintValidatorTestCase
     #[\Override]
     protected function createValidator(): CatchStatesValidator
     {
-        $getService = $this->createMock(GetLabelsService::class);
+        $getService = $this->createStub(GetLabelsService::class);
 
         $getService
             ->method('getCatchStates')

--- a/tests/src/Unit/Validator/CatchStatesValidatorTest.php
+++ b/tests/src/Unit/Validator/CatchStatesValidatorTest.php
@@ -8,7 +8,6 @@ use App\ResponseObject\Label\CatchState;
 use App\Service\GetLabelsService;
 use App\Validator\CatchStates;
 use App\Validator\CatchStatesValidator;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,7 +22,6 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  *
  * @extends ConstraintValidatorTestCase<CatchStatesValidator>
  */
-#[AllowMockObjectsWithoutExpectations]
 #[CoversClass(CatchStatesValidator::class)]
 #[UsesClass(CatchStates::class)]
 final class CatchStatesValidatorTest extends ConstraintValidatorTestCase

--- a/tests/src/Unit/Validator/CatchStatesValidatorTest.php
+++ b/tests/src/Unit/Validator/CatchStatesValidatorTest.php
@@ -11,6 +11,7 @@ use App\Validator\CatchStatesValidator;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -27,7 +28,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 #[UsesClass(CatchStates::class)]
 final class CatchStatesValidatorTest extends ConstraintValidatorTestCase
 {
-    public function testNullIsValid(): void
+    #[Test]
+    public function nullIsValid(): void
     {
         $this->validator->validate(null, new CatchStates());
 
@@ -35,7 +37,8 @@ final class CatchStatesValidatorTest extends ConstraintValidatorTestCase
     }
 
     #[DataProvider('providerInvalidConstraints')]
-    public function testTrueIsInvalid(CatchStates $constraint): void
+    #[Test]
+    public function trueIsInvalid(CatchStates $constraint): void
     {
         $this->validator->validate('douze', $constraint);
 
@@ -56,7 +59,8 @@ final class CatchStatesValidatorTest extends ConstraintValidatorTestCase
     }
 
     #[DataProvider('providerValidConstraints')]
-    public function testTrueIsValid(CatchStates $constraint): void
+    #[Test]
+    public function trueIsValid(CatchStates $constraint): void
     {
         $this->validator->validate('maybenot', $constraint);
 
@@ -73,14 +77,16 @@ final class CatchStatesValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    public function testUnexpectedType(): void
+    #[Test]
+    public function unexpectedType(): void
     {
         $this->expectException(UnexpectedTypeException::class);
 
         $this->validator->validate('maybenot', new NotNull());
     }
 
-    public function testUnexpectedValue(): void
+    #[Test]
+    public function unexpectedValue(): void
     {
         $this->expectException(UnexpectedValueException::class);
 


### PR DESCRIPTION
## Summary
- Migrates all `testXxx()` methods (Unit + Integration + Browser) to the `#[Test]` attribute with the `test` prefix dropped.
- Converts the one `createMock` double with no `->expects(...)` anywhere in its file (`CatchStatesValidatorTest`) to `createStub`; also drops the now-unused `#[AllowMockObjectsWithoutExpectations]` class attribute it required. The other 45 files with `createMock` all have a real expectation set — PHPUnit 12 already enforces this via `verifyMockObjects()`, which is why almost everything was already compliant.

## Notes
No tests were run while producing this change (by request) — please run the full suite before merging.

## Test plan
- [ ] `make tests` passes
- [ ] `make quality` / `make measures` still green (coverage/MSI)