### PR TITLE
fix(layout): full-width Admin and Dresseurs pages, responsive versions list

### DIFF
--- a/templates/Admin/_versions.html.twig
+++ b/templates/Admin/_versions.html.twig
@@ -4,12 +4,12 @@
   {'key': 'api', 'label': 'admin.versions.api', 'color': 'warning', 'brickVersion': versionsOverview.api},
   {'key': 'resources', 'label': 'admin.versions.resources', 'color': 'success', 'brickVersion': versionsOverview.resources},
 ] %}
-<div class="list-group col-4" id="versions-list">
+<div class="list-group col-12 col-lg-6" id="versions-list">
   {% for brick in bricks %}
-    <div class="list-group-item d-flex align-items-center gap-3" id="versions-row-{{ brick.key }}">
+    <div class="list-group-item d-flex flex-wrap align-items-center gap-3" id="versions-row-{{ brick.key }}">
       <span class="badge rounded-pill text-bg-{{ brick.color }}">{{ brick.label|trans|slice(0, 1)|upper }}</span>
       <span class="fw-semibold">{{ brick.label|trans }}</span>
-      <span class="versions-version fw-bold ms-auto">
+      <span class="versions-version fw-bold ms-sm-auto text-break">
         {% if brick.brickVersion.version is not null %}
           {{ brick.brickVersion.version }}
         {% else %}

--- a/templates/Admin/calculate_data.html.twig
+++ b/templates/Admin/calculate_data.html.twig
@@ -13,6 +13,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/invalidate_data.html.twig
+++ b/templates/Admin/invalidate_data.html.twig
@@ -13,6 +13,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/reports.html.twig
+++ b/templates/Admin/reports.html.twig
@@ -15,6 +15,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/trigger_pipeline.html.twig
+++ b/templates/Admin/trigger_pipeline.html.twig
@@ -13,6 +13,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/update_availabilities.html.twig
+++ b/templates/Admin/update_availabilities.html.twig
@@ -13,6 +13,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/update_data.html.twig
+++ b/templates/Admin/update_data.html.twig
@@ -13,6 +13,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Admin/versions.html.twig
+++ b/templates/Admin/versions.html.twig
@@ -3,6 +3,8 @@
 
 {% block title %}Pokénini {{ 'title.admin'|trans }}{% endblock %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block stylesheets %}
   {{ parent() }}
 

--- a/templates/Trainer/index.html.twig
+++ b/templates/Trainer/index.html.twig
@@ -14,6 +14,8 @@
   </style>
 {% endblock stylesheets %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block container %}
   <div class="row">
     <div class="col-md-10 mx-auto text-center row">

--- a/templates/Trainer/links.html.twig
+++ b/templates/Trainer/links.html.twig
@@ -11,6 +11,8 @@
   <link rel="stylesheet" href="{{ asset('css/trainer.css') }}">
 {% endblock stylesheets %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block container %}
   <div class="row">
     <div class="col-md-10 mx-auto text-center row">

--- a/templates/Trainer/personnal_data.html.twig
+++ b/templates/Trainer/personnal_data.html.twig
@@ -3,6 +3,8 @@
 
 {% block title %}Pokénini {{ 'title.trainer'|trans }}{% endblock title %}
 
+{% block container_class %}container-fluid{% endblock container_class %}
+
 {% block container %}
   <div class="row">
     <div class="col-md-10 mx-auto text-center row">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,7 +23,7 @@
     <body>
         {% block nav %}{% endblock nav %}
         {% block body %}
-        <div class="container" id="main-container">
+        <div class="{% block container_class %}container{% endblock container_class %}" id="main-container">
             {% block container %}{% endblock container %}
         </div>
         {% block footer %}


### PR DESCRIPTION
## Summary
- Made `templates/base.html.twig`'s page wrapper class overridable via a `container_class` block (defaults to `container`)
- Switched the Admin pages and all 3 Dresseurs (Trainer) pages to `container-fluid`, giving their sidebar+grid/list layouts full page width instead of being cramped in the centered `container`
- Fixed the Admin versions list not adapting on narrow screens (fixed `col-4`, no wrap fallback → now `col-12 col-lg-6` with `flex-wrap` and `text-break`)

## Test plan
- [ ] Visually check `/admin/*` pages at a few widths
- [ ] Visually check `/trainer`, `/trainer/links`, `/trainer/personnal-data` at a few widths
- [ ] Confirm non-Admin/non-Trainer pages are unaffected (still centered `container`)