### PR TITLE
feat(nav): dropdown navbar + Trainer/Admin sidebar menu, plus MAJ→Mise à jour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tools/php-security-checker/local-php-security-checker
 /.worktrees/
 /.worktrees-avt/
 /.worktrees-dexlink/
+/.worktrees-trainer-page-split/

--- a/docs/superpowers/plans/2026-08-12-navbar-subpage-dropdowns.md
+++ b/docs/superpowers/plans/2026-08-12-navbar-subpage-dropdowns.md
@@ -1,0 +1,352 @@
+# Navbar Dresseurs/Admin subpage dropdowns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the bottom navbar's "Dresseurs" and "Admin" items jump directly to any of their sub-pages via a dropdown, while the main label keeps navigating to the first (default) sub-page exactly as today.
+
+**Architecture:** Pure Twig template change in `templates/_nav.html.twig`. Each of the two nav items becomes a Bootstrap 5 split dropdown (`nav-link` label + separate `dropdown-toggle-split` button, both inside a `.dropdown.dropup` wrapper) listing that section's pages, reusing the exact `{key, label, route}` lists already defined in `templates/Trainer/_tabs.html.twig` and `templates/Admin/_tabs.html.twig` (duplicated locally, matching the project's existing convention of no shared data source between these partials). No controller, route, or JS changes — Bootstrap's bundled JS (already loaded in `base.html.twig`) drives the dropdown.
+
+**Tech Stack:** Symfony 8 / Twig 3.21+ (`|map` filter with arrow function), Bootstrap 5.3.8 (CDN, JS bundle already global), PHPUnit `WebTestCase` integration tests against Moco fixtures.
+
+## Global Constraints
+
+- `declare(strict_types=1)` in every PHP file touched (test files only here).
+- Test classes are `final`, carry `/** @internal */`, and `#[CoversClass(...)]` — this plan only edits existing test classes, no new ones, so just keep those attributes intact.
+- No new translation strings for sub-page labels — reuse `trainer.dex.title`, `trainer.links.title`, `trainer.personnal_data.title`, `admin.actions.update_data.title`, `admin.actions.update_availabilities.title`, `admin.actions.calculate_data.title`, `admin.actions.invalidate_data.title`, `admin.actions.trigger_pipeline.title`, `title.admin_reports`, `title.admin_versions`. One new key is needed for the toggle button's accessible name: `nav.toggle_submenu` (fr + en), added in Task 1.
+- Bootstrap detects `_inNavbar = true` because the dropdown lives inside `<nav class="navbar ...">`, so it skips Popper.js and positions the menu with plain CSS. This means the `.dropdown-toggle-split` `<button>` and the `<ul class="dropdown-menu">` MUST be direct siblings inside the same immediate wrapper as each other (Bootstrap's JS looks up the menu via "next sibling with class `dropdown-menu`" relative to the toggle) — do not nest the `<ul>` at a different depth than the toggle button.
+- `make code-quality` (includes w3c HTML validation) must stay green — every task's markup must be valid HTML5 (e.g. `<button>` not `<a href="#">` for the non-navigating toggle).
+
+---
+
+### Task 1: Trainer nav item — split dropdown
+
+**Files:**
+- Modify: `templates/_nav.html.twig:26-47`
+- Modify: `translations/messages+intl-icu.fr.yaml` (inside the `nav:` block, e.g. after line 24 `cookie-manager: "Gère tes cookies"`)
+- Modify: `translations/messages+intl-icu.en.yaml` (same location, English file)
+- Test: `tests/src/Integration/Controller/Trainer/TrainerPageTest.php`
+
+**Interfaces:**
+- Consumes: existing routes `app_trainerindex_index`, `app_trainerlinks_index`, `app_trainerpersonnaldata_index`; existing translation keys `title.trainer`, `trainer.dex.title`, `trainer.links.title`, `trainer.personnal_data.title`, `nav.login`.
+- Produces: translation key `nav.toggle_submenu` (fr: "Voir les sous-pages", en: "View sub-pages") — Task 2 (Admin) reuses this same key, no new key needed there.
+
+- [ ] **Step 1: Add the `nav.toggle_submenu` translation key**
+
+In `translations/messages+intl-icu.fr.yaml`, inside the existing `nav:` block, add a new line right after `cookie-manager: "Gère tes cookies"` (keep 2-space indent matching the sibling keys):
+
+```yaml
+  cookie-manager: "Gère tes cookies"
+  toggle_submenu: "Voir les sous-pages"
+```
+
+In `translations/messages+intl-icu.en.yaml`, same spot, after `cookie-manager: "Cookie manager"`:
+
+```yaml
+  cookie-manager: "Cookie manager"
+  toggle_submenu: "View sub-pages"
+```
+
+- [ ] **Step 2: Replace the trainer nav item markup**
+
+In `templates/_nav.html.twig`, replace lines 26-47:
+
+```twig
+                <li class="nav-item trainer-link">
+                    {% if is_granted("ROLE_TRAINER") %}
+                    {% set onTrainer = currentRoute in [
+                        'app_trainerindex_index',
+                        'app_trainerlinks_index',
+                        'app_trainerpersonnaldata_index',
+                    ] %}
+                    <a
+                        class="nav-link {{ onTrainer ? ' active' : '' }}"
+                        {{ onTrainer ? 'aria-current="page"' : '' }}
+                        href="{{ path('app_trainerindex_index') }}"
+                    >
+                        <i class="bi bi-person-badge"></i>
+                        {{ 'title.trainer'|trans }}
+                    </a>
+                    {% else %}
+                    <a class="nav-link" href="{{ path('app_connect_index') }}">
+                        <i class="bi bi-person"></i>
+                        {{ 'nav.login'|trans }}
+                    </a>
+                    {% endif %}
+                </li>
+```
+
+with:
+
+```twig
+                <li class="nav-item trainer-link">
+                    {% if is_granted("ROLE_TRAINER") %}
+                    {% set trainerPages = [
+                        {'key': 'customization', 'label': 'trainer.dex.title', 'route': 'app_trainerindex_index'},
+                        {'key': 'links', 'label': 'trainer.links.title', 'route': 'app_trainerlinks_index'},
+                        {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
+                    ] %}
+                    {% set onTrainer = currentRoute in trainerPages|map(p => p.route) %}
+                    <div class="dropdown dropup d-flex align-items-center">
+                        <a
+                            class="nav-link {{ onTrainer ? ' active' : '' }}"
+                            {{ onTrainer ? 'aria-current="page"' : '' }}
+                            href="{{ path('app_trainerindex_index') }}"
+                        >
+                            <i class="bi bi-person-badge"></i>
+                            {{ 'title.trainer'|trans }}
+                        </a>
+                        <button
+                            class="nav-link dropdown-toggle dropdown-toggle-split"
+                            type="button"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                        >
+                            <span class="visually-hidden">{{ 'nav.toggle_submenu'|trans }}</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            {% for page in trainerPages %}
+                            <li>
+                                <a
+                                    class="dropdown-item{{ currentRoute == page.route ? ' active' : '' }}"
+                                    {{ currentRoute == page.route ? 'aria-current="page"' : '' }}
+                                    href="{{ path(page.route) }}"
+                                >
+                                    {{ page.label|trans }}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% else %}
+                    <a class="nav-link" href="{{ path('app_connect_index') }}">
+                        <i class="bi bi-person"></i>
+                        {{ 'nav.login'|trans }}
+                    </a>
+                    {% endif %}
+                </li>
+```
+
+- [ ] **Step 3: Write the failing test assertions**
+
+In `tests/src/Integration/Controller/Trainer/TrainerPageTest.php`, in the `trainerPage()` test method, right after the existing line `$this->assertCount(3, $crawler->filter('#trainer-section-tab .nav-link'));`, add:
+
+```php
+        $this->assertCountFilter($crawler, 3, '.navbar-nav .trainer-link .dropdown-menu .dropdown-item');
+        $this->assertCountFilter($crawler, 1, '.navbar-nav .trainer-link .dropdown-item.active');
+        $this->assertStringContainsString(
+            '/fr/trainer',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item.active')->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/trainer/links',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item')->eq(1)->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/trainer/personnal_data',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item')->eq(2)->attr('href') ?? ''
+        );
+```
+
+- [ ] **Step 4: Run the test to verify it currently fails**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter trainerPage tests/src/Integration/Controller/Trainer/TrainerPageTest.php`
+Expected: FAIL (dropdown markup doesn't exist yet) — if Step 2 was already applied before running this, it will PASS instead; either order is fine as long as you've seen it fail once against the old markup. If you applied Step 2 first, temporarily revert `templates/_nav.html.twig` with `git stash`, run the test to confirm the FAIL, then `git stash pop`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter trainerPage tests/src/Integration/Controller/Trainer/TrainerPageTest.php`
+Expected: PASS
+
+- [ ] **Step 6: Run the full nav-touching integration suite**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Trainer`
+Expected: PASS (all trainer integration tests, including `TrainerLinksPageTest` and `TrainerPersonnalDataPageTest` which also render the navbar via `TestNavTrait`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/_nav.html.twig translations/messages+intl-icu.fr.yaml translations/messages+intl-icu.en.yaml tests/src/Integration/Controller/Trainer/TrainerPageTest.php
+git commit -m "feat(nav): add direct-link dropdown for trainer sub-pages"
+```
+
+---
+
+### Task 2: Admin nav item — split dropdown
+
+**Files:**
+- Modify: `templates/_nav.html.twig` (the admin `<li>` block, originally lines 87-107, now shifted down by the Task 1 diff — locate it via the `is_granted("ROLE_ADMIN")` condition)
+- Test: `tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php`
+
+**Interfaces:**
+- Consumes: existing routes `app_admin_update_data`, `app_admin_update_availabilities`, `app_admin_calculate_data`, `app_admin_invalidate_data`, `app_admin_trigger_pipeline`, `app_admin_reports`, `app_admin_versions`; existing translation keys `admin.actions.update_data.title`, `admin.actions.update_availabilities.title`, `admin.actions.calculate_data.title`, `admin.actions.invalidate_data.title`, `admin.actions.trigger_pipeline.title`, `title.admin_reports`, `title.admin_versions`, `nav.admin`; the `nav.toggle_submenu` key produced by Task 1.
+- Produces: nothing consumed by later tasks (this is the last task).
+
+- [ ] **Step 1: Replace the admin nav item markup**
+
+In `templates/_nav.html.twig`, find and replace:
+
+```twig
+                {% if is_granted("ROLE_ADMIN") %}
+                {% set onAdmin = currentRoute in [
+                    'app_admin_update_data',
+                    'app_admin_update_availabilities',
+                    'app_admin_calculate_data',
+                    'app_admin_invalidate_data',
+                    'app_admin_trigger_pipeline',
+                    'app_admin_reports',
+                    'app_admin_versions',
+                ] %}
+                <li class="nav-item admin-link">
+                    <a
+                        class="nav-link {{ onAdmin ? ' active' : '' }}"
+                        {{ onAdmin ? 'aria-current="page"' : '' }}
+                        href="{{ path('app_admin_update_data') }}"
+                    >
+                        <i class="bi bi-wrench-adjustable-circle"></i>
+                        {{ 'nav.admin'|trans }}
+                    </a>
+                </li>
+                {% endif %}
+```
+
+with:
+
+```twig
+                {% if is_granted("ROLE_ADMIN") %}
+                {% set adminPages = [
+                    {'key': 'update_data', 'label': 'admin.actions.update_data.title', 'route': 'app_admin_update_data'},
+                    {'key': 'update_availabilities', 'label': 'admin.actions.update_availabilities.title', 'route': 'app_admin_update_availabilities'},
+                    {'key': 'calculate_data', 'label': 'admin.actions.calculate_data.title', 'route': 'app_admin_calculate_data'},
+                    {'key': 'invalidate_data', 'label': 'admin.actions.invalidate_data.title', 'route': 'app_admin_invalidate_data'},
+                    {'key': 'trigger_pipeline', 'label': 'admin.actions.trigger_pipeline.title', 'route': 'app_admin_trigger_pipeline'},
+                    {'key': 'reports', 'label': 'title.admin_reports', 'route': 'app_admin_reports'},
+                    {'key': 'versions', 'label': 'title.admin_versions', 'route': 'app_admin_versions'},
+                ] %}
+                {% set onAdmin = currentRoute in adminPages|map(p => p.route) %}
+                <li class="nav-item admin-link">
+                    <div class="dropdown dropup d-flex align-items-center">
+                        <a
+                            class="nav-link {{ onAdmin ? ' active' : '' }}"
+                            {{ onAdmin ? 'aria-current="page"' : '' }}
+                            href="{{ path('app_admin_update_data') }}"
+                        >
+                            <i class="bi bi-wrench-adjustable-circle"></i>
+                            {{ 'nav.admin'|trans }}
+                        </a>
+                        <button
+                            class="nav-link dropdown-toggle dropdown-toggle-split"
+                            type="button"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                        >
+                            <span class="visually-hidden">{{ 'nav.toggle_submenu'|trans }}</span>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            {% for page in adminPages %}
+                            <li>
+                                <a
+                                    class="dropdown-item{{ currentRoute == page.route ? ' active' : '' }}"
+                                    {{ currentRoute == page.route ? 'aria-current="page"' : '' }}
+                                    href="{{ path(page.route) }}"
+                                >
+                                    {{ page.label|trans }}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </li>
+                {% endif %}
+```
+
+Note: this uses `dropdown-menu-end` here (unlike Task 1's trainer menu) because the admin item sits near the right edge of the navbar, right before the `logout-link` — without it, a 7-item-tall menu risks overflowing past the right edge of the viewport on narrow screens. The trainer item sits near the left edge, so the default (start-aligned) menu has room to grow rightward.
+
+- [ ] **Step 2: Write the failing test assertions**
+
+In `tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php`, in `testUpdateData()`, right after the existing line `$this->assertCountFilter($crawler, 1, '#admin-actions-tab .nav-link.active');`, add:
+
+```php
+        $this->assertCountFilter($crawler, 7, '.navbar-nav .admin-link .dropdown-menu .dropdown-item');
+        $this->assertCountFilter($crawler, 1, '.navbar-nav .admin-link .dropdown-item.active');
+        $this->assertStringContainsString(
+            '/fr/istration/update_data',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item.active')->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/istration/reports',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item')->eq(5)->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/istration/versions',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item')->eq(6)->attr('href') ?? ''
+        );
+```
+
+- [ ] **Step 3: Run the test to verify it currently fails**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter testUpdateData tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php`
+Expected: FAIL against the old markup (see Task 1 Step 4 for the stash trick if Step 1 here was already applied).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `docker compose exec php php vendor/bin/phpunit --filter testUpdateData tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Run the full admin integration suite**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin`
+Expected: PASS (covers every other Admin page that also renders this navbar item, e.g. `AdminReportsTest`, `AdminVersionsTest` if present, via `TestNavTrait`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/_nav.html.twig tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php
+git commit -m "feat(nav): add direct-link dropdown for admin sub-pages"
+```
+
+---
+
+### Task 3: Quality gates and visual verification
+
+**Files:** none created; this task only runs checks and, if needed, adds a targeted CSS fix to `public/css/base.css`.
+
+**Interfaces:**
+- Consumes: the finished markup from Tasks 1 and 2.
+- Produces: nothing (terminal task).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `make tests-integration`
+Expected: PASS, no regressions in any other test using `TestNavTrait` (e.g. `AccessReleasedTest`, `AccessPremiumTest`, `AccessPrivateTest` under `tests/src/Integration/Controller/Album/Access/`, which assert `.admin-link`/`.trainer-link` presence but not their internal structure — see Context in the design spec).
+
+- [ ] **Step 2: Run code quality checks**
+
+Run: `make code-quality`
+Expected: PASS, including the w3c HTML validator step (`<button>` used for the non-navigating toggle keeps this valid — no `<a href="#">`).
+
+- [ ] **Step 3: Manual visual check in a real browser**
+
+Run: `make start`, then open `http://localhost/fr/connect/f/c?t=admin` (Fake authenticator, dev-only route, grants `ROLE_ADMIN` which includes `ROLE_TRAINER`) to land on an authenticated page. Navigate to any page and check the bottom navbar:
+
+- Click the "Dresseurs" label → navigates straight to `/fr/trainer` (unchanged behavior).
+- Click the small caret next to "Dresseurs" → dropdown opens **upward** (not clipped below the viewport), listing all 3 trainer pages, with the current page highlighted.
+- Same checks for "Admin" (caret opens upward, lists all 7 pages, current page highlighted, menu doesn't overflow the right edge of the screen).
+- Resize the browser below the `sm` breakpoint (or use device toolbar) to confirm the collapsed hamburger menu still shows both dropdowns working the same way.
+
+If the split button's caret and label look visually misaligned or cramped (e.g. no gap between them, or the caret's hit-area feels too small on touch), add a small rule to `public/css/base.css`, appended after the existing rules:
+
+```css
+.navbar .dropdown-toggle-split {
+    padding-left: .5rem;
+    padding-right: .5rem;
+}
+```
+
+Only add this if the manual check shows a real problem — do not add it speculatively.
+
+- [ ] **Step 4: Commit (only if Step 3 required a CSS change)**
+
+```bash
+git add public/css/base.css
+git commit -m "style(nav): adjust dropdown-toggle-split padding for touch targets"
+```

--- a/docs/superpowers/plans/2026-08-12-trainer-admin-sidebar-nav.md
+++ b/docs/superpowers/plans/2026-08-12-trainer-admin-sidebar-nav.md
@@ -1,0 +1,714 @@
+# Trainer/Admin Sidebar Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the horizontal tab bar on the 3 Trainer pages and 7 Admin pages with an always-visible vertical sidebar menu (`col-md-3` beside `col-md-9` content at `md`+, stacked full-width below `md` — no toggle, no JS).
+
+**Architecture:** Pure Twig/CSS change across `templates/Trainer/_tabs.html.twig`, `templates/Admin/_tabs.html.twig`, and the 10 page templates that include them. `nav nav-tabs nav-fill` becomes `nav flex-column nav-pills` (Bootstrap's own documented tabs→sidebar conversion); every page's `{% block container %}` moves from three stacked full-width rows to a title row plus a two-column row. No controller, route, or translation changes.
+
+**Tech Stack:** Symfony 8 / Twig, Bootstrap 5.3.8 (`flex-column`, `nav-pills`, `sticky-top` utilities — all CSS-only, no new JS), PHPUnit `WebTestCase` integration tests (existing assertions, unmodified), Panther for manual visual verification.
+
+## Global Constraints
+
+- Every existing test selector must keep matching unmodified: `#trainer-section-tab .nav-link`, `#trainer-section-tab .nav-link.active`, `#admin-actions-tab > .nav-item > .nav-link`, `#admin-actions-tab .nav-link.active`, `a.nav-link` by position within `#admin-actions-tab`. This means `id`, `.nav-item`, `.nav-link`, `.active` classes and DOM order must not change — only the `<ul>`'s own class list (`nav-tabs nav-fill` → `flex-column nav-pills`) and the `role` attributes being dropped.
+- `role="tablist"` (on the `<ul>`) and `role="presentation"` (on each `<li>`) are removed in both partials — confirmed no test asserts on these.
+- `Admin/_versions.html.twig`'s root `<div class="list-group col-4">` must stay inside a `row justify-content-center` context (its content-column wrapper needs `class="col-md-9 row justify-content-center"`, not a bare `col-md-9`) — this is the one page that isn't a mechanical copy of the others.
+- No new translation strings. No changes to `Admin/_macros.html.twig` or any `_update_data.html.twig`-style content partial — they already open their own internal `.row` and nest unmodified inside the new narrower content column.
+- `make code-quality`'s `w3c` sub-check is currently not reliable evidence (see prior branch's final review — it validates the anonymous page, not the authenticated Trainer/Admin pages, and doesn't fail the build on errors). Don't treat a clean `make w3c` run as proof; rely on `make tests-integration` and real-browser visual verification instead.
+
+---
+
+### Task 1: Trainer sidebar
+
+**Files:**
+- Modify: `templates/Trainer/_tabs.html.twig`
+- Modify: `templates/Trainer/index.html.twig`
+- Modify: `templates/Trainer/links.html.twig`
+- Modify: `templates/Trainer/personnal_data.html.twig`
+
+**Interfaces:**
+- Consumes: existing `trainerPages` array (routes `app_trainerindex_index`, `app_trainerlinks_index`, `app_trainerpersonnaldata_index`; labels `trainer.dex.title`, `trainer.links.title`, `trainer.personnal_data.title`), existing content partials `Trainer/Section/_dex.html.twig`, `Trainer/Section/_links.html.twig`, `Trainer/Section/_personnal_data.html.twig` (unmodified).
+- Produces: nothing consumed by Task 2 (independent section).
+
+- [ ] **Step 1: Rewrite `templates/Trainer/_tabs.html.twig`**
+
+Replace the entire file content:
+
+```twig
+{% set trainerPages = [
+  {'key': 'customization', 'label': 'trainer.dex.title', 'route': 'app_trainerindex_index'},
+  {'key': 'links', 'label': 'trainer.links.title', 'route': 'app_trainerlinks_index'},
+  {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
+] %}
+
+<ul class="nav nav-tabs nav-fill mb-4" id="trainer-section-tab" role="tablist">
+  {% for page in trainerPages %}
+    <li class="nav-item" role="presentation">
+      <a
+        class="nav-link{{ page.key == active ? ' active' : '' }}"
+        {{ page.key == active ? 'aria-current="page"' : '' }}
+        href="{{ path(page.route) }}"
+      >
+        {{ page.label|trans }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+with:
+
+```twig
+{% set trainerPages = [
+  {'key': 'customization', 'label': 'trainer.dex.title', 'route': 'app_trainerindex_index'},
+  {'key': 'links', 'label': 'trainer.links.title', 'route': 'app_trainerlinks_index'},
+  {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
+] %}
+
+<ul class="nav flex-column nav-pills mb-4 mb-md-0" id="trainer-section-tab">
+  {% for page in trainerPages %}
+    <li class="nav-item">
+      <a
+        class="nav-link{{ page.key == active ? ' active' : '' }}"
+        {{ page.key == active ? 'aria-current="page"' : '' }}
+        href="{{ path(page.route) }}"
+      >
+        {{ page.label|trans }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+- [ ] **Step 2: Rewrite the container block in `templates/Trainer/index.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'customization'}) }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto row">
+
+      <p class="text-secondary">{{ 'trainer.welcome'|trans|htmlNl2br }}</p>
+
+      {{ include('Trainer/Section/_dex.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+with:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3 sticky-top">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'customization'}) }}
+    </div>
+    <div class="col-md-9">
+      <p class="text-secondary">{{ 'trainer.welcome'|trans|htmlNl2br }}</p>
+
+      {{ include('Trainer/Section/_dex.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+- [ ] **Step 3: Rewrite the container block in `templates/Trainer/links.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'links'}) }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto row">
+      {{ include('Trainer/Section/_links.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+with:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3 sticky-top">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'links'}) }}
+    </div>
+    <div class="col-md-9">
+      {{ include('Trainer/Section/_links.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+- [ ] **Step 4: Rewrite the container block in `templates/Trainer/personnal_data.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'personnal_data'}) }}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 mx-auto row">
+      {{ include('Trainer/Section/_personnal_data.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+with:
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3 sticky-top">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'personnal_data'}) }}
+    </div>
+    <div class="col-md-9">
+      {{ include('Trainer/Section/_personnal_data.html.twig') }}
+    </div>
+  </div>
+{% endblock container %}
+```
+
+- [ ] **Step 5: Run the Trainer integration suite**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Trainer`
+Expected: PASS, no changes needed — these tests assert on `#trainer-section-tab` ids/classes/hrefs, all preserved by Steps 1-4.
+
+- [ ] **Step 6: Visual verification (one Trainer page, two widths)**
+
+Write a throwaway Panther test (not committed — same disposable-test technique used on the earlier navbar-dropdown branch: create it under `tests/src/Browser/`, run it, read the screenshot, delete the test file and screenshot afterward). Cover `/fr/trainer`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser;
+
+use App\Tests\Utils\GetUserToken;
+use Facebook\WebDriver\WebDriverDimension;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class _ManualSidebarCheckTest extends AbstractBrowserTestCase
+{
+    #[Test]
+    public function trainerSidebarAtTwoWidths(): void
+    {
+        $client = self::getNewClient();
+        $user = GetUserToken::getFakeUserToken();
+        $user->addTrainerRole();
+        $this->loginUser($client, $user);
+
+        $client->manage()->window()->setSize(new WebDriverDimension(1280, 900));
+        $client->request('GET', '/fr/trainer');
+        $client->takeScreenshot('/app/var/screenshots/manual_sidebar_trainer_wide.png');
+
+        $client->manage()->window()->setSize(new WebDriverDimension(375, 900));
+        $client->request('GET', '/fr/trainer');
+        $client->takeScreenshot('/app/var/screenshots/manual_sidebar_trainer_narrow.png');
+
+        self::assertTrue(true);
+    }
+}
+```
+
+Run: `docker compose exec -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub -e PANTHER_BROWSER_NAME=chrome php php vendor/bin/phpunit --filter trainerSidebarAtTwoWidths tests/src/Browser/_ManualSidebarCheckTest.php`
+
+Read both screenshots. Confirm:
+- At 1280px: the "Ton espace de dresseur" / "C'est quoi ton dex ?" / "Données personnelles" menu sits as a narrow column to the left of the page content, not above it.
+- At 375px: the menu sits as a full-width block stacked above the page content, not squeezed beside it.
+
+Delete the throwaway test file and both screenshots afterward.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/Trainer/_tabs.html.twig templates/Trainer/index.html.twig templates/Trainer/links.html.twig templates/Trainer/personnal_data.html.twig
+git commit -m "feat(trainer): replace section tabs with a sidebar menu"
+```
+
+---
+
+### Task 2: Admin sidebar
+
+**Files:**
+- Modify: `templates/Admin/_tabs.html.twig`
+- Modify: `templates/Admin/update_data.html.twig`
+- Modify: `templates/Admin/update_availabilities.html.twig`
+- Modify: `templates/Admin/calculate_data.html.twig`
+- Modify: `templates/Admin/invalidate_data.html.twig`
+- Modify: `templates/Admin/trigger_pipeline.html.twig`
+- Modify: `templates/Admin/reports.html.twig`
+- Modify: `templates/Admin/versions.html.twig`
+
+**Interfaces:**
+- Consumes: existing `adminPages` array (7 routes/labels, unchanged), existing content partials `Admin/_update_data.html.twig` and five siblings, `Admin/_reports.html.twig`, `Admin/_versions.html.twig` (all unmodified — each already opens its own internal `.row`).
+- Produces: nothing consumed by Task 1 (independent section).
+
+- [ ] **Step 1: Rewrite `templates/Admin/_tabs.html.twig`**
+
+Replace the entire file content:
+
+```twig
+{% set adminPages = [
+  {'key': 'update_data', 'label': 'admin.actions.update_data.title', 'route': 'app_admin_update_data'},
+  {'key': 'update_availabilities', 'label': 'admin.actions.update_availabilities.title', 'route': 'app_admin_update_availabilities'},
+  {'key': 'calculate_data', 'label': 'admin.actions.calculate_data.title', 'route': 'app_admin_calculate_data'},
+  {'key': 'invalidate_data', 'label': 'admin.actions.invalidate_data.title', 'route': 'app_admin_invalidate_data'},
+  {'key': 'trigger_pipeline', 'label': 'admin.actions.trigger_pipeline.title', 'route': 'app_admin_trigger_pipeline'},
+  {'key': 'reports', 'label': 'title.admin_reports', 'route': 'app_admin_reports'},
+  {'key': 'versions', 'label': 'title.admin_versions', 'route': 'app_admin_versions'},
+] %}
+
+<ul class="nav nav-tabs nav-fill mb-4" id="admin-actions-tab" role="tablist">
+  {% for page in adminPages %}
+    <li class="nav-item" role="presentation">
+      <a
+        class="nav-link{{ page.key == active ? ' active' : '' }}"
+        {{ page.key == active ? 'aria-current="page"' : '' }}
+        href="{{ path(page.route) }}"
+      >
+        {{ page.label|trans }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+with:
+
+```twig
+{% set adminPages = [
+  {'key': 'update_data', 'label': 'admin.actions.update_data.title', 'route': 'app_admin_update_data'},
+  {'key': 'update_availabilities', 'label': 'admin.actions.update_availabilities.title', 'route': 'app_admin_update_availabilities'},
+  {'key': 'calculate_data', 'label': 'admin.actions.calculate_data.title', 'route': 'app_admin_calculate_data'},
+  {'key': 'invalidate_data', 'label': 'admin.actions.invalidate_data.title', 'route': 'app_admin_invalidate_data'},
+  {'key': 'trigger_pipeline', 'label': 'admin.actions.trigger_pipeline.title', 'route': 'app_admin_trigger_pipeline'},
+  {'key': 'reports', 'label': 'title.admin_reports', 'route': 'app_admin_reports'},
+  {'key': 'versions', 'label': 'title.admin_versions', 'route': 'app_admin_versions'},
+] %}
+
+<ul class="nav flex-column nav-pills mb-4 mb-md-0" id="admin-actions-tab">
+  {% for page in adminPages %}
+    <li class="nav-item">
+      <a
+        class="nav-link{{ page.key == active ? ' active' : '' }}"
+        {{ page.key == active ? 'aria-current="page"' : '' }}
+        href="{{ path(page.route) }}"
+      >
+        {{ page.label|trans }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+- [ ] **Step 2: Rewrite the container block in `templates/Admin/update_data.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'active': 'update_data'} %}
+    {% include 'Admin/_update_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'update_data'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_update_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 3: Rewrite the container block in `templates/Admin/update_availabilities.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'active': 'update_availabilities'} %}
+    {% include 'Admin/_update_availabilities.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'update_availabilities'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_update_availabilities.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 4: Rewrite the container block in `templates/Admin/calculate_data.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'active': 'calculate_data'} %}
+    {% include 'Admin/_calculate_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'calculate_data'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_calculate_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 5: Rewrite the container block in `templates/Admin/invalidate_data.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'active': 'invalidate_data'} %}
+    {% include 'Admin/_invalidate_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'invalidate_data'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_invalidate_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 6: Rewrite the container block in `templates/Admin/trigger_pipeline.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'active': 'trigger_pipeline'} %}
+    {% include 'Admin/_trigger_pipeline.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'trigger_pipeline'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_trigger_pipeline.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 7: Rewrite the container block in `templates/Admin/reports.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'page': 'reports', 'active': 'reports'} %}
+    {% include 'Admin/_reports.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'page': 'reports', 'active': 'reports'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_reports.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 8: Rewrite the container block in `templates/Admin/versions.html.twig`**
+
+Replace:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12 row justify-content-center">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+    {% include 'Admin/_tabs.html.twig' with {'page': 'versions', 'active': 'versions'} %}
+    {% include 'Admin/_versions.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+with:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'page': 'versions', 'active': 'versions'} %}
+  </div>
+  <div class="col-md-9 row justify-content-center">
+    {% include 'Admin/_versions.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+Note the `row justify-content-center` kept on this page's content column only: `Admin/_versions.html.twig`'s root element is `<div class="list-group col-4" id="versions-list">` — a grid column class on its own root, needing a `.row` context to size/center against. Every other Admin content partial already opens its own internal `.row` and doesn't need this.
+
+- [ ] **Step 9: Run the Admin integration suite**
+
+Run: `docker compose exec php php vendor/bin/phpunit tests/src/Integration/Controller/Admin`
+Expected: PASS, no changes needed — these tests assert on `#admin-actions-tab` ids/classes/hrefs/positions, all preserved by Steps 1-8.
+
+- [ ] **Step 10: Visual verification (two Admin pages, two widths each)**
+
+Same throwaway-Panther-test technique as Task 1 Step 6 (write under `tests/src/Browser/`, run, read screenshots, delete file and screenshots afterward — nothing committed). Cover `/fr/istration/update_data` (representative plain action page) and `/fr/istration/versions` (the special centered-content case):
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Browser;
+
+use App\Tests\Utils\GetUserToken;
+use Facebook\WebDriver\WebDriverDimension;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class _ManualAdminSidebarCheckTest extends AbstractBrowserTestCase
+{
+    #[Test]
+    public function adminSidebarAtTwoWidths(): void
+    {
+        $client = self::getNewClient();
+        $user = GetUserToken::getFakeUserToken();
+        $user->addAdminRole();
+        $this->loginUser($client, $user);
+
+        foreach (['update_data', 'versions'] as $page) {
+            $client->manage()->window()->setSize(new WebDriverDimension(1280, 900));
+            $client->request('GET', '/fr/istration/'.$page);
+            $client->takeScreenshot('/app/var/screenshots/manual_sidebar_admin_'.$page.'_wide.png');
+
+            $client->manage()->window()->setSize(new WebDriverDimension(375, 900));
+            $client->request('GET', '/fr/istration/'.$page);
+            $client->takeScreenshot('/app/var/screenshots/manual_sidebar_admin_'.$page.'_narrow.png');
+        }
+
+        self::assertTrue(true);
+    }
+}
+```
+
+Run: `docker compose exec -e PANTHER_SELENIUM_HOST=http://chrome:4444/wd/hub -e PANTHER_BROWSER_NAME=chrome php php vendor/bin/phpunit --filter adminSidebarAtTwoWidths tests/src/Browser/_ManualAdminSidebarCheckTest.php`
+
+Read all four screenshots. Confirm:
+- At 1280px on `update_data`: the 7-item menu sits as a narrow column to the left, action cards to the right, no horizontal overflow.
+- At 375px on `update_data`: the menu stacks full-width above the action cards.
+- At 1280px on `versions`: the version list stays centered within its content column (not flush-left, not overflowing) — this is the one page with the `row justify-content-center` special case from Step 8.
+- At 375px on `versions`: same stacking as `update_data`.
+
+Delete the throwaway test file and all four screenshots afterward.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add templates/Admin/_tabs.html.twig templates/Admin/update_data.html.twig templates/Admin/update_availabilities.html.twig templates/Admin/calculate_data.html.twig templates/Admin/invalidate_data.html.twig templates/Admin/trigger_pipeline.html.twig templates/Admin/reports.html.twig templates/Admin/versions.html.twig
+git commit -m "feat(admin): replace section tabs with a sidebar menu"
+```
+
+---
+
+### Task 3: Quality gates and final visual sweep
+
+**Files:** none created; this task only runs checks and, if needed, adds a targeted CSS fix to `public/css/base.css` or `public/css/admin.css`.
+
+**Interfaces:**
+- Consumes: the finished markup from Tasks 1 and 2.
+- Produces: nothing (terminal task).
+
+- [ ] **Step 1: Run the full integration suite**
+
+Run: `make tests-integration`
+Expected: PASS, no regressions anywhere in the codebase — no other test file references `_tabs.html.twig`'s markup beyond what Tasks 1/2 already verified.
+
+- [ ] **Step 2: Run code quality checks**
+
+Run: `make code-quality`
+Expected: phpcsfixer/phpmd/psalm/phpstan/deptrac all exit 0 (pure Twig/nothing-PHP change, so these should be unaffected, but confirm). Per Global Constraints, don't treat the `w3c` sub-check's result as meaningful signal either way — it doesn't validate these authenticated pages correctly (pre-existing, unrelated defect, already documented in the prior branch's final review).
+
+- [ ] **Step 3: Manual visual sweep of the remaining pages**
+
+Tasks 1 and 2 only screenshot-checked one Trainer page and two Admin pages. Using the same throwaway-Panther-test technique (write, run, read screenshots, delete test file and screenshots — nothing committed), spot-check the remaining pages at a single narrow width (375px) to confirm they all stack correctly, since they're the most likely to reveal a page-specific layout quirk the earlier checks didn't catch:
+
+- `/fr/trainer/links`
+- `/fr/trainer/personnal_data`
+- `/fr/istration/update_availabilities`
+- `/fr/istration/calculate_data`
+- `/fr/istration/invalidate_data`
+- `/fr/istration/trigger_pipeline`
+- `/fr/istration/reports`
+
+For each, confirm the sidebar stacks above the content with no horizontal overflow and no visually broken card grid. If any page shows a real layout problem, add the minimal CSS fix to `public/css/base.css` (Trainer pages) or `public/css/admin.css` (Admin pages) — do not add CSS speculatively for pages that already look correct.
+
+- [ ] **Step 4: Commit (only if Step 3 required a CSS change)**
+
+```bash
+git add public/css/base.css public/css/admin.css
+git commit -m "style(sidebar): fix layout issue found in visual sweep"
+```

--- a/docs/superpowers/specs/2026-08-12-navbar-subpage-dropdowns-design.md
+++ b/docs/superpowers/specs/2026-08-12-navbar-subpage-dropdowns-design.md
@@ -1,0 +1,126 @@
+# Direct links + dropdown for Dresseurs/Admin navbar items
+
+## Context
+
+`templates/_nav.html.twig` renders a `fixed-bottom` navbar. The "Dresseurs"
+(`trainer-link`) and "Admin" (`admin-link`) items are each a single
+`<a class="nav-link">` pointing at the first sub-page of their section:
+
+- Trainer (`is_granted("ROLE_TRAINER")`): links to `app_trainerindex_index`.
+  The section actually has three pages, already tabbed in-page by
+  `templates/Trainer/_tabs.html.twig`: `app_trainerindex_index` (dex
+  customization), `app_trainerlinks_index`, `app_trainerpersonnaldata_index`.
+- Admin (`is_granted("ROLE_ADMIN")`): links to `app_admin_update_data`. The
+  section has seven pages, already tabbed in-page by
+  `templates/Admin/_tabs.html.twig`: `app_admin_update_data`,
+  `app_admin_update_availabilities`, `app_admin_calculate_data`,
+  `app_admin_invalidate_data`, `app_admin_trigger_pipeline`,
+  `app_admin_reports`, `app_admin_versions`.
+
+Both `_tabs.html.twig` partials already define a local `{key, label, route}`
+list to render their in-page tab bar; `_nav.html.twig` currently only knows
+about the first route of each list, hardcoded, plus a separate flat list of
+routes to compute the `onTrainer`/`onAdmin` "is this section active" flag.
+
+Reaching any sub-page other than the first currently requires first landing
+on the section's default page, then clicking its in-page tab. The goal is
+to let the navbar jump straight to any sub-page.
+
+## Goal
+
+From the bottom navbar, without leaving it: keep the current one-click
+behavior to the default (first) sub-page, and add a dropdown to jump
+directly to any other sub-page of that section — for both Dresseurs and
+Admin.
+
+## Design
+
+### Markup: split dropdown per section, `dropup` because the navbar is fixed-bottom
+
+Bootstrap 5.3.8's JS bundle is already loaded globally (`base.html.twig`),
+so the native dropdown component (`data-bs-toggle="dropdown"`) needs no
+custom JS.
+
+For each of the two sections, `_nav.html.twig` changes the `<li class="nav-item ...">`
+into a split-button-style dropdown, adapting Bootstrap's split-button
+pattern (normally `btn-group` + `btn`) to a nav item:
+
+- `<li class="nav-item trainer-link dropdown dropup">` (`admin-link` for
+  the other one). `dropdown` establishes the positioning context; `dropup`
+  flips the menu to open upward (there is no room below a fixed-bottom
+  navbar) — pure CSS, Bootstrap reads the class at dropdown-open time.
+- Inside, a `<div class="d-flex align-items-center">` wrapping two links:
+  - `<a class="nav-link ...">` — unchanged `href` to the first route
+    (`app_trainerindex_index` / `app_admin_update_data`), unchanged icon
+    and label, unchanged `active`/`aria-current` logic. This preserves the
+    current one-click behavior exactly.
+  - `<a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">`
+    — the only new clickable element, showing just Bootstrap's default
+    caret (flipped upward by `.dropup`) plus a `visually-hidden` label for
+    screen readers (new translation key `nav.toggle_submenu`, fr/en).
+- `<ul class="dropdown-menu">` listing every page of the section (including
+  the first — consistent with how `_tabs.html.twig` always shows all tabs,
+  and lets the current page be highlighted even when it's the first one):
+  one `<li><a class="dropdown-item{{ active ? ' active' : '' }}" href="{{ path(page.route) }}">{{ page.label|trans }}</a></li>`
+  per entry.
+
+### Data: local list per section, matching existing duplication style
+
+`_nav.html.twig` gets its own `trainerPages` / `adminPages` Twig `{% set %}`
+lists (same `{key, label, route}` shape and same translation keys already
+used by the two `_tabs.html.twig` partials — no new translation strings
+for labels). This duplicates the list that already exists in each
+`_tabs.html.twig`; the project has no shared-data pattern between these
+partials today (each `_tabs.html.twig` already hardcodes its own list
+independently), so this follows existing convention rather than
+introducing a new abstraction. If a third consumer of these lists shows up
+later, that's the point to extract a shared source (e.g. a Twig
+extension), not before.
+
+The existing `onTrainer` / `onAdmin` flags (used for the main link's
+`active`/`aria-current`) are simplified to `currentRoute in trainerPages|map(p => p.route)`
+(resp. `adminPages`), instead of a separately hand-maintained flat list of
+routes — same result, one fewer place to keep in sync when a section
+grows.
+
+### No changes to
+
+- Any controller or route.
+- `Trainer/_tabs.html.twig` / `Admin/_tabs.html.twig` (in-page tabs stay
+  exactly as they are).
+- `TestNavTrait` — no test asserts an exact count of `<a>` elements inside
+  `.trainer-link`/`.admin-link`, only presence of the `li` and a `href`
+  substring on the first matched `a`, both of which keep working since the
+  main link stays the first `<a>` in the item.
+
+### CSS
+
+`.dropdown-toggle-split` is Bootstrap's generic split-button class (not
+scoped to `.btn`), so it applies its padding tweaks to the `nav-link`
+caret without extra CSS. No new rules expected in `base.css`; only add
+something there if visual QA in a real browser shows misalignment.
+
+## Tests
+
+- Extend integration tests that already render the navbar (wherever
+  `assertConnectedNavBar`/`assertTrainerAlbumNavBar`/`assertAdminAlbumNavBar`
+  from `TestNavTrait` are used) or add a small dedicated nav test: assert
+  the dropdown-menu for each section lists all of its routes, and that the
+  entry matching the current route carries `.active`.
+- Browser test (optional, `tests/src/Browser/`): click the caret, assert
+  the menu becomes visible and a sub-page link navigates correctly. Given
+  the existing browser-test suite doesn't cover the navbar today, add this
+  only if it fits naturally; not a hard requirement of this design.
+- `make tests-unit`/`make tests-integration` must stay green; no unit-level
+  logic is introduced (pure Twig template change), so no new unit tests.
+
+## Out of scope
+
+- No visual redesign of the navbar beyond this dropdown addition (icons,
+  colors, spacing stay as-is besides the new caret).
+- No change to which pages exist in each section or their order.
+- No "remember last visited sub-page" behavior — the main link always goes
+  to the first page, as today.
+- Mobile (`navbar-toggler` collapsed) view: no special-casing: Bootstrap's
+  dropdown component works the same inside a collapsed `navbar-collapse`,
+  so no separate design needed for small screens.

--- a/docs/superpowers/specs/2026-08-12-trainer-admin-sidebar-nav-design.md
+++ b/docs/superpowers/specs/2026-08-12-trainer-admin-sidebar-nav-design.md
@@ -1,0 +1,243 @@
+# Replace Trainer/Admin section tabs with a sidebar menu
+
+## Context
+
+`templates/Trainer/_tabs.html.twig` and `templates/Admin/_tabs.html.twig` each
+render a horizontal Bootstrap tab bar (`<ul class="nav nav-tabs nav-fill"
+role="tablist" id="...">`) listing the pages of their section (3 trainer
+pages, 7 admin pages — same `{key, label, route}` lists documented in
+[2026-08-12-navbar-subpage-dropdowns-design.md](2026-08-12-navbar-subpage-dropdowns-design.md)).
+Every one of the 10 pages that includes one of these partials
+(`Trainer/index.html.twig`, `Trainer/links.html.twig`,
+`Trainer/personnal_data.html.twig`; `Admin/update_data.html.twig`,
+`Admin/update_availabilities.html.twig`, `Admin/calculate_data.html.twig`,
+`Admin/invalidate_data.html.twig`, `Admin/trigger_pipeline.html.twig`,
+`Admin/reports.html.twig`, `Admin/versions.html.twig`) follows the same
+shape: a full-width `<h1>` row, then a full-width row containing the tabs
+include, then a full-width row containing the page's content include.
+
+The goal is to turn this into a sidebar layout: the section's pages listed
+in a vertical menu to the left, page content to the right.
+
+## Goal
+
+Replace the horizontal tab bar with an always-visible vertical sidebar menu
+on both the Trainer and Admin sections. On screens narrower than the `md`
+breakpoint (768px) the sidebar stacks above the content instead of sitting
+beside it — no toggle button, no offcanvas, no JS. This was confirmed with
+the user: the sidebar is a pure layout change, always visible.
+
+## Design
+
+### `_tabs.html.twig`: tabs markup → vertical pills
+
+Both partials change identically. `Trainer/_tabs.html.twig`:
+
+```twig
+{% set trainerPages = [
+  {'key': 'customization', 'label': 'trainer.dex.title', 'route': 'app_trainerindex_index'},
+  {'key': 'links', 'label': 'trainer.links.title', 'route': 'app_trainerlinks_index'},
+  {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
+] %}
+
+<ul class="nav flex-column nav-pills mb-4 mb-md-0" id="trainer-section-tab">
+  {% for page in trainerPages %}
+    <li class="nav-item">
+      <a
+        class="nav-link{{ page.key == active ? ' active' : '' }}"
+        {{ page.key == active ? 'aria-current="page"' : '' }}
+        href="{{ path(page.route) }}"
+      >
+        {{ page.label|trans }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+```
+
+`Admin/_tabs.html.twig` gets the same treatment (its own `adminPages` array
+and `id="admin-actions-tab"` untouched).
+
+Changes from the current markup, and why each one is safe:
+- `nav nav-tabs nav-fill` → `nav flex-column nav-pills`: this is Bootstrap's
+  own documented conversion from horizontal tabs to a vertical sidebar nav.
+  `nav-fill` (equal-width horizontal tabs) has no meaning once the list is
+  vertical, so it's dropped.
+- `mb-4` → `mb-4 mb-md-0`: keeps a gap below the menu when it's stacked
+  above content on narrow screens, removes it once the menu sits beside
+  content as its own column at `md`+ (a `col-md-9` sibling already provides
+  the visual separation there).
+- `role="tablist"` / `role="presentation"` on each `<li>` are dropped. These
+  pages are separate routes, not panels of a single-page tab widget — the
+  ARIA tabs pattern was already a mismatch for full-page navigation before
+  this change; removing it here is a small correction that falls out
+  naturally from rewriting this markup, not a separate cleanup pass.
+- `id="trainer-section-tab"` / `id="admin-actions-tab"` and every
+  `.nav-item` / `.nav-link` / `.active` class are unchanged. Every existing
+  test selector (`#trainer-section-tab .nav-link`, `#admin-actions-tab >
+  .nav-item > .nav-link`, `.nav-link.active`, etc. — see Tests below) keeps
+  matching without modification.
+- Sidebar becomes `sticky-top` (Bootstrap utility, no JS) so it stays
+  visible while scrolling long pages like Admin's "MAJ des données", which
+  stacks several action cards vertically. Applied on the wrapping column
+  (`<div class="col-md-3">...`) in each page template, not on the `<ul>`
+  itself, so it has no effect once the column isn't beside content (below
+  `md`, a stacked full-width column has nothing to "stick" against that
+  isn't already at the top).
+
+### Page templates: one row → two columns
+
+Every page's `{% block container %}` moves from three stacked full-width
+rows (title / tabs / content) to: one full-width row for the `<h1>`, then
+one row split into a `col-md-3` (sidebar) and a `col-md-9` (content). Below
+`md` both columns are full width and stack (`col-md-*` only takes effect at
+`md`+; Bootstrap's default column behavior below that is 100% width,
+already stacked — this is exactly the "always visible, stacked" behavior
+the user chose, achieved with zero extra classes).
+
+Trainer example (`Trainer/index.html.twig`, the other two Trainer pages
+follow the identical shape with their own `active` key and content
+include):
+
+```twig
+{% block container %}
+  <div class="row">
+    <div class="col-md-10 mx-auto text-center row">
+      <h1>{{ 'title.trainer'|trans }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3 sticky-top">
+      {{ include('Trainer/_tabs.html.twig', {'active': 'customization'}) }}
+    </div>
+    <div class="col-md-9">
+      <p class="text-secondary">{{ 'trainer.welcome'|trans|htmlNl2br }}</p>
+
+      {{ include('Trainer/Section/_dex.html.twig') }}
+    </div>
+  </div>
+{% endblock %}
+```
+
+The content include's own internal grid (e.g. `Trainer/Section/_dex.html.twig`
+already opens its own `<div class="row">` for its item cards) is untouched
+— it nests correctly inside the new `col-md-9` exactly as it nested inside
+the old `col-md-12`. The vestigial extra `row` class on the old
+`col-md-12 mx-auto row` content wrapper is dropped as part of this rewrite
+(it did nothing: nothing inside `_dex.html.twig`, `_links.html.twig`, or
+`_personnal_data.html.twig` is a direct `col-*` child of that specific div).
+
+Admin example (`Admin/update_data.html.twig`, the other five plain Admin
+action pages — `update_availabilities`, `calculate_data`,
+`invalidate_data`, `trigger_pipeline`, `reports` — follow the identical
+shape):
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'active': 'update_data'} %}
+  </div>
+  <div class="col-md-9">
+    {% include 'Admin/_update_data.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+`reports.html.twig` keeps passing its (already-unused — pre-existing dead
+parameter, out of scope to remove here) `'page': 'reports'` include
+argument alongside `'active': 'reports'`.
+
+**`Admin/versions.html.twig` is a special case.** `Admin/_versions.html.twig`
+(the content partial) opens with `<div class="list-group col-4"
+id="versions-list">` — it puts a grid column class directly on its own root
+element and relies on being inside a `row justify-content-center` wrapper
+to center that narrow list on the page (this is why today's
+`versions.html.twig` wraps everything in `<div class="col-12 row
+justify-content-center">`). Moving the include straight into a bare
+`col-md-9` would lose that centering. Keep the centering wrapper, scoped
+to just the content column:
+
+```twig
+{% block container %}
+<div id="admin" class="row">
+  <div class="col-12">
+    <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
+    {% include 'Admin/_tabs.html.twig' with {'page': 'versions', 'active': 'versions'} %}
+  </div>
+  <div class="col-md-9 row justify-content-center">
+    {% include 'Admin/_versions.html.twig' %}
+  </div>
+</div>
+{% endblock %}
+```
+
+### No changes to
+
+- Any controller, route, or translation.
+- The content partials themselves (`Trainer/Section/_*.html.twig`,
+  `Admin/_update_data.html.twig` and siblings, `Admin/_reports.html.twig`,
+  `Admin/_versions.html.twig`) — all already open their own internal
+  `.row` where they need one, so they drop into a narrower parent column
+  unmodified.
+- `public/css/base.css` / `public/css/admin.css` — no new rules expected;
+  only add something if visual QA in a real browser shows a real problem
+  (same policy as the earlier navbar-dropdown work), not speculatively.
+
+### Expected visual side effect (not a defect)
+
+Bootstrap grid breakpoints size against the viewport, not the parent
+column. Card grids inside the new narrower `col-md-9` content area (Admin's
+`col-lg-4 col-md-6` action cards, the Trainer dex's `col-lg-3 col-md-4
+col-sm-6` items) will pack more tightly per row than they do today at the
+same viewport width, because they now share the row with a sidebar instead
+of spanning the full page. This is the standard trade-off of any
+sidebar-plus-content layout and is not compensated for in this design.
+
+## Tests
+
+Every existing test assertion targeting these partials keeps passing
+unmodified, because ids, `.nav-item`/`.nav-link`/`.active` classes, hrefs,
+and item counts/order are all untouched — only wrapping/layout classes
+change:
+- `TrainerPageTest`, `TrainerLinksPageTest`, `TrainerPersonnalDataPageTest`:
+  `#trainer-section-tab .nav-link` count and `.nav-link.active` href.
+- `AdminUpdateDataTest`: `#admin-actions-tab > .nav-item > .nav-link` count,
+  `.nav-link.active` count, and specific `a.nav-link` hrefs by position.
+- `AdminReportsTest`, and the dropdown-active-state assertions added to it
+  and to `TrainerLinksPageTest` by the earlier navbar-dropdown branch
+  (`.navbar-nav .trainer-link .dropdown-item.active` /
+  `.navbar-nav .admin-link .dropdown-item.active`) — those target the
+  *bottom navbar*, an entirely different partial, untouched by this design.
+
+No new PHPUnit assertions are strictly required for a pure layout/CSS
+change, but the one behavior that could silently break — the stack-below-
+`md` responsive switch — has no automated coverage today and won't get any
+from a DOM-structure assertion (it's a CSS media-query effect, not a markup
+difference). Verify it with a real-browser screenshot check (same
+throwaway-Panther-test technique used for the navbar-dropdown branch): one
+screenshot at a `md`+ width showing sidebar-beside-content, one at a narrow
+width showing sidebar-stacked-above-content, for at least one Trainer page
+and one Admin page (`versions.html.twig`, given its special centering
+case, is worth including).
+
+## Out of scope
+
+- No changes to the bottom navbar or its "jump directly to a sub-page"
+  dropdown added in the prior branch — that's global cross-section
+  navigation from anywhere in the site; this sidebar is local, in-page
+  navigation within the Trainer or Admin section. The two overlap in
+  purpose but are not merged into one component.
+- No offcanvas/collapsible sidebar for narrow screens — confirmed with the
+  user, always-visible stacked layout only.
+- No removal of the pre-existing unused `'page'` include parameter on
+  `Admin/reports.html.twig` / `Admin/versions.html.twig`.
+- No compensating changes to the card-grid breakpoints inside content
+  partials (see "Expected visual side effect" above).

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -100,3 +100,16 @@ html {
     font-size: .8rem;
     color: var(--bs-secondary-color);
 }
+
+/* _nav.html.twig's split-dropdown <ul> is a flex-item child of the
+    d-flex .dropdown row (needed so Bootstrap's JS finds it as a sibling of
+    the toggle button), not of a block-level <li> like Bootstrap's normal
+    navbar-dropdown markup. Below the sm breakpoint Bootstrap's own CSS sets
+    .navbar-nav .dropdown-menu to position: static, so it would render as a
+    third flex item beside the label/caret and overflow the viewport with
+    long labels. Force absolute positioning at every width - the .dropdown
+    wrapper is already position: relative, and the navbar is fixed-bottom so
+    there's always room above. */
+.navbar-nav .dropdown.dropup .dropdown-menu {
+    position: absolute;
+}

--- a/templates/Admin/_tabs.html.twig
+++ b/templates/Admin/_tabs.html.twig
@@ -8,9 +8,9 @@
   {'key': 'versions', 'label': 'title.admin_versions', 'route': 'app_admin_versions'},
 ] %}
 
-<ul class="nav nav-tabs nav-fill mb-4" id="admin-actions-tab" role="tablist">
+<ul class="nav flex-column nav-pills mb-4 mb-md-0" id="admin-actions-tab">
   {% for page in adminPages %}
-    <li class="nav-item" role="presentation">
+    <li class="nav-item">
       <a
         class="nav-link{{ page.key == active ? ' active' : '' }}"
         {{ page.key == active ? 'aria-current="page"' : '' }}

--- a/templates/Admin/calculate_data.html.twig
+++ b/templates/Admin/calculate_data.html.twig
@@ -23,7 +23,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'active': 'calculate_data'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_calculate_data.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/calculate_data.html.twig
+++ b/templates/Admin/calculate_data.html.twig
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'active': 'calculate_data'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/invalidate_data.html.twig
+++ b/templates/Admin/invalidate_data.html.twig
@@ -23,7 +23,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'active': 'invalidate_data'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_invalidate_data.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/invalidate_data.html.twig
+++ b/templates/Admin/invalidate_data.html.twig
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'active': 'invalidate_data'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/reports.html.twig
+++ b/templates/Admin/reports.html.twig
@@ -26,7 +26,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'page': 'reports', 'active': 'reports'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/reports.html.twig
+++ b/templates/Admin/reports.html.twig
@@ -25,7 +25,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'page': 'reports', 'active': 'reports'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_reports.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/trigger_pipeline.html.twig
+++ b/templates/Admin/trigger_pipeline.html.twig
@@ -23,7 +23,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'active': 'trigger_pipeline'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_trigger_pipeline.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/trigger_pipeline.html.twig
+++ b/templates/Admin/trigger_pipeline.html.twig
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'active': 'trigger_pipeline'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/update_availabilities.html.twig
+++ b/templates/Admin/update_availabilities.html.twig
@@ -23,7 +23,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'active': 'update_availabilities'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_update_availabilities.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/update_availabilities.html.twig
+++ b/templates/Admin/update_availabilities.html.twig
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'active': 'update_availabilities'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/update_data.html.twig
+++ b/templates/Admin/update_data.html.twig
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'active': 'update_data'} %}
   </div>
   <div class="col-md-9">

--- a/templates/Admin/update_data.html.twig
+++ b/templates/Admin/update_data.html.twig
@@ -23,7 +23,11 @@
 <div id="admin" class="row">
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'active': 'update_data'} %}
+  </div>
+  <div class="col-md-9">
     {% include 'Admin/_update_data.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/versions.html.twig
+++ b/templates/Admin/versions.html.twig
@@ -11,9 +11,13 @@
 
 {% block container %}
 <div id="admin" class="row">
-  <div class="col-12 row justify-content-center">
+  <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
+  </div>
+  <div class="col-md-3 sticky-top">
     {% include 'Admin/_tabs.html.twig' with {'page': 'versions', 'active': 'versions'} %}
+  </div>
+  <div class="col-md-9 row justify-content-center">
     {% include 'Admin/_versions.html.twig' %}
   </div>
 </div>

--- a/templates/Admin/versions.html.twig
+++ b/templates/Admin/versions.html.twig
@@ -14,7 +14,7 @@
   <div class="col-12">
     <h1 class="text-center">{{ 'title.admin'|trans }}</h1>
   </div>
-  <div class="col-md-3 sticky-top">
+  <div class="col-md-3">
     {% include 'Admin/_tabs.html.twig' with {'page': 'versions', 'active': 'versions'} %}
   </div>
   <div class="col-md-9 row justify-content-center">

--- a/templates/Trainer/_tabs.html.twig
+++ b/templates/Trainer/_tabs.html.twig
@@ -4,9 +4,9 @@
   {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
 ] %}
 
-<ul class="nav nav-tabs nav-fill mb-4" id="trainer-section-tab" role="tablist">
+<ul class="nav flex-column nav-pills mb-4 mb-md-0" id="trainer-section-tab">
   {% for page in trainerPages %}
-    <li class="nav-item" role="presentation">
+    <li class="nav-item">
       <a
         class="nav-link{{ page.key == active ? ' active' : '' }}"
         {{ page.key == active ? 'aria-current="page"' : '' }}

--- a/templates/Trainer/index.html.twig
+++ b/templates/Trainer/index.html.twig
@@ -22,7 +22,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-3 sticky-top">
+    <div class="col-md-3">
       {{ include('Trainer/_tabs.html.twig', {'active': 'customization'}) }}
     </div>
     <div class="col-md-9">

--- a/templates/Trainer/index.html.twig
+++ b/templates/Trainer/index.html.twig
@@ -22,14 +22,10 @@
   </div>
 
   <div class="row">
-    <div class="col-md-12 mx-auto">
+    <div class="col-md-3 sticky-top">
       {{ include('Trainer/_tabs.html.twig', {'active': 'customization'}) }}
     </div>
-  </div>
-
-  <div class="row">
-    <div class="col-md-12 mx-auto row">
-
+    <div class="col-md-9">
       <p class="text-secondary">{{ 'trainer.welcome'|trans|htmlNl2br }}</p>
 
       {{ include('Trainer/Section/_dex.html.twig') }}

--- a/templates/Trainer/links.html.twig
+++ b/templates/Trainer/links.html.twig
@@ -19,13 +19,10 @@
   </div>
 
   <div class="row">
-    <div class="col-md-12 mx-auto">
+    <div class="col-md-3 sticky-top">
       {{ include('Trainer/_tabs.html.twig', {'active': 'links'}) }}
     </div>
-  </div>
-
-  <div class="row">
-    <div class="col-md-12 mx-auto row">
+    <div class="col-md-9">
       {{ include('Trainer/Section/_links.html.twig') }}
     </div>
   </div>

--- a/templates/Trainer/links.html.twig
+++ b/templates/Trainer/links.html.twig
@@ -19,7 +19,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-3 sticky-top">
+    <div class="col-md-3">
       {{ include('Trainer/_tabs.html.twig', {'active': 'links'}) }}
     </div>
     <div class="col-md-9">

--- a/templates/Trainer/personnal_data.html.twig
+++ b/templates/Trainer/personnal_data.html.twig
@@ -11,13 +11,10 @@
   </div>
 
   <div class="row">
-    <div class="col-md-12 mx-auto">
+    <div class="col-md-3 sticky-top">
       {{ include('Trainer/_tabs.html.twig', {'active': 'personnal_data'}) }}
     </div>
-  </div>
-
-  <div class="row">
-    <div class="col-md-12 mx-auto row">
+    <div class="col-md-9">
       {{ include('Trainer/Section/_personnal_data.html.twig') }}
     </div>
   </div>

--- a/templates/Trainer/personnal_data.html.twig
+++ b/templates/Trainer/personnal_data.html.twig
@@ -11,7 +11,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-3 sticky-top">
+    <div class="col-md-3">
       {{ include('Trainer/_tabs.html.twig', {'active': 'personnal_data'}) }}
     </div>
     <div class="col-md-9">

--- a/templates/_nav.html.twig
+++ b/templates/_nav.html.twig
@@ -109,24 +109,48 @@
                     </a>
                 </li>
                 {% if is_granted("ROLE_ADMIN") %}
-                {% set onAdmin = currentRoute in [
-                    'app_admin_update_data',
-                    'app_admin_update_availabilities',
-                    'app_admin_calculate_data',
-                    'app_admin_invalidate_data',
-                    'app_admin_trigger_pipeline',
-                    'app_admin_reports',
-                    'app_admin_versions',
+                {% set adminPages = [
+                    {'key': 'update_data', 'label': 'admin.actions.update_data.title', 'route': 'app_admin_update_data'},
+                    {'key': 'update_availabilities', 'label': 'admin.actions.update_availabilities.title', 'route': 'app_admin_update_availabilities'},
+                    {'key': 'calculate_data', 'label': 'admin.actions.calculate_data.title', 'route': 'app_admin_calculate_data'},
+                    {'key': 'invalidate_data', 'label': 'admin.actions.invalidate_data.title', 'route': 'app_admin_invalidate_data'},
+                    {'key': 'trigger_pipeline', 'label': 'admin.actions.trigger_pipeline.title', 'route': 'app_admin_trigger_pipeline'},
+                    {'key': 'reports', 'label': 'title.admin_reports', 'route': 'app_admin_reports'},
+                    {'key': 'versions', 'label': 'title.admin_versions', 'route': 'app_admin_versions'},
                 ] %}
+                {% set onAdmin = currentRoute in adminPages|map(p => p.route) %}
                 <li class="nav-item admin-link">
-                    <a
-                        class="nav-link {{ onAdmin ? ' active' : '' }}"
-                        {{ onAdmin ? 'aria-current="page"' : '' }}
-                        href="{{ path('app_admin_update_data') }}"
-                    >
-                        <i class="bi bi-wrench-adjustable-circle"></i>
-                        {{ 'nav.admin'|trans }}
-                    </a>
+                    <div class="dropdown dropup d-flex align-items-center">
+                        <a
+                            class="nav-link {{ onAdmin ? ' active' : '' }}"
+                            {{ onAdmin ? 'aria-current="page"' : '' }}
+                            href="{{ path('app_admin_update_data') }}"
+                        >
+                            <i class="bi bi-wrench-adjustable-circle"></i>
+                            {{ 'nav.admin'|trans }}
+                        </a>
+                        <button
+                            class="nav-link dropdown-toggle dropdown-toggle-split"
+                            type="button"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                        >
+                            <span class="visually-hidden">{{ 'nav.toggle_submenu'|trans }}</span>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            {% for page in adminPages %}
+                            <li>
+                                <a
+                                    class="dropdown-item{{ currentRoute == page.route ? ' active' : '' }}"
+                                    {{ currentRoute == page.route ? 'aria-current="page"' : '' }}
+                                    href="{{ path(page.route) }}"
+                                >
+                                    {{ page.label|trans }}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
                 </li>
                 {% endif %}
                 {% if app.user %}

--- a/templates/_nav.html.twig
+++ b/templates/_nav.html.twig
@@ -25,19 +25,43 @@
             <ul class="navbar-nav">
                 <li class="nav-item trainer-link">
                     {% if is_granted("ROLE_TRAINER") %}
-                    {% set onTrainer = currentRoute in [
-                        'app_trainerindex_index',
-                        'app_trainerlinks_index',
-                        'app_trainerpersonnaldata_index',
+                    {% set trainerPages = [
+                        {'key': 'customization', 'label': 'trainer.dex.title', 'route': 'app_trainerindex_index'},
+                        {'key': 'links', 'label': 'trainer.links.title', 'route': 'app_trainerlinks_index'},
+                        {'key': 'personnal_data', 'label': 'trainer.personnal_data.title', 'route': 'app_trainerpersonnaldata_index'},
                     ] %}
-                    <a
-                        class="nav-link {{ onTrainer ? ' active' : '' }}"
-                        {{ onTrainer ? 'aria-current="page"' : '' }}
-                        href="{{ path('app_trainerindex_index') }}"
-                    >
-                        <i class="bi bi-person-badge"></i>
-                        {{ 'title.trainer'|trans }}
-                    </a>
+                    {% set onTrainer = currentRoute in trainerPages|map(p => p.route) %}
+                    <div class="dropdown dropup d-flex align-items-center">
+                        <a
+                            class="nav-link {{ onTrainer ? ' active' : '' }}"
+                            {{ onTrainer ? 'aria-current="page"' : '' }}
+                            href="{{ path('app_trainerindex_index') }}"
+                        >
+                            <i class="bi bi-person-badge"></i>
+                            {{ 'title.trainer'|trans }}
+                        </a>
+                        <button
+                            class="nav-link dropdown-toggle dropdown-toggle-split"
+                            type="button"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                        >
+                            <span class="visually-hidden">{{ 'nav.toggle_submenu'|trans }}</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            {% for page in trainerPages %}
+                            <li>
+                                <a
+                                    class="dropdown-item{{ currentRoute == page.route ? ' active' : '' }}"
+                                    {{ currentRoute == page.route ? 'aria-current="page"' : '' }}
+                                    href="{{ path(page.route) }}"
+                                >
+                                    {{ page.label|trans }}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
                     {% else %}
                     <a class="nav-link" href="{{ path('app_connect_index') }}">
                         <i class="bi bi-person"></i>

--- a/tests/src/Integration/Controller/Admin/AdminReportsTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminReportsTest.php
@@ -125,5 +125,11 @@ final class AdminReportsTest extends WebTestCase
                 ->eq(3)
                 ->text()
         );
+
+        $this->assertCountFilter($crawler, 1, '.navbar-nav .admin-link .dropdown-item.active');
+        $this->assertStringContainsString(
+            '/fr/istration/reports',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item.active')->attr('href') ?? ''
+        );
     }
 }

--- a/tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php
+++ b/tests/src/Integration/Controller/Admin/AdminUpdateDataTest.php
@@ -52,6 +52,21 @@ final class AdminUpdateDataTest extends WebTestCase
         $this->assertCountFilter($crawler, 7, '#admin-actions-tab > .nav-item > .nav-link');
         $this->assertCountFilter($crawler, 1, '#admin-actions-tab .nav-link.active');
 
+        $this->assertCountFilter($crawler, 7, '.navbar-nav .admin-link .dropdown-menu .dropdown-item');
+        $this->assertCountFilter($crawler, 1, '.navbar-nav .admin-link .dropdown-item.active');
+        $this->assertStringContainsString(
+            '/fr/istration/update_data',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item.active')->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/istration/reports',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item')->eq(5)->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/istration/versions',
+            $crawler->filter('.navbar-nav .admin-link .dropdown-item')->eq(6)->attr('href') ?? ''
+        );
+
         $reportsLinkHref = $crawler->filter('#admin-actions-tab a.nav-link')->eq(5)->attr('href') ?? '';
         $this->assertStringContainsString('/fr/istration/reports', $reportsLinkHref);
 

--- a/tests/src/Integration/Controller/Trainer/TrainerLinksPageTest.php
+++ b/tests/src/Integration/Controller/Trainer/TrainerLinksPageTest.php
@@ -71,6 +71,12 @@ final class TrainerLinksPageTest extends WebTestCase
             '/fr/trainer/links',
             $crawler->filter('#trainer-section-tab .nav-link.active')->attr('href')
         );
+
+        $this->assertCount(1, $crawler->filter('.navbar-nav .trainer-link .dropdown-item.active'));
+        $this->assertStringContainsString(
+            '/fr/trainer/links',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item.active')->attr('href') ?? ''
+        );
     }
 
     #[Test]

--- a/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
+++ b/tests/src/Integration/Controller/Trainer/TrainerPageTest.php
@@ -62,6 +62,21 @@ final class TrainerPageTest extends WebTestCase
             $crawler->filter('#trainer-section-tab .nav-link.active')->attr('href')
         );
 
+        $this->assertCountFilter($crawler, 3, '.navbar-nav .trainer-link .dropdown-menu .dropdown-item');
+        $this->assertCountFilter($crawler, 1, '.navbar-nav .trainer-link .dropdown-item.active');
+        $this->assertStringContainsString(
+            '/fr/trainer',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item.active')->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/trainer/links',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item')->eq(1)->attr('href') ?? ''
+        );
+        $this->assertStringContainsString(
+            '/fr/trainer/personnal_data',
+            $crawler->filter('.navbar-nav .trainer-link .dropdown-item')->eq(2)->attr('href') ?? ''
+        );
+
         $this->assertCount(0, $crawler->filter('.navbar-link'));
 
         $this->assertCountFilter($crawler, 1, '.dex_is_shiny');

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -24,6 +24,7 @@ nav:
   is_private: "Private album"
   open-offcanvas: "Open the sidebar"
   cookie-manager: "Cookie manager"
+  toggle_submenu: "View sub-pages"
 
 title:
   home: "Home"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -420,7 +420,7 @@ admin:
       failed: "Échoué"
   actions:
     update_availabilities:
-      title: "MAJ des données de disponibilités"
+      title: "Mise à jour des données de disponibilités"
       games_availabilities:
         title: "Mise à jour des disponibilités des jeux"
         item: "Disponibilités des jeux"
@@ -437,7 +437,7 @@ admin:
         cta: "Mettre à jour"
         description: "Resynchronise depuis Google Sheets quels Pokémon sont disponibles dans chaque collection."
     update_data:
-      title: "MAJ des données"
+      title: "Mise à jour des données"
       labels:
         title: "Mise à jour des labels"
         cta: "Mettre à jour"

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -24,6 +24,7 @@ nav:
   is_private: "Album privé"
   open-offcanvas: "Ouvrir le panneau latéral"
   cookie-manager: "Gère tes cookies"
+  toggle_submenu: "Voir les sous-pages"
 
 title:
   home: "Accueil"


### PR DESCRIPTION
## Summary
- **Bottom navbar**: "Dresseurs" and "Admin" now open a split dropdown listing every sub-page of their section (direct link still goes to the default page), instead of only reaching the first page.
- **Trainer/Admin pages**: the horizontal section tab bar is replaced by an always-visible vertical sidebar menu (side column at `md`+/768px, stacked full-width above content below that — no toggle, no JS).
- **Copy fix**: the two Admin section titles ("MAJ des données…") now spell out "Mise à jour", consistent with every other admin action title.

## Details
- Design specs: `docs/superpowers/specs/2026-08-12-navbar-subpage-dropdowns-design.md`, `docs/superpowers/specs/2026-08-12-trainer-admin-sidebar-nav-design.md`
- Implementation plans: `docs/superpowers/plans/2026-08-12-navbar-subpage-dropdowns.md`, `docs/superpowers/plans/2026-08-12-trainer-admin-sidebar-nav.md`
- Both features went through brainstorming → spec → plan → subagent-driven implementation with per-task and whole-branch code review; the whole-branch reviews each caught and fixed one real bug before merge (a Bootstrap in-navbar dropdown-positioning quirk on the navbar work, and a `sticky-top` CSS behavior that was a no-op on desktop and a transparent scroll overlay on mobile on the sidebar work).

## Test plan
- [x] `make tests-integration` — 295 tests, 3662 assertions, all passing
- [x] `make code-quality` — phpcsfixer/phpmd/psalm/phpstan/deptrac all green (note: `w3c` and `editorconfig-linter` sub-checks have known pre-existing environment/tooling limitations unrelated to this branch, documented in the specs)
- [x] Manual real-browser visual verification (desktop + mobile widths) for both the navbar dropdowns and the sidebar layout, including the `versions` page's special centering case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhQeiML1mfVvDjXjB3g14e