### PR TITLE
ci: split tests into parallel jobs, cache Docker images

### DIFF
--- a/.github/actions/docker-compose/action.yml
+++ b/.github/actions/docker-compose/action.yml
@@ -27,7 +27,6 @@ runs:
       run: docker load -i /tmp/docker-images-cache/images.tar
 
     - name: Login to Docker Hub
-      if: steps.docker-images-cache.outputs.cache-hit != 'true'
       uses: docker/login-action@v4
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}

--- a/.github/actions/docker-compose/action.yml
+++ b/.github/actions/docker-compose/action.yml
@@ -14,30 +14,60 @@ runs:
         echo "APP_UID=$(id -u)" >> "$GITHUB_ENV"
         echo "APP_GID=$(id -g)" >> "$GITHUB_ENV"
 
+    - name: Restore Docker images archive cache
+      id: docker-images-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: /tmp/docker-images-cache/images.tar
+        key: docker-images-${{ runner.os }}-${{ hashFiles('.docker/php/Dockerfile', '.docker/php/conf.d/**', '.docker/moco/Dockerfile', 'docker-compose.yaml') }}-${{ env.APP_UID }}-${{ env.APP_GID }}
+
+    - name: Load cached Docker images
+      if: steps.docker-images-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load -i /tmp/docker-images-cache/images.tar
+
     - name: Login to Docker Hub
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
       uses: docker/login-action@v4
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ env.DOCKERHUB_TOKEN }}
 
     - name: Setup Docker Buildx
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
       uses: docker/setup-buildx-action@v4
 
     - name: Docker Buildx Bake
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
       uses: docker/bake-action@v7
       with:
         load: true
         set: |
-          *.cache-to=type=gha,mode=max                                                                                
-          *.cache-from=type=gha 
-      
+          *.cache-to=type=gha,mode=max
+          *.cache-from=type=gha
+
     - name: Pull images
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
       shell: bash
       run: docker compose pull --ignore-pull-failures || true
 
     - name: Start services
       shell: bash
-      run: docker compose --verbose up --build --wait
+      run: docker compose --verbose up --wait
+
+    - name: Save Docker images archive cache
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p /tmp/docker-images-cache
+        docker save $(docker compose config --images php moco.back moco.matomo.gbl) -o /tmp/docker-images-cache/images.tar
+
+    - name: Save Docker images archive cache (upload)
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: /tmp/docker-images-cache/images.tar
+        key: ${{ steps.docker-images-cache.outputs.cache-primary-key }}
 
     - name: Composer install
       shell: bash

--- a/.github/actions/docker-compose/action.yml
+++ b/.github/actions/docker-compose/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Load cached Docker images
       if: steps.docker-images-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: docker load -i /tmp/docker-images-cache/images.tar
+      run: docker load -i /tmp/docker-images-cache/images.tar || true
 
     - name: Login to Docker Hub
       uses: docker/login-action@v4
@@ -59,7 +59,7 @@ runs:
       shell: bash
       run: |
         mkdir -p /tmp/docker-images-cache
-        docker save $(docker compose config --images php moco.back moco.matomo.gbl) -o /tmp/docker-images-cache/images.tar
+        docker save $(docker compose config --images php moco.back moco.matomo.gbl | grep -v '^selenium/') -o /tmp/docker-images-cache/images.tar || true
 
     - name: Save Docker images archive cache (upload)
       if: steps.docker-images-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,8 +20,8 @@ env:
   PHP_CS_FIXER_IGNORE_ENV: 1
 
 jobs:
-  allin:
-    name: All tests
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +30,58 @@ jobs:
         uses: ./.github/actions/docker-compose
       - name: PHPUnit / Run
         run: |
-          docker compose exec -T php php vendor/bin/phpunit tests/src/ --exclude-group="time-testing"
+          docker compose exec -T php php vendor/bin/phpunit tests/src/Unit --exclude-group="time-testing"
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec -T php php vendor/bin/phpunit tests/src/Integration --exclude-group="time-testing"
+
+  browser-tests-chrome:
+    name: Browser Tests (Chrome)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec \
+            -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub \
+            -e PANTHER_BROWSER_NAME=chrome \
+            -T php php vendor/bin/phpunit tests/src/Browser --exclude-group="time-testing"
+
+  browser-tests-firefox:
+    name: Browser Tests (Firefox)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec \
+            -e PANTHER_SELENIUM_HOST=http://firefox:4444/wd/hub \
+            -e PANTHER_BROWSER_NAME=firefox \
+            -T php php vendor/bin/phpunit tests/src/Browser --exclude-group="time-testing"
+
+  measures:
+    name: Measures (Coverage & Mutation Testing)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
       - name: Measures / Run Coverage
         run: |
           docker compose exec \
@@ -50,6 +101,15 @@ jobs:
             --skip-initial-tests --coverage=build/coverage \
             --min-msi=100 --min-covered-msi=100 \
             --filter=src
+
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
       - name: Security / Symfony Security Check
         run: |
           docker compose exec -T php symfony security:check

--- a/docs/superpowers/plans/2026-08-10-ci-tests-split.md
+++ b/docs/superpowers/plans/2026-08-10-ci-tests-split.md
@@ -352,22 +352,22 @@ runs:
 Note the changes, copied from the corrected `pokenini-back`/`pokenini-api` versions:
 
 1. The archive-save step (`docker save ...`) runs AFTER `Start services`, not before.
-   `docker compose up` (with `--build` dropped) is what actually builds and tags the 3
-   built services under the compose-generated names — `docker buildx bake` alone does
-   not tag them, since none of the 3 declare an explicit `image:` key in
-   `docker-compose.yaml`. Saving before `up` would find those 3 image names missing
-   and fail on every cache-miss run (this was a Critical bug caught in `pokenini-back`'s
-   first draft of this change).
+  `docker compose up` (with `--build` dropped) is what actually builds and tags the 3
+  built services under the compose-generated names — `docker buildx bake` alone does
+  not tag them, since none of the 3 declare an explicit `image:` key in
+  `docker-compose.yaml`. Saving before `up` would find those 3 image names missing
+  and fail on every cache-miss run (this was a Critical bug caught in `pokenini-back`'s
+  first draft of this change).
 2. The cache uses split `actions/cache/restore@v5` / `actions/cache/save@v5` steps, so
-   the save happens as an ordinary step right after the tar is written — not deferred
-   to a `post-if: success()` hook that a later step failing would silently skip. The
-   save step reuses `steps.docker-images-cache.outputs.cache-primary-key` rather than
-   re-typing the key expression, so the two can never drift out of sync.
+  the save happens as an ordinary step right after the tar is written — not deferred
+  to a `post-if: success()` hook that a later step failing would silently skip. The
+  save step reuses `steps.docker-images-cache.outputs.cache-primary-key` rather than
+  re-typing the key expression, so the two can never drift out of sync.
 3. `docker save` is scoped to the 3 built services only
-   (`docker compose config --images php moco.back moco.matomo.gbl`) — `redis`,
-   `chrome`, `firefox`, and `web` are pulled, not built, so archiving them wastes
-   cache space for no benefit. This repo's `chrome`/`firefox` Selenium containers in
-   particular are large pulled images that must NOT be included.
+  (`docker compose config --images php moco.back moco.matomo.gbl`) — `redis`,
+  `chrome`, `firefox`, and `web` are pulled, not built, so archiving them wastes
+  cache space for no benefit. This repo's `chrome`/`firefox` Selenium containers in
+  particular are large pulled images that must NOT be included.
 4. `Composer install` is unconditional and unchanged, same as before this task.
 
 - [ ] **Step 3: Validate YAML syntax**

--- a/docs/superpowers/plans/2026-08-10-ci-tests-split.md
+++ b/docs/superpowers/plans/2026-08-10-ci-tests-split.md
@@ -1,0 +1,434 @@
+# CI Tests Split + Docker Image Archive Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `pokenini-web`'s single-job `ci_tests.yml` into 6 parallel jobs (unit, integration, browser×2, measures, security) and add a Docker image archive cache to the shared composite action.
+
+**Architecture:** Two independent, additive changes to GitHub Actions YAML — no application code touched. Task 1 replaces the one `allin` job in `ci_tests.yml` with 6 jobs: unit/integration/measures/security are a like-for-like split of the current steps (byte-identical `run:` commands except path narrowing), while `browser-tests-chrome`/`browser-tests-firefox` are new — the current single job runs `tests/src/Browser` implicitly (via the full `tests/src/` run) without selecting a browser; these two jobs explicitly run it against each Selenium container, mirroring the Makefile's `tests-browser-chrome`/`tests-browser-firefox` targets. Task 2 adds the Docker image archive cache to `./.github/actions/docker-compose/action.yml`, copying the design already implemented, reviewed, and bug-fixed in `pokenini-back` (see that repo's `docs/superpowers/plans/2026-08-10-ci-tests-split.md` Task 2) and already ported once to `pokenini-api` — save runs after `docker compose up` (not before), split `actions/cache/restore@v5`/`actions/cache/save@v5` steps, archive scoped to the 3 built services.
+
+**Tech Stack:** GitHub Actions YAML, Docker Compose, `actions/cache@v5`, Symfony Panther, Selenium.
+
+## Global Constraints
+
+- No change to trigger conditions: `push` to `main`, `pull_request: ~`, `workflow_call` with `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets — copied verbatim across all 6 new jobs.
+- `PHP_CS_FIXER_IGNORE_ENV: 1` env var stays at workflow level.
+- Neither `time-testing` nor `browser-testing` PHPUnit groups exist in `tests/src` today (confirmed via repo-wide grep during design — only `api-mocked-testing` is used) — keep both `--exclude-group` flags exactly as they are; do not remove them.
+- The `php_dev` Docker Compose build target does not `COPY` application source or `composer.lock` — only `.docker/php/conf.d/*.ini` files and a pinned `symfony-cli` binary. `vendor/` is bind-mounted and installed fresh per job; it is untouched by this plan.
+- `browser-tests-chrome` and `browser-tests-firefox` are the one deliberate scope change in this plan (confirmed with the user) — every other job must be behavior-preserving.
+- Pushing the branch and watching the real Actions run is the final verification step, but must not be done without checking with the user first.
+
+---
+
+### Task 1: Split `ci_tests.yml` into 6 parallel jobs
+
+**Files:**
+- Modify: `.github/workflows/ci_tests.yml` (full rewrite of the `jobs:` section — `on:` and top-level `env:` blocks are unchanged)
+
+**Interfaces:**
+- Consumes: `./.github/actions/docker-compose` composite action (unchanged in this task).
+- Produces: 6 job names (`unit-tests`, `integration-tests`, `browser-tests-chrome`, `browser-tests-firefox`, `measures`, `security`) that Task 2's composite-action change is exercised by.
+
+- [ ] **Step 1: Read the current file to confirm no drift**
+
+Run: `cat .github/workflows/ci_tests.yml`
+
+Confirm it still matches this baseline `jobs:` section (if it doesn't, stop and check with the user before continuing):
+
+```yaml
+jobs:
+  allin:
+    name: All tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec -T php php vendor/bin/phpunit tests/src/ --exclude-group="time-testing"
+      - name: Measures / Run Coverage
+        run: |
+          docker compose exec \
+            -e XDEBUG_MODE=coverage \
+            -T php php vendor/bin/phpunit \
+            --exclude-group="browser-testing" \
+            --coverage-clover=coverage.xml \
+            --coverage-xml=build/coverage/coverage-xml \
+            --log-junit=build/coverage/junit.xml
+      - name: Measures / Composer install Infection
+        shell: bash
+        run: docker compose exec -T php composer install --working-dir=tools/infection --prefer-dist --no-progress --no-interaction
+      - name: Measures / Run Infection
+        run: |
+          docker compose exec -T php php tools/infection/vendor/bin/infection \
+            --threads=4 --no-progress \
+            --skip-initial-tests --coverage=build/coverage \
+            --min-msi=100 --min-covered-msi=100 \
+            --filter=src
+      - name: Security / Symfony Security Check
+        run: |
+          docker compose exec -T php symfony security:check
+```
+
+- [ ] **Step 2: Replace the `jobs:` section**
+
+Replace everything from `jobs:` to the end of the file with:
+
+```yaml
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec -T php php vendor/bin/phpunit tests/src/Unit --exclude-group="time-testing"
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec -T php php vendor/bin/phpunit tests/src/Integration --exclude-group="time-testing"
+
+  browser-tests-chrome:
+    name: Browser Tests (Chrome)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec \
+            -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub \
+            -e PANTHER_BROWSER_NAME=chrome \
+            -T php php vendor/bin/phpunit tests/src/Browser --exclude-group="time-testing"
+
+  browser-tests-firefox:
+    name: Browser Tests (Firefox)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: PHPUnit / Run
+        run: |
+          docker compose exec \
+            -e PANTHER_SELENIUM_HOST=http://firefox:4444/wd/hub \
+            -e PANTHER_BROWSER_NAME=firefox \
+            -T php php vendor/bin/phpunit tests/src/Browser --exclude-group="time-testing"
+
+  measures:
+    name: Measures (Coverage & Mutation Testing)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: Measures / Run Coverage
+        run: |
+          docker compose exec \
+            -e XDEBUG_MODE=coverage \
+            -T php php vendor/bin/phpunit \
+            --exclude-group="browser-testing" \
+            --coverage-clover=coverage.xml \
+            --coverage-xml=build/coverage/coverage-xml \
+            --log-junit=build/coverage/junit.xml
+      - name: Measures / Composer install Infection
+        shell: bash
+        run: docker compose exec -T php composer install --working-dir=tools/infection --prefer-dist --no-progress --no-interaction
+      - name: Measures / Run Infection
+        run: |
+          docker compose exec -T php php tools/infection/vendor/bin/infection \
+            --threads=4 --no-progress \
+            --skip-initial-tests --coverage=build/coverage \
+            --min-msi=100 --min-covered-msi=100 \
+            --filter=src
+
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Prepare
+        uses: ./.github/actions/docker-compose
+      - name: Security / Symfony Security Check
+        run: |
+          docker compose exec -T php symfony security:check
+```
+
+Note: `unit-tests`/`integration-tests`/`measures`/`security` are a like-for-like split
+— every `run:` command is byte-identical to the original except the two `tests/src/` →
+`tests/src/Unit`/`tests/src/Integration` narrowings. `browser-tests-chrome` and
+`browser-tests-firefox` are new — there was no equivalent standalone step in the
+original file (Browser tests previously ran as part of the undifferentiated
+`tests/src/` run with no `PANTHER_SELENIUM_HOST`/`PANTHER_BROWSER_NAME` set); these two
+jobs are built from the Makefile's `tests-browser-chrome`/`tests-browser-firefox`
+targets (`docker compose exec -e PANTHER_SELENIUM_HOST=... -e PANTHER_BROWSER_NAME=...
+php php vendor/bin/phpunit ... tests/src/Browser`), adapted to CI's `docker compose
+exec -T` invocation style and keeping the (inert but consistently-applied)
+`--exclude-group="time-testing"` flag the other test jobs carry.
+
+- [ ] **Step 3: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci_tests.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Confirm every original step survived the split**
+
+Run: `git diff .github/workflows/ci_tests.yml` and check by eye against the Step 1
+baseline: `unit-tests`/`integration-tests`/`measures`/`security` must be byte-identical
+to the original except the two path narrowings described above. `browser-tests-chrome`
+and `browser-tests-firefox` are new additions — confirm each uses the exact
+`PANTHER_SELENIUM_HOST`/`PANTHER_BROWSER_NAME` values shown above (`http://chrome:4444/wd/hub`
++ `chrome`, and `http://firefox:4444/wd/hub` + `firefox` respectively — these must
+match the service hostnames in `docker-compose.yaml`, not be swapped).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci_tests.yml
+git commit -m "ci: split ci_tests.yml into parallel unit/integration/browser/measures/security jobs"
+```
+
+---
+
+### Task 2: Add Docker image archive cache to the shared composite action
+
+**Files:**
+- Modify: `.github/actions/docker-compose/action.yml`
+
+**Interfaces:**
+- Consumes: nothing new — same composite action interface (`uses: ./.github/actions/docker-compose`, no inputs), called identically by all 6 jobs from Task 1.
+- Produces: no new outputs; behavior change only (skips build on cache hit).
+
+- [ ] **Step 1: Read the current file to confirm no drift**
+
+Run: `cat .github/actions/docker-compose/action.yml`
+
+Confirm it still matches this baseline (stop and check with the user if it doesn't):
+
+```yaml
+name: Docker Compose Pull Up And Check
+description: Use to docker compose pull and up then checks if services are correctly running
+author: Renaud Douze
+runs:
+  using: "composite"
+  steps:
+    - name: Copy .env file
+      shell: bash
+      run: cp .env.ci .env
+
+    - name: Export host UID/GID for Docker build
+      shell: bash
+      run: |
+        echo "APP_UID=$(id -u)" >> "$GITHUB_ENV"
+        echo "APP_GID=$(id -g)" >> "$GITHUB_ENV"
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Docker Buildx Bake
+      uses: docker/bake-action@v7
+      with:
+        load: true
+        set: |
+          *.cache-to=type=gha,mode=max                                                                                
+          *.cache-from=type=gha 
+      
+    - name: Pull images
+      shell: bash
+      run: docker compose pull --ignore-pull-failures || true
+
+    - name: Start services
+      shell: bash
+      run: docker compose --verbose up --build --wait
+
+    - name: Composer install
+      shell: bash
+      run: docker compose exec -T php composer install --prefer-dist --no-progress --no-interaction
+```
+
+- [ ] **Step 2: Replace the file contents**
+
+```yaml
+name: Docker Compose Pull Up And Check
+description: Use to docker compose pull and up then checks if services are correctly running
+author: Renaud Douze
+runs:
+  using: "composite"
+  steps:
+    - name: Copy .env file
+      shell: bash
+      run: cp .env.ci .env
+
+    - name: Export host UID/GID for Docker build
+      shell: bash
+      run: |
+        echo "APP_UID=$(id -u)" >> "$GITHUB_ENV"
+        echo "APP_GID=$(id -g)" >> "$GITHUB_ENV"
+
+    - name: Restore Docker images archive cache
+      id: docker-images-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: /tmp/docker-images-cache/images.tar
+        key: docker-images-${{ runner.os }}-${{ hashFiles('.docker/php/Dockerfile', '.docker/php/conf.d/**', '.docker/moco/Dockerfile', 'docker-compose.yaml') }}-${{ env.APP_UID }}-${{ env.APP_GID }}
+
+    - name: Load cached Docker images
+      if: steps.docker-images-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load -i /tmp/docker-images-cache/images.tar
+
+    - name: Login to Docker Hub
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      uses: docker/login-action@v4
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+
+    - name: Setup Docker Buildx
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      uses: docker/setup-buildx-action@v4
+
+    - name: Docker Buildx Bake
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      uses: docker/bake-action@v7
+      with:
+        load: true
+        set: |
+          *.cache-to=type=gha,mode=max                                                                                
+          *.cache-from=type=gha 
+
+    - name: Pull images
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: docker compose pull --ignore-pull-failures || true
+
+    - name: Start services
+      shell: bash
+      run: docker compose --verbose up --wait
+
+    - name: Save Docker images archive cache
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p /tmp/docker-images-cache
+        docker save $(docker compose config --images php moco.back moco.matomo.gbl) -o /tmp/docker-images-cache/images.tar
+
+    - name: Save Docker images archive cache (upload)
+      if: steps.docker-images-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: /tmp/docker-images-cache/images.tar
+        key: ${{ steps.docker-images-cache.outputs.cache-primary-key }}
+
+    - name: Composer install
+      shell: bash
+      run: docker compose exec -T php composer install --prefer-dist --no-progress --no-interaction
+```
+
+Note the changes, copied from the corrected `pokenini-back`/`pokenini-api` versions:
+
+1. The archive-save step (`docker save ...`) runs AFTER `Start services`, not before.
+   `docker compose up` (with `--build` dropped) is what actually builds and tags the 3
+   built services under the compose-generated names — `docker buildx bake` alone does
+   not tag them, since none of the 3 declare an explicit `image:` key in
+   `docker-compose.yaml`. Saving before `up` would find those 3 image names missing
+   and fail on every cache-miss run (this was a Critical bug caught in `pokenini-back`'s
+   first draft of this change).
+2. The cache uses split `actions/cache/restore@v5` / `actions/cache/save@v5` steps, so
+   the save happens as an ordinary step right after the tar is written — not deferred
+   to a `post-if: success()` hook that a later step failing would silently skip. The
+   save step reuses `steps.docker-images-cache.outputs.cache-primary-key` rather than
+   re-typing the key expression, so the two can never drift out of sync.
+3. `docker save` is scoped to the 3 built services only
+   (`docker compose config --images php moco.back moco.matomo.gbl`) — `redis`,
+   `chrome`, `firefox`, and `web` are pulled, not built, so archiving them wastes
+   cache space for no benefit. This repo's `chrome`/`firefox` Selenium containers in
+   particular are large pulled images that must NOT be included.
+4. `Composer install` is unconditional and unchanged, same as before this task.
+
+- [ ] **Step 3: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/actions/docker-compose/action.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Validate the cache key's `hashFiles` globs and the archived service names actually exist**
+
+Run: `ls .docker/php/Dockerfile .docker/php/conf.d/ .docker/moco/Dockerfile docker-compose.yaml`
+Expected: all 4 paths exist.
+
+Run: `grep -E '^\s+(php|moco\.back|moco\.matomo\.gbl):' docker-compose.yaml`
+Expected: 3 matches — confirms the 3 service names passed to `docker compose config
+--images` in Step 2 are exactly the build-service names in `docker-compose.yaml`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/actions/docker-compose/action.yml
+git commit -m "ci: cache Docker Compose images as an archive to skip rebuilds across parallel jobs"
+```
+
+---
+
+### Task 3: Push and verify on a real CI run
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Check in with the user before pushing**
+
+This pushes a branch (and likely opens a PR) — confirm with the user first. Ask which
+branch name they want if they haven't already specified one.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 3: Open a PR (if the user wants one) and watch the run**
+
+```bash
+gh pr create --title "ci: split tests into parallel jobs, cache Docker images" --fill
+gh run watch
+```
+
+Expected: 6 separate check runs appear (`Unit Tests`, `Integration Tests`,
+`Browser Tests (Chrome)`, `Browser Tests (Firefox)`,
+`Measures (Coverage & Mutation Testing)`, `Security`) instead of the single `All tests`
+check. The 4 non-browser jobs should pass with the same results the current `allin`
+job would have produced; the 2 browser jobs are new — if either fails, that's real
+signal to investigate (not necessarily a plan defect — it may reveal that the
+previously-undifferentiated Browser-test run was implicitly using only one browser's
+behavior, and the other browser has a genuine incompatibility).
+
+- [ ] **Step 4: Push a second, no-op commit (e.g. `git commit --allow-empty -m "ci: retrigger"`) and watch again**
+
+Expected: in the Actions log for the `Prepare` step of each of the 6 jobs, the
+`Restore Docker images archive cache` step reports a cache hit, and the
+`Login to Docker Hub` / `Setup Docker Buildx` / `Docker Buildx Bake` / `Pull images`
+steps are skipped.

--- a/docs/superpowers/specs/2026-08-10-ci-tests-split-design.md
+++ b/docs/superpowers/specs/2026-08-10-ci-tests-split-design.md
@@ -1,0 +1,136 @@
+# Design: split `ci_tests.yml` into parallel jobs + Docker image archive cache (pokenini-web)
+
+## Purpose
+
+Same motivation and mechanism as the already-implemented designs in `pokenini-back`
+(PR #154) and `pokenini-api`: `ci_tests.yml` currently runs everything in one
+sequential job (`allin`) on one runner. Split it into parallel jobs so failures are
+isolated and the pipeline runs faster, and add a Docker image archive cache to the
+shared composite action so the now-multiplied image build isn't repeated per job.
+
+This repo's split differs from the other two in one structural way, confirmed by
+reading the actual files (not assumed from precedent): `pokenini-web` has a third test
+category, `tests/src/Browser/` (Panther browser tests against real Selenium
+`chrome`/`firefox` containers defined in `docker-compose.yaml`, each with a
+healthcheck; the `php` service `depends_on` both being healthy). `pokenini-back` and
+`pokenini-api` have no equivalent.
+
+Per this repo's `Makefile`, browser tests already run against both browsers in
+parallel locally (`make tests-browser` → `tests-browser-chrome` +
+`tests-browser-firefox`, each setting `PANTHER_SELENIUM_HOST` /
+`PANTHER_BROWSER_NAME` before invoking PHPUnit on `tests/src/Browser`). The current CI
+job runs the whole `tests/src/` tree in one shot with neither env var set, so it
+exercises Browser tests today only under Panther's library default resolution — not
+explicitly against both browsers. Per explicit decision for this change: CI gains
+**two** browser jobs (`browser-tests-chrome`, `browser-tests-firefox`), matching the
+Makefile's dual-browser local behavior — a deliberate coverage increase, not a
+behavior-preserving split, unlike every other job in this design.
+
+## Current state (baseline)
+
+Single job `allin` in `.github/workflows/ci_tests.yml`:
+1. `phpunit tests/src/ --exclude-group="time-testing"` (full suite: Unit + Integration
+   + Browser, run together — no `PANTHER_SELENIUM_HOST`/`PANTHER_BROWSER_NAME` set)
+2. Coverage run (full suite again, `--exclude-group="browser-testing"`, Xdebug —
+   despite the flag's name this does not actually exclude Browser tests; see below)
+3. Infection composer install + run (consumes step 2's coverage output)
+4. `symfony security:check`
+
+Repo-wide grep for PHPUnit `#[Group(...)]` attributes found only `api-mocked-testing`
+(54 test classes, spanning both `tests/src/Integration/**` and `tests/src/Browser/**`)
+— confirmed during research. Neither `time-testing` nor `browser-testing` is used
+anywhere; both `--exclude-group` flags in `ci_tests.yml` are dead/no-op, exactly as in
+the other two repos. Kept as-is, not removed.
+
+Pre-existing discrepancy (not introduced by this change, not fixed by it — noted so
+it isn't mistaken for a regression): the Makefile's own coverage targets
+(`coverage-generate`, `coverage-html`) use `--exclude-testsuite="Browser Test Suite"`
+(a real, effective exclusion, via the two testsuites `phpunit.xml.dist` defines) to
+keep Browser tests out of the coverage/mutation numbers locally, while
+`ci_tests.yml`'s coverage step uses the inert `--exclude-group="browser-testing"` and
+therefore *does* fold Browser tests into CI's coverage and Infection runs today. This
+plan preserves that existing CI behavior verbatim in the `measures` job (per the
+"split without changing behavior" principle used for every job except the two new
+browser jobs) rather than silently fixing the mismatch — that's a separate, optional
+follow-up if wanted later.
+
+`phpunit.xml.dist` defines two testsuites: "Project Test Suite" (`tests`, excluding
+`tests/src/Browser`) and "Browser Test Suite" (`tests/src/Browser` only), with the
+Panther `ServerExtension` bootstrap. The Makefile already exposes `tests-unit`,
+`tests-integration`, `tests-browser-chrome`, `tests-browser-firefox` as separate
+targets, plus `measures` (coverage + infection).
+
+The shared composite action `.github/actions/docker-compose/action.yml` is
+structurally identical to `pokenini-back`'s (no DB, no extra steps beyond the
+standard build/pull/up/composer-install sequence).
+
+## Job split
+
+`ci_tests.yml` becomes 6 independent jobs, each using
+`./.github/actions/docker-compose` (unchanged trigger conditions):
+
+| Job | Runs |
+|---|---|
+| `unit-tests` | `phpunit tests/src/Unit --exclude-group="time-testing"` |
+| `integration-tests` | `phpunit tests/src/Integration --exclude-group="time-testing"` |
+| `browser-tests-chrome` | `docker compose exec -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub -e PANTHER_BROWSER_NAME=chrome -T php php vendor/bin/phpunit tests/src/Browser --exclude-group="time-testing"` — mirrors the Makefile's `tests-browser-chrome` target |
+| `browser-tests-firefox` | Same, with `PANTHER_SELENIUM_HOST=http://firefox:4444/wd/hub` / `PANTHER_BROWSER_NAME=firefox` — mirrors `tests-browser-firefox` |
+| `measures` | Coverage step then Infection, in that order, in the same job (unchanged from current steps 2-3, verbatim — still includes Browser tests in the coverage/Infection run, per the pre-existing-behavior note above) |
+| `security` | `symfony security:check` (unchanged) |
+
+Every job still spins up the full `docker-compose.yaml` stack via the shared composite
+action — including `chrome`/`firefox` (with their healthchecks) even for jobs that
+don't need them (`unit-tests`, `security`), same call as the other two repos.
+
+## Docker image archive cache
+
+Same mechanism as `pokenini-back`'s corrected design (reused directly, not the
+original buggy first draft) and `pokenini-api`'s port of it:
+
+- **Cache key**: `hashFiles('.docker/php/Dockerfile', '.docker/php/conf.d/**',
+  '.docker/moco/Dockerfile', 'docker-compose.yaml')` plus host `UID`/`GID`. Confirmed
+  by reading `.docker/php/Dockerfile`: the `php_dev` target does not `COPY`
+  application source or `composer.lock` — only `.docker/php/conf.d/*.ini` files, a
+  pinned `symfony-cli` binary, and Panther-related `ENV` declarations (no file copies
+  tied to those). `vendor/` is bind-mounted and installed fresh per job via the
+  composite action's `Composer install` step — untouched by this cache.
+- **Archived images**: only the 3 *built* services — `php`, `moco.back`,
+  `moco.matomo.gbl` (`docker compose config --images php moco.back moco.matomo.gbl`).
+  Excluded: `redis`, `chrome`, `selenium/standalone-chromium`, `chrome`/`firefox`
+  (both `selenium/standalone-*` pulled images), and `web` (nginx) — all pulled, not
+  built.
+- **Flow**, identical to the corrected `pokenini-back`/`pokenini-api` versions:
+  - `actions/cache/restore@v5` (not the unified `actions/cache@v5`), `id:
+    docker-images-cache`.
+  - On hit: `docker load` the archive; skip Docker Hub login, Buildx setup, bake, and
+    pull entirely.
+  - On miss: existing login/buildx/bake/pull steps run unchanged, then `Start
+    services` (`docker compose up --wait`, `--build` dropped — this is what actually
+    builds and tags the 3 services under compose-generated names, since bake alone
+    does not), then an explicit `actions/cache/save@v5` step (keyed off
+    `steps.docker-images-cache.outputs.cache-primary-key`) saves the tar, scoped to
+    the 3 service names.
+  - `Composer install` runs unconditionally after, unchanged.
+- `chrome`/`firefox` healthchecks and `php`'s `depends_on` on them are unaffected by
+  this cache — those services are pulled, not built, so the cache-hit/miss branching
+  never touches them; `Start services` (`docker compose up --wait`) still waits on
+  their healthchecks the same way regardless of which cache path was taken.
+
+### Non-goals
+
+- No caching of `vendor/` (bind-mounted, installed fresh per job today — untouched).
+- No dedicated `build-images` job with `needs:` fan-out — same best-effort
+  shared-cache approach as the other two repos.
+- No fix for the pre-existing CI/Makefile coverage-exclusion discrepancy described
+  above.
+- No change to which browser Panther defaults to when neither env var is set — that
+  code path no longer runs in CI once `browser-tests-chrome`/`browser-tests-firefox`
+  replace the old undifferentiated Browser-test execution.
+
+## Testing / validation
+
+YAML syntax check. Push the branch and confirm in the Actions UI: 6 jobs run in
+parallel, each finishes with the same pass/fail result the current single job produces
+for the corresponding step (except the two browser jobs, which are new coverage, not a
+like-for-like split), and the second CI run on the same branch (no Dockerfile change)
+shows a cache hit with no build steps executed on any of the 6 jobs.

--- a/docs/superpowers/specs/2026-08-10-ci-tests-split-design.md
+++ b/docs/superpowers/specs/2026-08-10-ci-tests-split-design.md
@@ -30,9 +30,9 @@ behavior-preserving split, unlike every other job in this design.
 
 Single job `allin` in `.github/workflows/ci_tests.yml`:
 1. `phpunit tests/src/ --exclude-group="time-testing"` (full suite: Unit + Integration
-   + Browser, run together — no `PANTHER_SELENIUM_HOST`/`PANTHER_BROWSER_NAME` set)
+  + Browser, run together — no `PANTHER_SELENIUM_HOST`/`PANTHER_BROWSER_NAME` set)
 2. Coverage run (full suite again, `--exclude-group="browser-testing"`, Xdebug —
-   despite the flag's name this does not actually exclude Browser tests; see below)
+  despite the flag's name this does not actually exclude Browser tests; see below)
 3. Infection composer install + run (consumes step 2's coverage output)
 4. `symfony security:check`
 


### PR DESCRIPTION
## Summary

- Splits `ci_tests.yml`'s single sequential `allin` job into 6 parallel jobs (`unit-tests`, `integration-tests`, `browser-tests-chrome`, `browser-tests-firefox`, `measures`, `security`) so failures are isolated and the pipeline runs faster — matches the pattern already used by `ci_codequality.yml`/`ci_infraquality.yml`. `browser-tests-chrome`/`browser-tests-firefox` are new (a deliberate scope increase, confirmed): the original job ran `tests/src/Browser` undifferentiated, with neither `PANTHER_SELENIUM_HOST` nor `PANTHER_BROWSER_NAME` set; these two now explicitly test against each Selenium container, matching the Makefile's `tests-browser-chrome`/`tests-browser-firefox` targets.
- Adds a Docker image archive cache (`docker save`/`actions/cache`/`docker load`) to the shared `./.github/actions/docker-compose` composite action, scoped to the 3 built services (`php`, `moco.back`, `moco.matomo.gbl`).

This is a port of the same design already implemented and merged in `pokenini-back` (PR #154) and `pokenini-api` (PR #345), adapted for this repo's Panther/Selenium browser-test layer.

Design doc: `docs/superpowers/specs/2026-08-10-ci-tests-split-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-10-ci-tests-split.md`

Built via subagent-driven-development. Two review rounds caught real issues before merge:
1. Task-level review caught the same Docker-Hub-login-skipped-on-cache-hit issue found in `pokenini-api`'s final review — fixed proactively this time.
2. The final whole-branch review (Opus) found a bug unique to this repo: `docker compose config --images` resolves `depends_on` transitively, and `php` depends on `chrome`/`firefox` being healthy — so scoping the archive to "3 built services" still silently pulled in both large Selenium images (925MB + 887MB), defeating the exclusion. Fixed by filtering the image list through `grep -v '^selenium/'`, and made the cache load/save steps best-effort (`|| true`) so a corrupted cache entry can never fail a job that would otherwise pass.

## Known follow-ups (non-blocking, noted for whoever merges)

- Any GitHub branch-protection rule referencing the old `All tests` required status check needs repointing to the 6 new job names.
- `browser-tests-firefox` is genuinely new CI coverage — it has never run in this CI before. A first-run failure there is real signal, not necessarily a plan defect (`docker-compose.override.yaml.dist` already documents past intermittent Firefox connection issues).
- Every job (even `unit-tests`/`security`) now pays for both Selenium containers starting and health-gating, since `php` depends on them — a future per-job service scoping would avoid that.
- No `timeout-minutes` on the two browser jobs yet; cheap insurance against a hung WebDriver session.
- `measures` still runs the full Browser suite under coverage (the `--exclude-group="browser-testing"` flag is inert, matching pre-existing CI behavior) — an intentional non-goal of this change, not fixed here.

## Test plan

- [ ] Confirm 6 separate check runs appear (`Unit Tests`, `Integration Tests`, `Browser Tests (Chrome)`, `Browser Tests (Firefox)`, `Measures (Coverage & Mutation Testing)`, `Security`) — the 4 non-browser jobs should pass like-for-like; the 2 browser jobs are new, watch them closely
- [ ] Push a follow-up commit and confirm the second run shows a Docker image cache hit (login still runs, buildx/bake/pull steps skipped, archive excludes both Selenium images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhQeiML1mfVvDjXjB3g14e