### PR TITLE
fix(nav): right-align logout link in the navbar

### DIFF
--- a/templates/_nav.html.twig
+++ b/templates/_nav.html.twig
@@ -22,7 +22,7 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
+            <ul class="navbar-nav flex-grow-1">
                 <li class="nav-item trainer-link">
                     {% if is_granted("ROLE_TRAINER") %}
                     {% set trainerPages = [


### PR DESCRIPTION
## Summary
- The logout link's `ms-auto` had no effect on desktop widths: `navbar-nav` stays shrink-to-fit inside `navbar-collapse` (which is the element that actually grows to fill the bar), so the auto-margin had no free space to consume and "Se déconnecter" just trailed the last regular nav item instead of sitting flush against the right edge.
- Adding `flex-grow-1` to the `navbar-nav` `<ul>` makes it fill the available width, giving `ms-auto` room to push the logout item to the true right edge. Verified on both desktop (row layout) and mobile expanded menu (column layout, already worked before).

## Test plan
- [ ] `make start`, log in via `/fr/connect/f/c?t=admin`, confirm "Se déconnecter" sits flush right in the bottom navbar at desktop width
- [ ] Resize below the `sm` breakpoint, expand the hamburger menu, confirm "Se déconnecter" is still right-aligned (no regression)